### PR TITLE
Added error checking and fixed append_expansion.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,9 +625,7 @@ impl<'t> Captures<'t> {
     ///
     /// [`Expander`]: expand/struct.Expander.html
     pub fn expand(&self, replacement: &str, dst: &mut String) {
-        Expander::default()
-            .append_expansion(dst, replacement, self)
-            .expect("expansion succeeded");
+        Expander::default().append_expansion(dst, replacement, self);
     }
 
     /// Iterate over the captured groups in order in which they appeared in the regex. The first


### PR DESCRIPTION
This adds the error checking method I mentioned before, and it fixes a bug in `append_expansion` that causes the initial contents of `dst` to be overwritten.