### PR TITLE
Fix fancy casei literal compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ with the exception that 0.x versions can break between minor versions.
 - Support `\b`, `\f`, `\t`, `\n`, `\r`, `\v`
 - Support look-behind with variable sized alternative
 - Implement `Debug` for `Regex`
+- More test coverage including running one of Oniguruma's test suites
 ### Changed
 - Change `find` to return a `Match` struct (breaking change)
 - Change `Captures` API (breaking change):

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -133,6 +133,9 @@ impl<'a> Analyzer<'a> {
                 min_size = child_info.min_size;
                 const_size = child_info.const_size;
                 looks_left = child_info.looks_left;
+                // If there's a backref to this group, we potentially have to backtrack within the
+                // group. E.g. with `(x|xy)\1` and input `xyxy`, `x` matches but then the backref
+                // doesn't, so we have to backtrack and try `xy`.
                 hard = child_info.hard | self.backrefs.contains(group);
                 children.push(child_info);
             }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -105,9 +105,9 @@ impl Compiler {
             Expr::Empty => (),
             Expr::Literal { ref val, casei } => {
                 if !casei {
-                    self.compile_delegates(&[info])?;
-                } else {
                     self.b.add(Insn::Lit(val.clone()));
+                } else {
+                    self.compile_delegates(&[info])?;
                 }
             }
             Expr::Any { newline: true } => {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -9,6 +9,13 @@ fn find_wrap() {
 }
 
 #[test]
+fn find_fancy_case_insensitive() {
+    assert_eq!(find(r"(x|xy)\1", "XX"), None);
+    assert_eq!(find(r"(x|xy)\1", "xx"), Some((0, 2)));
+    assert_eq!(find(r"((?i:x|xy))\1", "XX"), Some((0, 2)));
+}
+
+#[test]
 fn lookahead_grouping_single_expression() {
     // These would fail if the delegate expression was `^x|a` (if we didn't
     // group as `^(?:x|a)`).


### PR DESCRIPTION
The logic was the wrong way around, so a case-insensitive literal was being
compiled as case-sensitive.

Also found by writing tests for uncovered branches.