### PR TITLE
CI: Fix coverage action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin
+      image: xd009642/tarpaulin:0.16.0
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout sources


### PR DESCRIPTION
See https://github.com/xd009642/tarpaulin/issues/461#issuecomment-753466606

Looks like the latest version (0.17.0) is broken. It has been yanked
from crates.io but the Docker image is still on that. Use a pinned
version, which is better for CI anyway.