### PR TITLE
Fix panic for matching backref to unmatched group

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -410,6 +410,10 @@ pub fn run(prog: &Prog, s: &str, pos: usize, options: u32) -> Result<Option<Vec<
                 }
                 Insn::Backref(slot) => {
                     let lo = state.get(slot);
+                    if lo == usize::MAX {
+                        // Referenced group hasn't matched, so the backref doesn't match either
+                        break 'fail;
+                    }
                     let hi = state.get(slot + 1);
                     let ix_end = ix + (hi - lo);
                     if ix_end > s.len() || s[ix..ix_end] != s[lo..hi] {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -72,6 +72,11 @@ fn negative_lookahead_fail() {
     assert_eq!(find(r"(?!`(?:[^`]+(?=`)|x)`)", "`a`"), Some((1, 1)));
 }
 
+#[test]
+fn backref_for_unmatched_group() {
+    assert_eq!(find(r"(a)?\1", "bb"), None);
+}
+
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     let regex = common::regex(re);
     let result = regex.find(text);

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -239,10 +239,10 @@
   // Compile failed: UnknownFlag
   x2("(?<pare>\\(([^\\(\\)]++|\\g<pare>)*+\\))", "((a))", 0, 5);
 
-  // Panic while matching
+  // No match found
   x2("()*\\1", "", 0, 0);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|())*\\1\\2", "", 0, 0);
 
   // Compile failed: InvalidBackref
@@ -251,10 +251,10 @@
   // Compile failed: InvalidEscape
   x2("x((.)*)*x(?i:\\1)\\Z", "0x1x2x1X2", 1, 9);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|()|()|()|()|())*\\2\\5", "", 0, 0);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|()|()|(x)|()|())*\\2b\\5", "b", 0, 1);
 
   // Compile failed: InvalidEscape
@@ -362,13 +362,13 @@
   // Compile failed: InvalidEscape
   x2("(a\\Kb|\\Kac\\K)*", "acababacab", 9, 10);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|())*\\1", "abc", 0, 0);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|())*\\2", "abc", 0, 0);
 
-  // Panic while matching
+  // No match found
   x2("(?:()|()|())*\\3\\1", "abc", 0, 0);
 
   // Compile failed: InvalidEscape


### PR DESCRIPTION
Note that the tests still fail because `()*` doesn't capture in our implementation (neither does it in regex).

In Oniguruma, it captures the empty string, so `()*\1` matches.