### PR TITLE
Bump dependencies and test against Rust 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: required
 
 matrix:
   include:
+    # minimal supported Rust version, keep in sync with regex crate
+    - rust: 1.24.1
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ bit-set = "0.5"
 
 [dev-dependencies]
 matches = "0.1.8"
-quickcheck = "0.8"
-rand = "0.6"
+quickcheck = "0.7"
+rand = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ description = "An implementation of regexes, supporting a relatively rich set of
 repository = "https://github.com/fancy-regex/fancy-regex"
 
 [dependencies]
-regex = "1.0"
+regex = "1.1"
 bit-set = "0.5"
 
 [dev-dependencies]
-matches = "0.1.6"
-quickcheck = "0.6"
+matches = "0.1.8"
+quickcheck = "0.8"
+rand = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ extern crate matches;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
+#[cfg(test)]
+extern crate rand;
 
 use std::fmt;
 use std::usize;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -449,6 +449,7 @@ pub fn run(prog: &Prog, s: &str, pos: usize, options: u32) ->
 mod tests {
     use super::*;
     use quickcheck::{Arbitrary, Gen};
+    use rand::Rng;
 
     #[test]
     fn state_push_pop() {


### PR DESCRIPTION
1.24.1 is the minimal supported Rust version of the regex crate, see [CHANGELOG](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md). It
probably makes sense to support the same.