### PR TITLE
travis: Change sudo to required for cargo-tarpaulin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: rust
 dist: trusty
-sudo: false
+sudo: required
 
 matrix:
   include:


### PR DESCRIPTION
See https://github.com/xd009642/tarpaulin#travis-ci-and-coverage-sites

The previous PR fixed the installation, but then running it didn't produce any results.
This should fix that :).