### PR TITLE
Add test for captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Cargo.lock
 target
 
 *.iml
+.idea/
 .vscode/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub enum Regex {
     }
 }
 
+#[derive(Debug)]
 pub enum Captures<'t> {
     Wrap {
         inner: regex::Captures<'t>,
@@ -107,6 +108,7 @@ pub enum Captures<'t> {
     }
 }
 
+#[derive(Debug)]
 pub struct SubCaptures<'t> {
     caps: &'t Captures<'t>,
     i: usize,

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -1,0 +1,21 @@
+extern crate fancy_regex;
+
+use fancy_regex::Captures;
+
+mod common;
+
+#[test]
+fn captures_after_lookbehind() {
+    let captures = captures(r"\s*(?<=[() ])(@\w+)(\([^)]*\))?\s*", " @another(foo bar)   ");
+    assert_eq!(Some("@another"), captures.at(1));
+    assert_eq!(Some("(foo bar)"), captures.at(2));
+}
+
+fn captures<'a>(re: &str, text: &'a str) -> Captures<'a> {
+    let regex = common::regex(re);
+    let result = regex.captures(text);
+    assert!(result.is_ok(), "Expected captures to succeed, but was {:?}", result);
+    let captures = result.unwrap();
+    assert!(captures.is_some(), "Expected captures, but was {:?}", captures);
+    captures.unwrap()
+}


### PR DESCRIPTION
That was broken in 0.1.0, see https://github.com/google/fancy-regex/issues/49