### PR TITLE
Support comments using `(?# comment)` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## Unreleased
+### Added
+- Support comments using `(?# comment)` syntax
+
 ## [0.3.3] - 2020-02-28
 ### Changed
 - Optimization: Delegate const-sized suffixes in more cases

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -31,9 +31,6 @@
   // Compile failed: InvalidBackref
   x2("\\17", "\017", 0, 1);
 
-  // Compile failed: UnknownFlag
-  x2("a(?#....\\\\JJJJ)b", "ab", 0, 2);
-
   // No match found
   x2("(?x)  G (o O(?-x)oO) g L", "GoOoOgLe", 0, 7);
 


### PR DESCRIPTION
Same as Oniguruma. See https://github.com/trishume/syntect/issues/287 where the lack of support for this is a problem.