### PR TITLE
Include string snippet in errors for unknown group and invalid escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## Unreleased
+### Added
+- Include string snippet in errors for unknown group and invalid escape
+  to make it easier to identify the problem.
+
 ## [0.3.4] - 2020-04-28
 ### Added
 - Support comments using `(?# comment)` syntax

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     /// Backslash without following character
     TrailingBackslash,
     /// Invalid escape
-    InvalidEscape,
+    InvalidEscape(String),
     /// Unicode escape not closed
     UnclosedUnicodeName,
     /// Invalid hex escape
@@ -30,7 +30,7 @@ pub enum Error {
     /// Invalid character class
     InvalidClass,
     /// Unknown group flag
-    UnknownFlag,
+    UnknownFlag(String),
     /// Disabling Unicode not supported
     NonUnicodeUnsupported,
     /// Invalid back reference
@@ -67,14 +67,14 @@ impl fmt::Display for Error {
             Error::RecursionExceeded => write!(f, "Pattern too deeply nested"),
             Error::LookBehindNotConst => write!(f, "Look-behind assertion without constant size"),
             Error::TrailingBackslash => write!(f, "Backslash without following character"),
-            Error::InvalidEscape => write!(f, "Invalid escape"),
+            Error::InvalidEscape(s) => write!(f, "Invalid escape: {}", s),
             Error::UnclosedUnicodeName => write!(f, "Unicode escape not closed"),
             Error::InvalidHex => write!(f, "Invalid hex escape"),
             Error::InvalidCodepointValue => {
                 write!(f, "Invalid codepoint for hex or unicode escape")
             }
             Error::InvalidClass => write!(f, "Invalid character class"),
-            Error::UnknownFlag => write!(f, "Unknown group flag"),
+            Error::UnknownFlag(s) => write!(f, "Unknown group flag: {}", s),
             Error::NonUnicodeUnsupported => write!(f, "Disabling Unicode not supported"),
             Error::InvalidBackref => write!(f, "Invalid back reference"),
             Error::InnerError(e) => write!(f, "Regex error: {}", e),

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -7,25 +7,25 @@
   // No match found
   x2("^a", "\na", 1, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\O")
   x2("$\\O", "bb\n", 2, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("\\G", "", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("\\Z", "", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\c")
   x2("\\ca", "\001", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\C")
   x2("\\C-b", "\002", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\c")
   x2("\\c\\\\", "\034", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\c")
   x2("q[\\c\\\\]", "q\034", 0, 2);
 
   // Compile failed: InvalidBackref
@@ -47,16 +47,16 @@
   // ))
   x2("[a-&&-a]", "-", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("\\A\\Z", "", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("xyz\\Z", "xyz", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("a\\Z", "a", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("\\Gaz", "az", 0, 2);
 
   // No match found
@@ -98,16 +98,16 @@
   // Match found at start 0 and end 1 (expected 0 and 0)
   x2("(|a)", "a", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("a|\\Gz", "bza", 2, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("a|\\Gz", "za", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("a|b\\Z", "ba", 1, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("a|b\\Z", "b", 0, 1);
 
   // Match found at start 1 and end 2 (expected 0 and 2)
@@ -137,103 +137,103 @@
   // Compile failed: InvalidBackref
   x2("(?:(?:\\1|z)(a))+$", "zaaa", 0, 4);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("(a*\\Z)\\1", "a", 1, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2(".(a*\\Z)\\1", "ba", 1, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("(a)\\g<1>", "aa", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<name1>a)", "a", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<name_2>ab)\\g<name_2>", "abab", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<name_3>.zv.)\\k<name_3>", "azvbazvb", 0, 8);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("(?<=\\g<ab>)|-\\zEND (?<ab>XyZ)", "XyZ", 3, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<n>|a\\g<n>)+", "", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<n>|\\(\\g<n>\\))+$", "()(())", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x3("\\g<n>(?<n>.){0}", "X", 0, 1, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g<n>(abc|df(?<n>.YZ){2,8}){0}", "XYZ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("\\A(?<n>(a\\g<n>)|)\\z", "aaaa", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<n>|\\g<m>\\g<n>)\\z|\\zEND (?<m>a|(b)\\g<m>)", "bbbbabba", 0, 8);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<name1240>\\w+\\sx)a+\\k<name1240>", "  fg xaaaaaaaafg x", 2, 18);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x3("(z)()()(?<_9>a)\\g<_9>", "zaa", 2, 3, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(.)(((?<_>a)))\\k<_>", "zaa", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("((?<name1>\\d)|(?<name2>\\w))(\\k<name1>|\\k<name2>)", "ff", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?:(?<x>)|(?<x>efg))\\k<x>", "", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?:(?<x>abc)|(?<x>efg))\\k<x>", "abcefgefg", 3, 9);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?:(?<n1>.)|(?<n1>..)|(?<n1>...)|(?<n1>....)|(?<n1>.....)|(?<n1>......)|(?<n1>.......)|(?<n1>........)|(?<n1>.........)|(?<n1>..........)|(?<n1>...........)|(?<n1>............)|(?<n1>.............)|(?<n1>..............))\\k<n1>$", "a-pyumpyum", 2, 10);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x3("(?:(?<n1>.)|(?<n1>..)|(?<n1>...)|(?<n1>....)|(?<n1>.....)|(?<n1>......)|(?<n1>.......)|(?<n1>........)|(?<n1>.........)|(?<n1>..........)|(?<n1>...........)|(?<n1>............)|(?<n1>.............)|(?<n1>..............))\\k<n1>$", "xxxxabcdefghijklmnabcdefghijklmn", 4, 18, 14);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x3("(?<name1>)(?<name2>)(?<name3>)(?<name4>)(?<name5>)(?<name6>)(?<name7>)(?<name8>)(?<name9>)(?<name10>)(?<name11>)(?<name12>)(?<name13>)(?<name14>)(?<name15>)(?<name16>aaa)(?<name17>)$", "aaa", 0, 3, 16);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<foo>a|\\(\\g<foo>\\))", "a", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<foo>a|\\(\\g<foo>\\))", "((((((a))))))", 0, 13);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x3("(?<foo>a|\\(\\g<foo>\\))", "((((((((a))))))))", 0, 17, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g<bar>|\\zEND(?<bar>.*abc$)", "abcxxxabc", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g<1>|\\zEND(.a.)", "bac", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x3("\\g<_A>\\g<_A>|\\zEND(.a.)(?<_A>.b.)", "xbxyby", 3, 6, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\A(?:\\g<pon>|\\g<pan>|\\zEND  (?<pan>a|c\\g<pon>c)(?<pon>b|d\\g<pan>d))$", "cdcbcdc", 0, 7);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("\\A(?<n>|a\\g<m>)\\z|\\zEND (?<m>\\g<n>)", "aaaa", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<n>(a|b\\g<n>c){3,5})", "baaaaca", 1, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<n>(a|b\\g<n>c){3,5})", "baaaacaaaaa", 0, 10);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<pare>\\(([^\\(\\)]++|\\g<pare>)*+\\))", "((a))", 0, 5);
 
   // No match found
@@ -245,7 +245,7 @@
   // Compile failed: InvalidBackref
   x3("(?:\\1a|())*", "a", 0, 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("x((.)*)*x(?i:\\1)\\Z", "0x1x2x1X2", 1, 9);
 
   // No match found
@@ -254,109 +254,109 @@
   // No match found
   x2("(?:()|()|()|(x)|()|())*\\2b\\5", "b", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x3("(\\(((?:[^(]|\\g<1>)*)\\))", "(abc)(abc)", 1, 4, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\o")
   x2("\\o{101}", "A", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\A(a|b\\g<1>c)\\k<1+3>\\z", "bbacca", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("(?i)\\A(a|b\\g<1>c)\\k<1+2>\\z", "bBACcbac", 0, 8);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?i)(?<X>aa)|(?<X>bb)\\k<X>", "BBbb", 0, 4);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\k")
   x2("(?:\\k'+1'B|(A)C)*", "ACAB", 0, 4);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g<+2>(abc)(ABC){0}", "ABCabc", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("A\\g'0'|B()", "AAAAB", 0, 5);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x3("(A\\g'0')|B", "AAAAB", 0, 5, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a*)(?(1))aa", "aaaaa", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a*)(?(-1))aa", "aaaaa", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<name>aaa)(?('name'))aa", "aaaaa", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a)(?(1)aa|bb)a", "aaaaa", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(?:aa|())(?(<1>)aa|bb)a", "aabba", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(?:aa|())(?('1')aa|bb|cc)a", "aacca", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x3("(a*)(?(1)aa|a)b", "aaab", 0, 1, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a)(?(1)|)c", "ac", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a)(?(1+0)b|c)d", "abd", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?\'")
   x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "ace", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?\'")
   x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "bce", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\R")
   x2("\\R", "\r\n", 0, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\R")
   x2("\\R", "\r", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\R")
   x2("\\R", "\n", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\R")
   x2("\\R", "\x0b", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\R")
   x2("\\R", "\xc2\x85", 0, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\N")
   x2("\\N", "a", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\O")
   x2("\\O", "a", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\O")
   x2("\\O", "\n", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\O")
   x2("(?m:\\O)", "\n", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\O")
   x2("(?-m:\\O)", "\n", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\K")
   x2("\\K", "a", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\K")
   x2("a\\K", "a", 1, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\K")
   x2("a\\Kb", "ab", 1, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\K")
   x2("(a\\Kb|ac\\Kd)", "acd", 2, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\K")
   x2("(a\\Kb|\\Kac\\K)*", "acababacab", 9, 10);
 
   // No match found
@@ -368,187 +368,187 @@
   // No match found
   x2("(?:()|()|())*\\3\\1", "abc", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("(|(?:a(?:\\g'1')*))b|", "abc", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("((?<x>abc){0}a\\g<x>d)+", "aabcd", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("((?(abc)true|false))+", "false", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("()(?<x>ab)(?(<x>)a|b)", "aba", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(?<=(?(a)a|bb))z", "aaz", 2, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<x>a)(?<x>b)(\\k<x>)+", "abbaab", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("((?(a)b|c))(\\1)", "abab", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<x>$|b\\g<x>)", "bbb", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<x>(?(a)a|b)|c\\g<x>)", "cccb", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(a)(?(1)a*|b*)+", "aaaa", 0, 4);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\o")
   x2("[\\o{101}]", "A", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~)", "", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~)", "A", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("aaaaa(?~)", "aaaaaaaaaa", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~(?:|aaa))", "aaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~aaa|)", "aaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("a(?~(?~)).", "abcdefghijklmnopqrstuvwxyz", 0, 26);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("/\\*(?~\\*/)\\*/", "/* */ */", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~\\w+)zzzzz", "zzzzz", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~\\w*)zzzzz", "zzzzz", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~A.C|B)", "ABC", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~XYZ|ABC)a", "ABCa", 1, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~XYZ|ABC)a", "aABCa", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("<[^>]*>(?~[<>])</[^>]*>", "<a>vvv</a>   <b>  </b>", 0, 10);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~ab)", "ccc\ndab", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?m:(?~ab))", "ccc\ndab", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?-m:(?~ab))", "ccc\ndab", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~abc)xyz", "xyz012345678901234567890123456789abc", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|78|\\d*)", "123456789", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|def|(?:abc|de|f){0,100})", "abcdedeabcfdefabc", 0, 11);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|.*)", "ccc\nddd", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|\\O*)", "ccc\ndab", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|\\O{2,10})", "ccc\ndab", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|\\O{1,10})", "ab", 1, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc|\\O{1,10})", "abc", 1, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|\\O{5,10})|abc", "abc", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|ab|\\O{1,10})", "cccccccccccab", 0, 10);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|aaa|)", "aaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~||a*)", "aaaaaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~||a*?)", "aaaaaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(a)(?~|b|\\1)", "aaaaaa", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(a)(?~|bb|(?:a\\1)*)", "aaaaaa", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(b|c)(?~|abac|(?:a\\1)*)", "abababacabab", 1, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|aaaaa|a*+)", "aaaaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|aaaaaa|a*+)b", "aaaaaab", 1, 7);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abcd|(?>))", "zzzabcd", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc|a*?)", "aaaabc", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc)a*", "aaaaaabc", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc)a*z|aaaaaabc", "aaaaaabc", 0, 8);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|aaaaaa)a*", "aaaaaa", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc)aaaa|aaaabc", "aaaabc", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?>(?~|abc))aaaa|aaaabc", "aaaabc", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|)a", "a", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|a)(?~|)a", "a", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|a).*(?~|)a", "bbbbbbbbbbbbbbbbbbbba", 0, 21);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc).*(xyz|pqr)(?~|)abc", "aaaaxyzaaapqrabc", 0, 16);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?~")
   x2("(?~|abc).*(xyz|pqr)(?~|)abc", "aaaaxyzaaaabcpqrabc", 11, 19);
 
   // No match found
   x2("\\xca\\xb8", "\xca\xb8", 0, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("むめも\\Z", "むめも", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("かきく\\Z", "かきく\n", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("\\Gぽぴ", "ぽぴ", 0, 6);
 
   // No match found
@@ -557,19 +557,19 @@
   // No match found
   x2("(?m:.め)", "ま\nめ", 3, 7);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("鬼|\\G車", "け車鬼", 6, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\G")
   x2("鬼|\\G車", "車鬼", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("鬼|車\\Z", "車鬼", 3, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("鬼|車\\Z", "車", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("鬼|車\\Z", "車\n", 0, 3);
 
   // No match found
@@ -599,16 +599,16 @@
   // No match found
   x3("((?m:あ.う))", "あ\nう", 0, 7, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2("(あ*\\Z)\\1", "あ", 3, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Z")
   x2(".(あ*\\Z)\\1", "いあ", 3, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?<")
   x2("(?<愚か>変|\\(\\g<愚か>\\))", "((((((変))))))", 0, 15);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\A(?:\\g<阿_1>|\\g<云_2>|\\z終了  (?<阿_1>観|自\\g<云_2>自)(?<云_2>在|菩薩\\g<阿_1>菩薩))$", "菩薩自菩薩自在自菩薩自菩薩", 0, 39);
 
   // Compile failed: InnerError(Syntax(
@@ -761,58 +761,58 @@
   // ))
   x2("[^[\\p{^Cntrl}]&&[\\p{ASCII}]]", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:\\p{Word})", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?W")
   x2("(?W:\\p{Word})", "k", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:[[:word:]])", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-D")
   x2("(?-D:\\p{Digit})", "３", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-S")
   x2("(?-S:\\p{Space})", "\xc2\x85", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-P")
   x2("(?-P:\\p{Word})", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:\\w)", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:\\w)", "k", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?W")
   x2("(?W:\\w)", "k", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?W")
   x2("(?W:\\W)", "こ", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:\\b)", "こ", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-W")
   x2("(?-W:\\b)", "h", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?W")
   x2("(?W:\\b)", "h", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?W")
   x2("(?W:\\B)", "こ", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-P")
   x2("(?-P:\\b)", "こ", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?-P")
   x2("(?-P:\\b)", "h", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?P")
   x2("(?P:\\b)", "h", 0, 0);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?P")
   x2("(?P:\\B)", "こ", 0, 0);
 
   // Compile failed: InnerError(Syntax(
@@ -825,130 +825,130 @@
   // ))
   x2("\\p{InBasicLatin}", "\x41", 0, 1);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2(".\\Y\\O", "\x0d\x0a", 0, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2(".\\Y.", "\x67\xCC\x88", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\y")
   x2("\\y.\\Y.\\y", "\x67\xCC\x88", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\y")
   x2("\\y.\\y", "\xEA\xB0\x81", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2("^.\\Y.\\Y.$", "\xE1\x84\x80\xE1\x85\xA1\xE1\x86\xA8", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2(".\\Y.", "\xE0\xAE\xA8\xE0\xAE\xBF", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2(".\\Y.", "\xE0\xB8\x81\xE0\xB8\xB3", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2(".\\Y.", "\xE0\xA4\xB7\xE0\xA4\xBF", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2("..\\Y.", "\xE3\x80\xB0\xE2\x80\x8D\xE2\xAD\x95", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\Y")
   x2("...\\Y.", "\xE3\x80\xB0\xCC\x82\xE2\x80\x8D\xE2\xAD\x95", 0, 11);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\x0d\x0a", 0, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\x67\xCC\x88", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\xE1\x84\x80\xE1\x85\xA1\xE1\x86\xA8", 0, 9);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\xE0\xAE\xA8\xE0\xAE\xBF", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\xE0\xB8\x81\xE0\xB8\xB3", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("^\\X$", "\xE0\xA4\xB7\xE0\xA4\xBF", 0, 6);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\X")
   x2("h\\Xllo", "ha\xCC\x80llo", 0, 7);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{g})\\yabc\\y", "abc", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{g})\\y\\X\\y", "abc", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\yabc\\y", "abc", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "\r\n", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "\x0cz", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "q\x0c", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "\xE2\x80\x8D\xE2\x9D\x87", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "\x20\x20", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "a\xE2\x80\x8D", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "abc", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "v\xCE\x87w", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "\xD7\x93\x27", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "\xD7\x93\x22\xD7\x93", 0, 5);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "14 45", 0, 2);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "a14", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "832e", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "8\xEF\xBC\x8C\xDB\xB0", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "ケン", 0, 6);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "ケン\xE2\x80\xAFタ", 0, 12);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "\x21\x23", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\y\\X\\y", "山ア", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "3.14", 0, 4);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?y")
   x2("(?y{w})\\X", "3 14", 0, 1);
 
   // Compile failed: InvalidHex
   x2("\\x1", "\x01", 0, 1);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("((?()0+)+++(((0\\g<0>)0)|())++++((?(1)(0\\g<0>))++++++0*())++++((?(1)(0\\g<1>)+)++++++++++*())++++((?(1)((0)\\g<0>)+)++())+0++*+++(((0\\g<0>))*())++++((?(1)(0\\g<0>)+)++++++++++*|)++++*+++((?(1)((0)\\g<0>)+)+++++++++())++*|)++++((?()0))|", "abcde", 0, 0);
 
   // Compile failed: InnerError(Syntax(
@@ -972,22 +972,22 @@
   x2("(?:(*COUNT[AB]{X})[ab]|(*COUNT[CD]{X})[cd])*(*CMP{AB,<,CD})",
      "abababcdab", 5, 8);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(?(?{....})123|456)", "123", 0, 3);
 
-  // Compile failed: UnknownFlag
+  // Compile failed: UnknownFlag("(?(")
   x2("(?(*FAIL)123|456)", "456", 0, 3);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g'0'++{,0}",   "abcdefgh", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g'0'++{,0}?",  "abcdefgh", 0, 0);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g'0'++{,0}b",  "abcdefgh", 1, 2);
 
-  // Compile failed: InvalidEscape
+  // Compile failed: InvalidEscape("\\g")
   x2("\\g'0'++{,0}?def", "abcdefgh", 3, 6);
 
   // Compile failed: InnerError(Syntax(


### PR DESCRIPTION
Makes it easier to identify the problem. Before:

```
"Unknown group flag"
"Invalid escape"
```

After:

```
"Unknown group flag: (?<"
"Invalid escape: \g"
```

(For https://github.com/trishume/syntect/issues/287)