### PR TITLE
Fix backref with multibyte chars

### DIFF
--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -91,6 +91,14 @@ fn backref_for_unmatched_group() {
 }
 
 #[test]
+fn backref_with_multibyte() {
+    assert_eq!(
+        find(r"(.+)\1+", "x\u{1F431}\u{1F436}\u{1F431}\u{1F436}"),
+        Some((1, 17))
+    );
+}
+
+#[test]
 fn repeat_non_greedy() {
     // (?=a) to make it fancy and use VM
     assert_eq!(find(r"(a(?=a)){2,}?", "aaa"), Some((0, 2)));


### PR DESCRIPTION
The test failed like this before:

    thread 'backref_with_multibyte' panicked at
    'byte index 10 is not a char boundary;
    it is inside '🐱' (bytes 9..13) of `x🐱🐶🐱🐶`',
    src/libcore/str/mod.rs:2068:5