### PR TITLE
Added: `Match:range()` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,6 +566,7 @@ impl<'t> Match<'t> {
         &self.text[self.start..self.end]
     }
 
+    /// Creates a new match from the given text and byte offsets.
     fn new(text: &'t str, start: usize, end: usize) -> Match<'t> {
         Match { text, start, end }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ assert!(!re.is_match("abc").unwrap());
 
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 use std::sync::Arc;
 use std::usize;
 
@@ -551,6 +552,12 @@ impl<'t> Match<'t> {
     #[inline]
     pub fn end(&self) -> usize {
         self.end
+    }
+
+    /// Returns the range over the starting and ending byte offsets of the match in text.
+    #[inline]
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.end
     }
 
     /// Returns the matched text.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,9 +419,10 @@ impl Regex {
             RegexImpl::Wrap { inner, .. } => Ok(inner
                 .find(text)
                 .map(|m| Match::new(text, m.start(), m.end()))),
-            RegexImpl::Fancy { prog, options, .. } => vm::run(prog, text, 0, 0, options)?
-                .map(|saves| Ok(Match::new(text, saves[0], saves[1])))
-                .transpose(),
+            RegexImpl::Fancy { prog, options, .. } => {
+                let result = vm::run(prog, text, 0, 0, options)?;
+                Ok(result.map(|saves| Match::new(text, saves[0], saves[1])))
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,6 +572,18 @@ impl<'t> Match<'t> {
     }
 }
 
+impl<'t> From<Match<'t>> for &'t str {
+    fn from(m: Match<'t>) -> &'t str {
+        m.as_str()
+    }
+}
+
+impl<'t> From<Match<'t>> for Range<usize> {
+    fn from(m: Match<'t>) -> Range<usize> {
+        m.range()
+    }
+}
+
 #[allow(clippy::len_without_is_empty)] // follow regex's API
 impl<'t> Captures<'t> {
     /// Get the capture group by its index in the regex.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,10 +419,9 @@ impl Regex {
             RegexImpl::Wrap { inner, .. } => Ok(inner
                 .find(text)
                 .map(|m| Match::new(text, m.start(), m.end()))),
-            RegexImpl::Fancy { prog, options, .. } => {
-                let result = vm::run(prog, text, 0, 0, options)?;
-                Ok(result.map(|saves| Match::new(text, saves[0], saves[1])))
-            }
+            RegexImpl::Fancy { prog, options, .. } => vm::run(prog, text, 0, 0, options)?
+                .map(|saves| Ok(Match::new(text, saves[0], saves[1])))
+                .transpose(),
         }
     }
 


### PR DESCRIPTION
- These are ported from `regex` crate.
- Added `Match::range()`
- Added description for `Match::new()`
- Implemented `From<Match>` for string slice and `Range<usize>`.