### PR TITLE
add find_iter, captures_iter (and find_from_pos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ from parents to children.
 Still in development, though the basic ideas are in place. Currently,
 the following features are missing:
 
-* Iterator methods likes `find_iter` and `captures_iter`
+* Replace methods like `replace`, `replacen` and `replaceall`
 * Procedure calls and recursive expressions
 
 ## Acknowledgements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,123 @@ pub struct Match<'t> {
     end: usize,
 }
 
+/// Returns the smallest possible index of the next valid UTF-8 sequence
+/// starting after `i`.
+/// Adapted from a function with the same name in the `regex` crate.
+fn next_utf8(text: &str, i: usize) -> usize {
+    let b = match text.as_bytes().get(i) {
+        None => return i + 1,
+        Some(&b) => b,
+    };
+    let inc = if b <= 0x7F {
+        1
+    } else if b <= 0b110_11111 {
+        2
+    } else if b <= 0b1110_1111 {
+        3
+    } else {
+        4
+    };
+    i + inc
+}
+
+/// An iterator over all non-overlapping matches for a particular string.
+///
+/// The iterator yields a `Match` value. The iterator stops when no more
+/// matches can be found.
+///
+/// `'r` is the lifetime of the compiled regular expression and `'t` is the
+/// lifetime of the matched string.
+#[derive(Debug)]
+pub struct Matches<'r, 't> {
+    re: &'r Regex,
+    text: &'t str,
+    last_end: usize,
+    last_match: Option<usize>,
+}
+
+impl<'r, 't> Iterator for Matches<'r, 't> {
+    type Item = Result<Match<'t>>;
+
+    /// Adapted from the `regex` crate. Calls `find_from_pos` repeatedly.
+    /// Ignores empty matches immediately after a match.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last_end > self.text.len() {
+            return None;
+        }
+
+        let mat = match self.re.find_from_pos(self.text, self.last_end) {
+            Err(error) => return Some(Err(error)),
+            Ok(None) => return None,
+            Ok(Some(captures)) => {
+                captures
+            },
+        };
+
+        if mat.start == mat.end {
+            // This is an empty match. To ensure we make progress, start
+            // the next search at the smallest possible starting position
+            // of the next match following this one.
+            self.last_end = next_utf8(self.text, mat.end);
+            // Don't accept empty matches immediately following a match.
+            // Just move on to the next match.
+            if Some(mat.end) == self.last_match {
+                return self.next();
+            }
+        } else {
+            self.last_end = mat.end;
+        }
+
+        self.last_match = Some(mat.end);
+
+        Some(Ok(mat))
+    }
+}
+
+/// An iterator that yields all non-overlapping capture groups matching a
+/// particular regular expression.
+///
+/// The iterator stops when no more matches can be found.
+///
+/// `'r` is the lifetime of the compiled regular expression and `'t` is the
+/// lifetime of the matched string.
+#[derive(Debug)]
+pub struct CaptureMatches<'r, 't>(Matches<'r, 't>);
+
+impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
+    type Item = Result<Captures<'t>>;
+
+    /// Adapted from the `regex` crate. Calls `captures_from_pos` repeatedly.
+    /// Ignores empty matches immediately after a match.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.last_end > self.0.text.len() {
+            return None;
+        }
+
+        let captures = match self.0.re.captures_from_pos(self.0.text, self.0.last_end) {
+            Err(error) => return Some(Err(error)),
+            Ok(None) => return None,
+            Ok(Some(captures)) => {
+                captures
+            },
+        };
+
+        let mat = captures.get(0).expect("`Captures` is expected to have entire match at 0th position");
+        if mat.start == mat.end {
+            self.0.last_end = next_utf8(self.0.text, mat.end);
+            if Some(mat.end) == self.0.last_match {
+                return self.next();
+            }
+        } else {
+            self.0.last_end = mat.end;
+        }
+        
+        self.0.last_match = Some(mat.end);
+
+        Some(Ok(captures))
+    }
+}
+
 /// A set of capture groups found for a regex.
 #[derive(Debug)]
 pub struct Captures<'t> {
@@ -402,6 +519,29 @@ impl Regex {
         }
     }
 
+    /// Returns an iterator for each successive non-overlapping match in `text`.
+    ///
+    /// If you have capturing groups in your regex that you want to extract, use the [captures_iter()]
+    /// method.
+    /// 
+    /// # Example
+    ///
+    /// Find all words followed by an exclamation point:
+    ///
+    /// ```rust
+    /// # use fancy_regex::Regex;
+    ///
+    /// let re = Regex::new(r"\w+(?=!)").unwrap();
+    /// let mut matches = re.find_iter("so fancy! even with! iterators!");
+    /// assert_eq!(matches.next().unwrap().unwrap().as_str(), "fancy");
+    /// assert_eq!(matches.next().unwrap().unwrap().as_str(), "with");
+    /// assert_eq!(matches.next().unwrap().unwrap().as_str(), "iterators");
+    /// assert!(matches.next().is_none());
+    /// ```
+    pub fn find_iter<'r, 't>(&'r self, text: &'t str) -> Matches<'r, 't> {
+        Matches { re: &self, text, last_end: 0, last_match: None }
+    }
+
     /// Find the first match in the input text.
     ///
     /// If you have capturing groups in your regex that you want to extract, use the [captures()]
@@ -418,15 +558,66 @@ impl Regex {
     /// assert_eq!(re.find("so fancy!").unwrap().unwrap().as_str(), "fancy");
     /// ```
     pub fn find<'t>(&self, text: &'t str) -> Result<Option<Match<'t>>> {
+        self.find_from_pos(text, 0)
+    }
+
+    /// Returns the first match in `text`, starting from the specified byte position `pos`.
+    ///
+    /// # Examples
+    ///
+    /// Finding match starting at a position:
+    ///
+    /// ```
+    /// # use fancy_regex::Regex;
+    /// let re = Regex::new(r"(?m:^)(\d+)").unwrap();
+    /// let text = "1 test 123\n2 foo";
+    /// let mat = re.find_from_pos(text, 7).unwrap().unwrap();
+    ///
+    /// assert_eq!(mat.start(), 11);
+    /// assert_eq!(mat.end(), 12);
+    /// ```
+    ///
+    /// Note that in some cases this is not the same as using the `captures`
+    /// methods and passing a slice of the string, see [captures_from_pos()] for details.
+    pub fn find_from_pos<'t>(&self, text: &'t str, pos: usize) -> Result<Option<Match<'t>>> {
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner
-                .find(text)
+                .find_at(text, pos)
                 .map(|m| Match::new(text, m.start(), m.end()))),
             RegexImpl::Fancy { prog, options, .. } => {
-                let result = vm::run(prog, text, 0, 0, options)?;
+                let result = vm::run(prog, text, pos, 0, options)?;
                 Ok(result.map(|saves| Match::new(text, saves[0], saves[1])))
             }
         }
+    }
+
+    /// Returns an iterator over all the non-overlapping capture groups matched in `text`.
+    ///
+    /// # Examples
+    ///
+    /// Finding all matches and capturing parts of each:
+    ///
+    /// ```rust
+    /// # use fancy_regex::Regex;
+    ///
+    /// let re = Regex::new(r"(\d{4})-(\d{2})").unwrap();
+    /// let text = "It was between 2018-04 and 2020-01";
+    /// let mut all_captures = re.captures_iter(text);
+    ///
+    /// let first = all_captures.next().unwrap().unwrap();
+    /// assert_eq!(first.get(1).unwrap().as_str(), "2018");
+    /// assert_eq!(first.get(2).unwrap().as_str(), "04");
+    /// assert_eq!(first.get(0).unwrap().as_str(), "2018-04");
+    ///
+    /// let second = all_captures.next().unwrap().unwrap();
+    /// assert_eq!(second.get(1).unwrap().as_str(), "2020");
+    /// assert_eq!(second.get(2).unwrap().as_str(), "01");
+    /// assert_eq!(second.get(0).unwrap().as_str(), "2020-01");
+    ///
+    /// assert!(all_captures.next().is_none());
+    /// ```
+    pub fn captures_iter<'r, 't>(&'r self, text: &'t str) -> CaptureMatches<'r, 't> {
+        CaptureMatches(self.find_iter(text))
     }
 
     /// Returns the capture groups for the first match in `text`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ fn next_utf8(text: &str, i: usize) -> usize {
 
 /// An iterator over all non-overlapping matches for a particular string.
 ///
-/// The iterator yields a `Match` value. The iterator stops when no more
+/// The iterator yields a `Result<Match>`. The iterator stops when no more
 /// matches can be found.
 ///
 /// `'r` is the lifetime of the compiled regular expression and `'t` is the
@@ -263,7 +263,7 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
         let mat = match self.re.find_from_pos(self.text, self.last_end) {
             Err(error) => return Some(Err(error)),
             Ok(None) => return None,
-            Ok(Some(captures)) => captures,
+            Ok(Some(mat)) => mat,
         };
 
         if mat.start == mat.end {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,8 +604,8 @@ impl Regex {
     /// assert_eq!(mat.end(), 12);
     /// ```
     ///
-    /// Note that in some cases this is not the same as using the `captures`
-    /// methods and passing a slice of the string, see [Regex::captures_from_pos()] for details.
+    /// Note that in some cases this is not the same as using the `find`
+    /// method and passing a slice of the string, see [Regex::captures_from_pos()] for details.
     pub fn find_from_pos<'t>(&self, text: &'t str, pos: usize) -> Result<Option<Match<'t>>> {
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ impl Regex {
 
     /// Returns an iterator for each successive non-overlapping match in `text`.
     ///
-    /// If you have capturing groups in your regex that you want to extract, use the [captures_iter()]
+    /// If you have capturing groups in your regex that you want to extract, use the [Regex::captures_iter()]
     /// method.
     /// 
     /// # Example
@@ -544,7 +544,7 @@ impl Regex {
 
     /// Find the first match in the input text.
     ///
-    /// If you have capturing groups in your regex that you want to extract, use the [captures()]
+    /// If you have capturing groups in your regex that you want to extract, use the [Regex::captures()]
     /// method.
     ///
     /// # Example
@@ -578,7 +578,7 @@ impl Regex {
     /// ```
     ///
     /// Note that in some cases this is not the same as using the `captures`
-    /// methods and passing a slice of the string, see [captures_from_pos()] for details.
+    /// methods and passing a slice of the string, see [Regex::captures_from_pos()] for details.
     pub fn find_from_pos<'t>(&self, text: &'t str, pos: usize) -> Result<Option<Match<'t>>> {
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,26 +203,6 @@ pub struct Match<'t> {
     end: usize,
 }
 
-/// Returns the smallest possible index of the next valid UTF-8 sequence
-/// starting after `i`.
-/// Adapted from a function with the same name in the `regex` crate.
-fn next_utf8(text: &str, i: usize) -> usize {
-    let b = match text.as_bytes().get(i) {
-        None => return i + 1,
-        Some(&b) => b,
-    };
-    let inc = if b <= 0x7F {
-        1
-    } else if b <= 0b110_11111 {
-        2
-    } else if b <= 0b1110_1111 {
-        3
-    } else {
-        4
-    };
-    i + inc
-}
-
 /// An iterator over all non-overlapping matches for a particular string.
 ///
 /// The iterator yields a `Result<Match>`. The iterator stops when no more
@@ -691,7 +671,7 @@ impl Regex {
     /// ```
     ///
     /// Note that in some cases this is not the same as using the `captures`
-    /// methods and passing a slice of the string, see the capture that we get
+    /// method and passing a slice of the string, see the capture that we get
     /// when we do this:
     ///
     /// ```
@@ -1188,6 +1168,17 @@ fn codepoint_len(b: u8) -> usize {
         b if b < 0xf0 => 3,
         _ => 4,
     }
+}
+
+/// Returns the smallest possible index of the next valid UTF-8 sequence
+/// starting after `i`.
+/// Adapted from a function with the same name in the `regex` crate.
+fn next_utf8(text: &str, i: usize) -> usize {
+    let b = match text.as_bytes().get(i) {
+        None => return i + 1,
+        Some(&b) => b,
+    };
+    i + codepoint_len(b)
 }
 
 // If this returns false, then there is no possible backref in the re

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -51,7 +51,10 @@ fn captures_after_lookbehind() {
 fn captures_iter() {
     let text = "11 21 33";
 
-    for (i, captures) in common::regex(r"(?P<num>\d)\d").captures_iter(text).enumerate() {
+    for (i, captures) in common::regex(r"(?P<num>\d)\d")
+        .captures_iter(text)
+        .enumerate()
+    {
         let captures = captures.unwrap();
 
         match i {
@@ -59,20 +62,31 @@ fn captures_iter() {
                 assert_eq!(captures.len(), 2);
                 assert_match(captures.get(0), "11", 0, 2);
                 assert_match(captures.name("num"), "1", 0, 1);
-            },
+            }
             1 => {
                 assert_eq!(captures.len(), 2);
                 assert_match(captures.get(0), "21", 3, 5);
                 assert_match(captures.name("num"), "2", 3, 4);
-            },
+            }
             2 => {
                 assert_eq!(captures.len(), 2);
                 assert_match(captures.get(0), "33", 6, 8);
                 assert_match(captures.name("num"), "3", 6, 7);
-            },
-            i => panic!("Expected 3 captures, got {}", i + 1)
+            }
+            i => panic!("Expected 3 captures, got {}", i + 1),
         }
-    }  
+    }
+}
+
+#[test]
+fn captures_iter_attributes() {
+    let text = "11 21 33";
+    let regex = common::regex(r"(?P<num>\d)\d");
+
+    let all_captures = regex.captures_iter(text);
+
+    assert_eq!(all_captures.text(), text);
+    assert_eq!(regex.as_str(), all_captures.regex().as_str());
 }
 
 #[test]

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -48,6 +48,34 @@ fn captures_after_lookbehind() {
 }
 
 #[test]
+fn captures_iter() {
+    let text = "11 21 33";
+
+    for (i, captures) in common::regex(r"(?P<num>\d)\d").captures_iter(text).enumerate() {
+        let captures = captures.unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(captures.len(), 2);
+                assert_match(captures.get(0), "11", 0, 2);
+                assert_match(captures.name("num"), "1", 0, 1);
+            },
+            1 => {
+                assert_eq!(captures.len(), 2);
+                assert_match(captures.get(0), "21", 3, 5);
+                assert_match(captures.name("num"), "2", 3, 4);
+            },
+            2 => {
+                assert_eq!(captures.len(), 2);
+                assert_match(captures.get(0), "33", 6, 8);
+                assert_match(captures.name("num"), "3", 6, 7);
+            },
+            i => panic!("Expected 3 captures, got {}", i + 1)
+        }
+    }  
+}
+
+#[test]
 fn captures_from_pos() {
     let text = "11 21 33";
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -185,6 +185,21 @@ fn find_iter_zero_length() {
 }
 
 #[test]
+fn find_iter_zero_length_longer_codepoint() {
+    let text = "é1é";
+
+    for (i, mat) in common::regex(r"\d*(?=é)").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 0)),
+            1 => assert_eq!((mat.start(), mat.end()), (2, 3)),
+            i => panic!("Expected 2 captures, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
 fn find_iter_attributes() {
     let text = "ab1c2";
     let regex = common::regex(r"\d*(?=[a-z])");

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -154,7 +154,10 @@ fn find_iter() {
 fn find_iter_overlapping_lookahead() {
     let text = "abcdef";
 
-    for (i, mat) in common::regex(r"[a-z]{2}(?=[a-z])").find_iter(text).enumerate() {
+    for (i, mat) in common::regex(r"[a-z]{2}(?=[a-z])")
+        .find_iter(text)
+        .enumerate()
+    {
         let mat = mat.unwrap();
 
         match i {
@@ -179,6 +182,17 @@ fn find_iter_zero_length() {
             i => panic!("Expected 3 captures, got {}", i + 1),
         }
     }
+}
+
+#[test]
+fn find_iter_attributes() {
+    let text = "ab1c2";
+    let regex = common::regex(r"\d*(?=[a-z])");
+
+    let matches = regex.find_iter(text);
+
+    assert_eq!(matches.text(), text);
+    assert_eq!(regex.as_str(), matches.regex().as_str());
 }
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -134,6 +134,53 @@ fn delegates_match_unicode_scalar_value() {
     assert_eq!(find(r".(?=\ba+)", "\u{1F60A}a"), Some((0, 4)));
 }
 
+#[test]
+fn find_iter() {
+    let text = "11 22 33";
+
+    for (i, mat) in common::regex(r"(\d)\d").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 2)),
+            1 => assert_eq!((mat.start(), mat.end()), (3, 5)),
+            2 => assert_eq!((mat.start(), mat.end()), (6, 8)),
+            i => panic!("Expected 3 captures, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn find_iter_overlapping_lookahead() {
+    let text = "abcdef";
+
+    for (i, mat) in common::regex(r"[a-z]{2}(?=[a-z])").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 2)),
+            1 => assert_eq!((mat.start(), mat.end()), (2, 4)),
+            i => panic!("Expected 2 captures, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn find_iter_zero_length() {
+    let text = "ab1c2";
+
+    for (i, mat) in common::regex(r"\d*(?=[a-z])").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 0)),
+            1 => assert_eq!((mat.start(), mat.end()), (1, 1)),
+            2 => assert_eq!((mat.start(), mat.end()), (2, 3)),
+            i => panic!("Expected 3 captures, got {}", i + 1),
+        }
+    }
+}
+
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     find_match(re, text).map(|m| (m.start(), m.end()))
 }


### PR DESCRIPTION
Hi!

This PR would fix #59 by adding `find_iter` and `captures_iter`. I also had to add `find_from_pos` which is called repeatedly by `find_iter` now. The implementations are adapted from the regex crate with minimal modifications.

Some things worth noting:
- There is some code duplication between the `Iterator` impl for `Matches` and `CaptureMatches`. This is also the case in the regex crate and I didn't see an easy way to avoid this.
- I had to copy the `next_utf8` method from the regex crate to move forward in case of an empty match. I made a note in the doc string.

Before this is merged, the current status in the Readme should also be updated.

Please let me know what you think!