### PR TITLE
Remove clippy from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,27 +78,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.32.0 # MSRV
-          profile: minimal
-          override: true
-          components: clippy
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
   coverage:
     name: coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's not deterministic enough to run it on a schedule. Additionally, it
would be nice to be able to run the newest clippy but not have it
complain about things that can't be fixed without bumping the MSRV.