### PR TITLE
Support \u and \U unicode escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with the exception that 0.x versions can break between minor versions.
 ## Unreleased
 ### Added
 - Support comments using `(?# comment)` syntax
+- Support unicode escapes like `\u21D2` and `\U0001F60A`
 
 ## [0.3.3] - 2020-02-28
 ### Changed

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -401,9 +401,6 @@
   // Compile failed: InvalidEscape
   x2("[\\o{101}]", "A", 0, 1);
 
-  // Compile failed: InvalidEscape
-  x2("[\\u0041]", "A", 0, 1);
-
   // Compile failed: UnknownFlag
   x2("(?~)", "", 0, 0);
 
@@ -950,12 +947,6 @@
 
   // Compile failed: InvalidHex
   x2("\\x1", "\x01", 0, 1);
-
-  // Compile failed: InvalidEscape
-  x2("\\u4E38", "\xE4\xB8\xB8", 0, 3);
-
-  // Compile failed: InvalidEscape
-  x2("\\u0040", "@", 0, 1);
 
   // Compile failed: UnknownFlag
   x2("((?()0+)+++(((0\\g<0>)0)|())++++((?(1)(0\\g<0>))++++++0*())++++((?(1)(0\\g<1>)+)++++++++++*())++++((?(1)((0)\\g<0>)+)++())+0++*+++(((0\\g<0>))*())++++((?(1)(0\\g<0>)+)++++++++++*|)++++*+++((?(1)((0)\\g<0>)+)+++++++++())++*|)++++((?()0))|", "abcde", 0, 0);


### PR DESCRIPTION
For https://github.com/trishume/syntect/issues/287