### PR TITLE
Bump MSRV to 1.41.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.32.0 # MSRV (minimum supported Rust version)
+          - 1.41.1 # MSRV (minimum supported Rust version)
           - stable
           - beta
     steps:
@@ -77,6 +77,27 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.41.1 # MSRV
+          profile: minimal
+          override: true
+          components: clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
 
   coverage:
     name: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,27 +78,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.41.1 # MSRV
-          profile: minimal
-          override: true
-          components: clippy
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ regex = "1.2" # when we go to >= 1.3.8, we can get rid of the `contains_empty` w
 bit-set = "0.5"
 
 [dev-dependencies]
-criterion = "= 0.3.0" # pinned because 0.3.1 doesn't work on Rust 1.32
-rayon-core = "= 1.7.0" # dependency of criterion, pinned to work on Rust 1.32
+criterion = "0.3.3"
 matches = "0.1.8"
 quickcheck = "0.7"
 rand = "0.5"

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -409,7 +409,7 @@ pub fn run_default(prog: &Prog, s: &str, pos: usize) -> Result<Option<Vec<usize>
 }
 
 /// Run the program with options.
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn run(
     prog: &Prog,
     s: &str,


### PR DESCRIPTION
The byteorder crate recently bumped to 1.41.1 and didn't compile on
1.32.0 anymore:
https://github.com/BurntSushi/byteorder/pull/171

So we'd either need to pin byteorder to an older version or bump our
MSRV. 1.41.1 is the version that's in Debian stable, that's new enough.

It also means we can add back clippy.