### PR TITLE
Add options for controlling program and dfa size limits

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -29,6 +29,7 @@ use crate::Error;
 use crate::Expr;
 use crate::LookAround;
 use crate::LookAround::*;
+use crate::RegexOptions;
 use crate::Result;
 
 // I'm thinking it probably doesn't make a lot of sense having this split
@@ -93,6 +94,7 @@ impl VMBuilder {
 
 struct Compiler {
     b: VMBuilder,
+    options: RegexOptions,
 }
 
 impl Compiler {
@@ -446,11 +448,11 @@ impl Compiler {
         start_group: usize,
         end_group: usize,
     ) -> Result<()> {
-        let compiled = compile_inner(inner_re)?;
+        let compiled = compile_inner(inner_re, &self.options)?;
         if looks_left {
             // The "s" flag is for allowing `.` to match `\n`
             let inner1 = ["^(?s:.)", &inner_re[1..]].concat();
-            let compiled1 = compile_inner(&inner1)?;
+            let compiled1 = compile_inner(&inner1, &self.options)?;
             self.b.add(Insn::Delegate {
                 inner: Box::new(compiled),
                 inner1: Some(Box::new(compiled1)),
@@ -472,14 +474,23 @@ impl Compiler {
     }
 }
 
-pub(crate) fn compile_inner(inner_re: &str) -> Result<regex::Regex> {
-    regex::Regex::new(inner_re).map_err(Error::InnerError)
+pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<regex::Regex> {
+    let mut builder = regex::RegexBuilder::new(inner_re);
+    if let Some(size_limit) = options.size_limit {
+        builder.size_limit(size_limit);
+    }
+    if let Some(dfa_size_limit) = options.dfa_size_limit {
+        builder.dfa_size_limit(dfa_size_limit);
+    }
+
+    builder.build().map_err(Error::InnerError)
 }
 
 /// Compile the analyzed expressions into a program.
 pub fn compile(info: &Info<'_>) -> Result<Prog> {
     let mut c = Compiler {
         b: VMBuilder::new(info.end_group),
+        options: Default::default(),
     };
     c.visit(info, false)?;
     c.b.add(Insn::End);
@@ -515,6 +526,7 @@ mod tests {
 
         let mut c = Compiler {
             b: VMBuilder::new(0),
+            options: Default::default(),
         };
         // Force "hard" so that compiler doesn't just delegate
         c.visit(&info, true).unwrap();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -476,10 +476,10 @@ impl Compiler {
 
 pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<regex::Regex> {
     let mut builder = regex::RegexBuilder::new(inner_re);
-    if let Some(size_limit) = options.size_limit {
+    if let Some(size_limit) = options.delegate_size_limit {
         builder.size_limit(size_limit);
     }
-    if let Some(dfa_size_limit) = options.dfa_size_limit {
+    if let Some(dfa_size_limit) = options.delegate_dfa_size_limit {
         builder.dfa_size_limit(dfa_size_limit);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,8 +212,8 @@ pub struct SubCaptureMatches<'c, 't> {
 struct RegexOptions {
     pattern: String,
     backtrack_limit: usize,
-    size_limit: Option<usize>,
-    dfa_size_limit: Option<usize>,
+    delegate_size_limit: Option<usize>,
+    delegate_dfa_size_limit: Option<usize>,
 }
 
 impl Default for RegexOptions {
@@ -221,8 +221,8 @@ impl Default for RegexOptions {
         RegexOptions {
             pattern: String::new(),
             backtrack_limit: 1_000_000,
-            size_limit: None,
-            dfa_size_limit: None,
+            delegate_size_limit: None,
+            delegate_dfa_size_limit: None,
         }
     }
 }
@@ -257,17 +257,22 @@ impl RegexBuilder {
 
     /// Set the approximate size limit of the compiled regular expression.
     ///
-    /// This option is forwarded from the wrapped `regex` crate.
-    pub fn size_limit(&mut self, limit: usize) -> &mut Self {
-        self.0.size_limit = Some(limit);
+    /// This option is forwarded from the wrapped `regex` crate. Note that depending on the used
+    /// regex features there may be multiple delegated sub-regexes fed to the `regex` crate. As
+    /// such the actual limit is closer to `<number of delegated regexes> * delegate_size_limit`.
+    pub fn delegate_size_limit(&mut self, limit: usize) -> &mut Self {
+        self.0.delegate_size_limit = Some(limit);
         self
     }
 
     /// Set the approximate size of the cache used by the DFA.
     ///
-    /// This option is forwarded from the wrapped `regex` crate.
-    pub fn dfa_size_limit(&mut self, limit: usize) -> &mut Self {
-        self.0.dfa_size_limit = Some(limit);
+    /// This option is forwarded from the wrapped `regex` crate. Note that depending on the used
+    /// regex features there may be multiple delegated sub-regexes fed to the `regex` crate. As
+    /// such the actual limit is closer to `<number of delegated regexes> *
+    /// delegate_dfa_size_limit`.
+    pub fn delegate_dfa_size_limit(&mut self, limit: usize) -> &mut Self {
+        self.0.delegate_dfa_size_limit = Some(limit);
         self
     }
 }


### PR DESCRIPTION
I want to have these options for parsing user-agent regexes in https://github.com/davidarmstronglewis/uap-rs, which parse fine with this crate and onig, but are just too large.