### PR TITLE
Change find to return a Match struct and add more documentation

### DIFF
--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -77,5 +77,5 @@ fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     let regex = common::regex(re);
     let result = regex.find(text);
     assert!(result.is_ok(), "Expected find to succeed, but was {:?}", result);
-    result.unwrap()
+    result.unwrap().map(|m| (m.start(), m.end()))
 }


### PR DESCRIPTION
Match is the same as in the regex crate to make the APIs more similar.