### PR TITLE
Try to fix build on Rust 1.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bit-set = "0.5"
 
 [dev-dependencies]
 criterion = "= 0.3.0" # pinned because 0.3.1 doesn't work on Rust 1.32
+rayon-core = "= 1.7.0" # dependency of criterion, pinned to work on Rust 1.32
 matches = "0.1.8"
 quickcheck = "0.7"
 rand = "0.5"


### PR DESCRIPTION
We should probably consider committing Cargo.lock to not get failures
like this when dependencies upgrade and break compatibility.