### PR TITLE
Added expansion APIs

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,24 +1,67 @@
 use crate::parse::{parse_decimal, parse_id};
-use crate::Captures;
+use crate::{Captures, Error, Result};
 
-pub struct Expander {
-    pub sub_char: char,
-    pub open: &'static str,
-    pub close: &'static str,
-    pub allow_undelimited_name: bool,
+/// A set of options for expanding a template string using the contents
+/// of capture groups.  Create using the `builder` method.
+#[derive(Debug)]
+pub struct Expander<'a> {
+    sub_char: char,
+    delimiters: Option<Delimiters<'a>>,
+    allow_undelimited_name: bool,
+    strict: bool,
 }
 
-impl Expander {
-    pub fn expand<'t>(&self, captures: &Captures<'t>, replacement: &str, dst: &mut String) {
-        let mut iter = replacement.chars();
+#[derive(Debug)]
+struct Delimiters<'a> {
+    open: &'a str,
+    close: &'a str,
+}
+
+impl<'a> Expander<'a> {
+    /// Creates a new builder object used to initialize a new `Expander`.  The expander
+    /// uses the character `sub_char` to introduce a substitution, with two consecutive
+    /// occurrences of `sub_char` used to denote a literal `sub_char` in the expansion.
+    ///
+    /// By default, only numbered capture groups can be expanded by following the
+    /// substitution character with zero or more decimal digits denoting the group
+    /// number.
+    pub fn builder(sub_char: char) -> ExpanderBuilder<'a> {
+        ExpanderBuilder(Expander {
+            sub_char,
+            delimiters: None,
+            allow_undelimited_name: false,
+            strict: false,
+        })
+    }
+
+    /// Expands the template string `template` using the syntax defined
+    /// by this expander and the values of capture groups from `captures`.
+    /// The output is appended to `dst`.
+    ///
+    /// Always succeeds when this expander is not strict.  When an error is
+    /// reported, a partial expansion may be appended to `dst`.
+    pub fn expand<'t>(
+        &self,
+        captures: &Captures<'t>,
+        template: &str,
+        dst: &mut String,
+    ) -> Result<()> {
+        let mut iter = template.chars();
         while let Some(c) = iter.next() {
             if c == self.sub_char {
                 let tail = iter.as_str();
                 let skip = if tail.starts_with(self.sub_char) {
                     dst.push(self.sub_char);
                     1
-                } else if let Some((id, skip)) =
-                    parse_id(tail, self.open, self.close).or_else(|| {
+                } else if let Some((id, skip)) = self
+                    .delimiters
+                    .as_ref()
+                    .and_then(|Delimiters { open, close }| {
+                        debug_assert!(!open.is_empty());
+                        debug_assert!(!close.is_empty());
+                        parse_id(tail, open, close)
+                    })
+                    .or_else(|| {
                         if self.allow_undelimited_name {
                             parse_id(tail, "", "")
                         } else {
@@ -28,10 +71,10 @@ impl Expander {
                 {
                     if let Some(m) = captures.name(id) {
                         *dst += m.as_str();
-                    } else if let Ok(num) = id.parse() {
-                        if let Some(m) = captures.get(num) {
-                            *dst += m.as_str();
-                        }
+                    } else if let Some(m) = id.parse().ok().and_then(|num| captures.get(num)) {
+                        *dst += m.as_str();
+                    } else if self.strict {
+                        return Err(Error::InvalidGroupName);
                     }
                     skip
                 } else if let Some((skip, num)) = parse_decimal(tail, 0) {
@@ -39,6 +82,8 @@ impl Expander {
                         *dst += m.as_str();
                     }
                     skip
+                } else if self.strict {
+                    return Err(Error::ParseError);
                 } else {
                     dst.push(self.sub_char);
                     0
@@ -48,5 +93,48 @@ impl Expander {
                 dst.push(c);
             }
         }
+        Ok(())
+    }
+}
+
+/// A builder object for constructing new `Expander` values.
+#[derive(Debug)]
+pub struct ExpanderBuilder<'a>(Expander<'a>);
+
+impl<'a> ExpanderBuilder<'a> {
+    /// Creates an expander using the current options in this builder.
+    pub fn build(self) -> Expander<'a> {
+        self.0
+    }
+
+    /// Sets an pair of non-empty delimiter strings used to enclose the name or number of
+    /// a capture group in an expander's template string.  To be recognized, the group name or
+    /// number surrounded by delimiters must immediately follow the substitution character
+    /// set by `Expander::builder`.
+    pub fn delimiters(mut self, open: &'a str, close: &'a str) -> Self {
+        assert!(
+            !open.is_empty() && !close.is_empty(),
+            "Empty delimiter strings are not allowed."
+        );
+        self.0.delimiters = Some(Delimiters { open, close });
+        self
+    }
+
+    /// By default, a capture group name must be enclosed by delimiters in order to
+    /// be recognized.  Passing `true` to this method allows undelimited names to be
+    /// recognized, where the name is taken to be the longest possible sequence of
+    /// identifier characters following the substitution character.
+    pub fn allow_undelimited_name(mut self, value: bool) -> Self {
+        self.0.allow_undelimited_name = value;
+        self
+    }
+
+    /// By default, `Expander::expand` always succeeds.  Invalid syntax in the template string
+    /// is treated as literal text, and a substitution involving a group that failed to
+    /// match, or a name that does not denote a capture group, is expanded to the empty string.
+    /// Passing `true` to this method causes both situations to be reported as errors.
+    pub fn strict(mut self, value: bool) -> Self {
+        self.0.strict = value;
+        self
     }
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,0 +1,52 @@
+use crate::parse::{parse_decimal, parse_id};
+use crate::Captures;
+
+pub struct Expander {
+    pub sub_char: char,
+    pub open: &'static str,
+    pub close: &'static str,
+    pub allow_undelimited_name: bool,
+}
+
+impl Expander {
+    pub fn expand<'t>(&self, captures: &Captures<'t>, replacement: &str, dst: &mut String) {
+        let mut iter = replacement.chars();
+        while let Some(c) = iter.next() {
+            if c == self.sub_char {
+                let tail = iter.as_str();
+                let skip = if tail.starts_with(self.sub_char) {
+                    dst.push(self.sub_char);
+                    1
+                } else if let Some((id, skip)) =
+                    parse_id(tail, self.open, self.close).or_else(|| {
+                        if self.allow_undelimited_name {
+                            parse_id(tail, "", "")
+                        } else {
+                            None
+                        }
+                    })
+                {
+                    if let Some(m) = captures.name(id) {
+                        *dst += m.as_str();
+                    } else if let Ok(num) = id.parse() {
+                        if let Some(m) = captures.get(num) {
+                            *dst += m.as_str();
+                        }
+                    }
+                    skip
+                } else if let Some((skip, num)) = parse_decimal(tail, 0) {
+                    if let Some(m) = captures.get(num) {
+                        *dst += m.as_str();
+                    }
+                    skip
+                } else {
+                    dst.push(self.sub_char);
+                    0
+                };
+                iter = iter.as_str()[skip..].chars();
+            } else {
+                dst.push(c);
+            }
+        }
+    }
+}

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::mem;
 
 /// A set of options for expanding a template string using the contents
-/// of capture groups.  Create using the `builder` method.
+/// of capture groups.
 #[derive(Debug)]
 pub struct Expander {
     sub_char: char,
@@ -79,9 +79,9 @@ impl Expander {
     /// by this expander and the values of capture groups from `captures`.
     ///
     /// Always succeeds when this expander is not strict.
-    pub fn expansion<'t>(&self, captures: &Captures<'t>, template: &str) -> io::Result<String> {
+    pub fn expansion<'t>(&self, template: &str, captures: &Captures<'t>) -> io::Result<String> {
         let mut cursor = io::Cursor::new(Vec::new());
-        self.write_expansion(&mut cursor, captures, template)?;
+        self.write_expansion(&mut cursor, template, captures)?;
         Ok(String::from_utf8(cursor.into_inner()).expect("expansion is UTF-8"))
     }
 
@@ -90,11 +90,11 @@ impl Expander {
     pub fn append_expansion<'t>(
         &self,
         dst: &mut String,
-        captures: &Captures<'t>,
         template: &str,
+        captures: &Captures<'t>,
     ) -> io::Result<()> {
         let mut cursor = io::Cursor::new(mem::replace(dst, String::new()).into_bytes());
-        self.write_expansion(&mut cursor, captures, template)?;
+        self.write_expansion(&mut cursor, template, captures)?;
         *dst = String::from_utf8(cursor.into_inner()).expect("expansion is UTF-8");
         Ok(())
     }
@@ -104,8 +104,8 @@ impl Expander {
     pub fn write_expansion<'t>(
         &self,
         mut dst: impl io::Write,
-        captures: &Captures<'t>,
         template: &str,
+        captures: &Captures<'t>,
     ) -> io::Result<()> {
         debug_assert!(!self.open.is_empty());
         debug_assert!(!self.close.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,7 +626,7 @@ impl<'t> Captures<'t> {
     /// [`Expander`]: expand/struct.Expander.html
     pub fn expand(&self, replacement: &str, dst: &mut String) {
         Expander::default()
-            .append_expansion(dst, self, replacement)
+            .append_expansion(dst, replacement, self)
             .expect("expansion succeeded");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::vm::Prog;
 
 pub use crate::error::{Error, Result};
-use crate::expand::Expander;
+pub use crate::expand::{Expander, ExpanderBuilder};
 
 const MAX_RECURSION: usize = 64;
 
@@ -621,13 +621,12 @@ impl<'t> Captures<'t> {
     ///
     /// To write a literal `$`, use `$$`.    
     pub fn expand(&self, replacement: &str, dst: &mut String) {
-        Expander {
-            sub_char: '$',
-            open: "{",
-            close: "}",
-            allow_undelimited_name: true,
-        }
-        .expand(self, replacement, dst)
+        Expander::builder('$')
+            .delimiters("{", "}")
+            .allow_undelimited_name(true)
+            .build()
+            .expand(self, replacement, dst)
+            .expect("expansion succeeded");
     }
 
     /// Alternate version of [`expand`] using a syntax compatible with
@@ -655,13 +654,12 @@ impl<'t> Captures<'t> {
     ///
     /// [`expand`]: #method.expand
     pub fn expand_backslash(&self, replacement: &str, dst: &mut String) {
-        Expander {
-            sub_char: '\\',
-            open: "g<",
-            close: ">",
-            allow_undelimited_name: false,
-        }
-        .expand(self, replacement, dst)
+        Expander::builder('\\')
+            .delimiters("g<", ">")
+            .allow_undelimited_name(false)
+            .build()
+            .expand(self, replacement, dst)
+            .expect("expansion succeeded");
     }
 
     /// Returns the match for a named capture group.  Returns `None` the capture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ use std::usize;
 mod analyze;
 mod compile;
 mod error;
+mod expand;
 mod parse;
 mod vm;
 
@@ -162,6 +163,7 @@ use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::vm::Prog;
 
 pub use crate::error::{Error, Result};
+use crate::expand::Expander;
 
 const MAX_RECURSION: usize = 64;
 
@@ -594,6 +596,72 @@ impl<'t> Captures<'t> {
                 })
             }
         }
+    }
+
+    /// Returns the match for a named capture group.  Returns `None` the capture
+    /// group did not match or if there is no group with the given name.
+    pub fn name(&self, name: &str) -> Option<Match<'t>> {
+        self.names.get(name).and_then(|i| self.get(*i))
+    }
+
+    /// Expands all instances of `$group` in `replacement` to the corresponding
+    /// capture group `name`, and writes them to the `dst` buffer given.
+    ///
+    /// `group` may be an integer corresponding to the index of the
+    /// capture group (counted by order of opening parenthesis where `0` is the
+    /// entire match) or it can be a name (consisting of letters, digits or
+    /// underscores) corresponding to a named capture group.
+    ///
+    /// If `group` isn't a valid capture group (whether the name doesn't exist
+    /// or isn't a valid index), then it is replaced with the empty string.
+    ///
+    /// The longest possible name is used. e.g., `$1a` looks up the capture
+    /// group named `1a` and not the capture group at index `1`. To exert more
+    /// precise control over the name, use braces, e.g., `${1}a`.
+    ///
+    /// To write a literal `$`, use `$$`.    
+    pub fn expand(&self, replacement: &str, dst: &mut String) {
+        Expander {
+            sub_char: '$',
+            open: "{",
+            close: "}",
+            allow_undelimited_name: true,
+        }
+        .expand(self, replacement, dst)
+    }
+
+    /// Alternate version of [`expand`] using a syntax compatible with
+    /// certain other regex implementations.
+    ///
+    /// Expands all instances of `\num` or `\g<name>` in `replacement`
+    /// to the corresponding capture group `num` or `name`, and writes
+    /// them to the `dst` buffer given.
+    ///
+    /// `name` may be an integer corresponding to the index of the
+    /// capture group (counted by order of opening parenthesis where `0` is the
+    /// entire match) or it can be a name (consisting of letters, digits or
+    /// underscores) corresponding to a named capture group.
+    ///
+    /// `num` must be an integer corresponding to the index of the
+    /// capture group.
+    ///
+    /// If `num` or `name` isn't a valid capture group (whether the name doesn't exist
+    /// or isn't a valid index), then it is replaced with the empty string.
+    ///
+    /// The longest possible number is used. e.g., `\10` looks up capture
+    /// group 10 and not capture group 1 followed by a literal 0.
+    ///
+    /// To write a literal `\`, use `\\`.
+    ///
+    /// [`expand`]: #method.expand
+    pub fn expand_backslash(&self, replacement: &str, dst: &mut String) {
+        Expander {
+            sub_char: '\\',
+            open: "g<",
+            close: ">",
+            allow_undelimited_name: false,
+        }
+        .expand(self, replacement, dst)
     }
 
     /// Returns the match for a named capture group.  Returns `None` the capture

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -193,14 +193,14 @@ fn expand() {
     assert_backlash_expansion(&cap, "\\g<π", "\\g<π");
 }
 
-#[track_caller]
+#[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_expansion(cap: &Captures, replacement: &str, text: &str) {
     let mut buf = String::new();
     cap.expand(replacement, &mut buf);
     assert_eq!(buf, text);
 }
 
-#[track_caller]
+#[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_backlash_expansion(cap: &Captures, replacement: &str, text: &str) {
     let mut buf = String::new();
     cap.expand_backslash(replacement, &mut buf);

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -216,25 +216,24 @@ fn expander_errors() {
         .allow_undelimited_name(true)
         .strict(true)
         .build();
-    let mut out = String::new();
 
     // Substitution char at end of template.
-    assert!(exp.expand(&cap, "$", &mut out).is_err());
+    assert!(exp.expand(&cap, "$").is_err());
 
     // Substitution char not followed by a name or number.
-    assert!(exp.expand(&cap, "$.", &mut out).is_err());
+    assert!(exp.expand(&cap, "$.").is_err());
 
     // Unmatched group number.
-    assert!(exp.expand(&cap, "$5", &mut out).is_err());
-    assert!(exp.expand(&cap, "${5}", &mut out).is_err());
+    assert!(exp.expand(&cap, "$5").is_err());
+    assert!(exp.expand(&cap, "${5}").is_err());
 
     // Unmatched group name.
-    assert!(exp.expand(&cap, "$xx", &mut out).is_err());
-    assert!(exp.expand(&cap, "${xx}", &mut out).is_err());
+    assert!(exp.expand(&cap, "$xx").is_err());
+    assert!(exp.expand(&cap, "${xx}").is_err());
 
     // Empty delimiter pair.
-    assert!(exp.expand(&cap, "${}", &mut out).is_err());
+    assert!(exp.expand(&cap, "${}").is_err());
 
     // Unterminated delimiter pair.
-    assert!(exp.expand(&cap, "${", &mut out).is_err());
+    assert!(exp.expand(&cap, "${").is_err());
 }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -136,3 +136,73 @@ fn assert_match(m: Option<Match<'_>>, expected_text: &str, start: usize, end: us
     assert_eq!(m.start(), start);
     assert_eq!(m.end(), end);
 }
+
+#[test]
+fn expand() {
+    let regex = common::regex("(a)(b)(?<π>c)(?P<x>d)");
+    let cap = regex.captures("abcd").unwrap().expect("matched");
+    assert_expansion(&cap, "$0", "abcd");
+    assert_expansion(&cap, "$1", "a");
+    assert_expansion(&cap, "$2", "b");
+    assert_expansion(&cap, "$3", "c");
+    assert_expansion(&cap, "$4", "d");
+    assert_expansion(&cap, "$π", "c");
+    assert_expansion(&cap, "$x", "d");
+    assert_expansion(&cap, "$0π", "");
+    assert_expansion(&cap, "$1π", "");
+    assert_expansion(&cap, "$2π", "");
+    assert_expansion(&cap, "$3π", "");
+    assert_expansion(&cap, "$4π", "");
+    assert_expansion(&cap, "$ππ", "");
+    assert_expansion(&cap, "$xπ", "");
+    assert_expansion(&cap, "${0}π", "abcdπ");
+    assert_expansion(&cap, "${1}π", "aπ");
+    assert_expansion(&cap, "${2}π", "bπ");
+    assert_expansion(&cap, "${3}π", "cπ");
+    assert_expansion(&cap, "${4}π", "dπ");
+    assert_expansion(&cap, "${π}π", "cπ");
+    assert_expansion(&cap, "${x}π", "dπ");
+    assert_expansion(&cap, "$", "$");
+    assert_expansion(&cap, "$π√", "c√");
+    assert_expansion(&cap, "$x√", "d√");
+    assert_expansion(&cap, "$$π", "$π");
+    assert_expansion(&cap, "${π", "${π");
+    assert_backlash_expansion(&cap, "\\0", "abcd");
+    assert_backlash_expansion(&cap, "\\1", "a");
+    assert_backlash_expansion(&cap, "\\2", "b");
+    assert_backlash_expansion(&cap, "\\3", "c");
+    assert_backlash_expansion(&cap, "\\4", "d");
+    assert_backlash_expansion(&cap, "\\π", "\\π");
+    assert_backlash_expansion(&cap, "\\x", "\\x");
+    assert_backlash_expansion(&cap, "\\0π", "abcdπ");
+    assert_backlash_expansion(&cap, "\\1π", "aπ");
+    assert_backlash_expansion(&cap, "\\2π", "bπ");
+    assert_backlash_expansion(&cap, "\\3π", "cπ");
+    assert_backlash_expansion(&cap, "\\4π", "dπ");
+    assert_backlash_expansion(&cap, "\\ππ", "\\ππ");
+    assert_backlash_expansion(&cap, "\\xπ", "\\xπ");
+    assert_backlash_expansion(&cap, "\\g<0>π", "abcdπ");
+    assert_backlash_expansion(&cap, "\\g<1>π", "aπ");
+    assert_backlash_expansion(&cap, "\\g<2>π", "bπ");
+    assert_backlash_expansion(&cap, "\\g<3>π", "cπ");
+    assert_backlash_expansion(&cap, "\\g<4>π", "dπ");
+    assert_backlash_expansion(&cap, "\\g<π>π", "cπ");
+    assert_backlash_expansion(&cap, "\\g<x>π", "dπ");
+    assert_backlash_expansion(&cap, "\\", "\\");
+    assert_backlash_expansion(&cap, "\\\\π", "\\π");
+    assert_backlash_expansion(&cap, "\\g<π", "\\g<π");
+}
+
+#[track_caller]
+fn assert_expansion(cap: &Captures, replacement: &str, text: &str) {
+    let mut buf = String::new();
+    cap.expand(replacement, &mut buf);
+    assert_eq!(buf, text);
+}
+
+#[track_caller]
+fn assert_backlash_expansion(cap: &Captures, replacement: &str, text: &str) {
+    let mut buf = String::new();
+    cap.expand_backslash(replacement, &mut buf);
+    assert_eq!(buf, text);
+}

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -204,7 +204,7 @@ fn assert_expansion(cap: &Captures, replacement: &str, text: &str) {
 #[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_python_expansion(cap: &Captures, replacement: &str, text: &str) {
     assert_eq!(
-        Expander::python().expansion(cap, replacement).unwrap(),
+        Expander::python().expansion(replacement, cap).unwrap(),
         text
     );
 }
@@ -227,22 +227,22 @@ fn expander_errors() {
     exp.set_strict(true);
 
     // Substitution char at end of template.
-    assert!(exp.expansion(&cap, "$").is_err());
+    assert!(exp.expansion("$", &cap).is_err());
 
     // Substitution char not followed by a name or number.
-    assert!(exp.expansion(&cap, "$.").is_err());
+    assert!(exp.expansion("$.", &cap).is_err());
 
     // Unmatched group number.
-    assert!(exp.expansion(&cap, "$5").is_err());
-    assert!(exp.expansion(&cap, "${5}").is_err());
+    assert!(exp.expansion("$5", &cap).is_err());
+    assert!(exp.expansion("${5}", &cap).is_err());
 
     // Unmatched group name.
-    assert!(exp.expansion(&cap, "$xx").is_err());
-    assert!(exp.expansion(&cap, "${xx}").is_err());
+    assert!(exp.expansion("$xx", &cap).is_err());
+    assert!(exp.expansion("${xx}", &cap).is_err());
 
     // Empty delimiter pair.
-    assert!(exp.expansion(&cap, "${}").is_err());
+    assert!(exp.expansion("${}", &cap).is_err());
 
     // Unterminated delimiter pair.
-    assert!(exp.expansion(&cap, "${").is_err());
+    assert!(exp.expansion("${", &cap).is_err());
 }


### PR DESCRIPTION
Adds a method similar to regex::Captures::expand, an alternate version using Python-style syntax, and a API for flexible expansion string syntax.

Not expected to build with PR #55.