### PR TITLE
Update metadata for repo move

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: false
 matrix:
   include:
     - rust: stable
+    - rust: beta
+    - rust: nightly
       addons:
         apt:
           packages:
@@ -14,8 +16,6 @@ matrix:
       install:
         # For test coverage. In install step so that it can use cache.
         - cargo tarpaulin --version || cargo install cargo-tarpaulin
-    - rust: beta
-    - rust: nightly
   allow_failures:
     - rust: nightly
 
@@ -27,7 +27,7 @@ script:
   - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo bench; fi'
 
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then
     # Calculate test coverage
     cargo tarpaulin --out Xml
     bash <(curl -s https://codecov.io/bash)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Fancy Regex authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC
+Raph Levien
+Robin Stocker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,11 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+# Contributing
 
-### Before you contribute
-Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1)
-(CLA), which you can do online. The CLA is necessary mainly because you own the
-copyright to your changes, even after your contribution becomes part of our
-codebase, so we need your permission to use and distribute your code. We also
-need to be sure of various other things—for instance that you'll tell us if you
-know that your code infringes on other people's patents. You don't have to sign
-the CLA until after you've submitted your code for review and a member has
-approved it, but you must do it before we can put your code into our codebase.
-Before you start working on a larger contribution, you should get in touch with
-us first through the issue tracker with your idea so that we can help out and
-possibly guide you. Coordinating up front makes it much easier to avoid
-frustration later on.
+The fancy-regex project is committed to fostering and preserving a
+diverse, welcoming community; all participants are expected to
+follow the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html).
 
-### Code reviews
-All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+Patching processes for this project are somewhat informal, as it's
+maintained by a small group. No Contributor License Agreement is needed.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than
-the one above, the Software Grant and Corporate Contributor License Agreement.
+If this is your first substantive pull  request in this repo, feel free
+to add yourself to the AUTHORS file.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Raph Levien <raph@google.com>"]
 license = "MIT"
 description = "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around."
-repository = "https://github.com/google/fancy-regex"
+repository = "https://github.com/fancy-regex/fancy-regex"
 
 [dependencies]
 regex = "1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright 2015 Google Inc. All rights reserved.
+Copyright 2015 The Fancy Regex Authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -139,16 +139,12 @@ creating the excellent regex crate.
 
 ## Authors
 
-The main author is Raph Levien.
+The main author is Raph Levien, with many contributions from Robin Stocker.
 
 ## Contributions
 
-We gladly accept contributions via GitHub pull requests, as long as the author
-has signed the Google Contributor License. Please see CONTRIBUTIONS.md for
-more details.
+We gladly accept contributions via GitHub pull requests. Please see
+[CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
-### Disclaimer
-
-This is not an official Google product (experimental or otherwise), it
-is just code that happens to be owned by Google.
-
+This project started out as a Google 20% project, but none of the authors currently
+work at Google so it has been forked to be community-maintained.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ NFA-based implementations (exemplified by
 [regex](https://crates.io/crates/regex) crate).
 
 [![crate](https://img.shields.io/crates/v/fancy-regex.svg)](https://crates.io/crates/fancy-regex)
-[![build status](https://travis-ci.org/google/fancy-regex.svg?branch=master)](https://travis-ci.org/google/fancy-regex)
-[![codecov](https://codecov.io/gh/google/fancy-regex/branch/master/graph/badge.svg)](https://codecov.io/gh/google/fancy-regex)
+[![build status](https://travis-ci.org/fancy-regex/fancy-regex.svg?branch=master)](https://travis-ci.org/fancy-regex/fancy-regex)
+[![codecov](https://codecov.io/gh/fancy-regex/fancy-regex/branch/master/graph/badge.svg)](https://codecov.io/gh/fancy-regex/fancy-regex)
 
 A goal is to be as efficient as possible. For a given regex, the NFA
 implementation has asymptotic running time linear in the length of the

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The Fancy Regex Authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We're moving the repo to the new "fancy-regex" organization. This
patch updates the copyright headers and other metadata.

The contribution guidelines have been updated (adopting the Rust
Code of Conduct), and the README freshened up just a bit.