### PR TITLE
Fix over-eager delegation preventing matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Fixed
+- Some regexes with fancy parts in the beginning/middle didn't match
+  when they should have, e.g. `((?!x)(a|ab))c` didn't match `abc`.
+
 ## [0.3.1] - 2019-12-09
 ### Added
 - Add `delegate_size_limit` and `delegate_dfa_size_limit` to

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -105,6 +105,13 @@ fn backtrack_limit() {
     }
 }
 
+#[test]
+fn end_of_hard_expression_cannot_be_delegated() {
+    assert_match(r"(?!x)(?:a|ab)c", "abc");
+    // If `(?:a|ab)` is delegated, there's no backtracking and `a` matches and `ab` is never tried.
+    assert_match(r"((?!x)(?:a|ab))c", "abc");
+}
+
 fn assert_match(re: &str, text: &str) {
     let result = match_text(re, text);
     assert_eq!(


### PR DESCRIPTION
Some regexes with fancy parts in the beginning/middle didn't match when
they should have, e.g. `((?!x)(a|ab))c` didn't match `abc` because
`(a|ab)` was delegated and so never backtracked to `ab`.

Fixes #37.