### PR TITLE
Make checking for specific failure message less strict

### DIFF
--- a/tests/oniguruma.rs
+++ b/tests/oniguruma.rs
@@ -220,10 +220,9 @@ fn oniguruma() {
             assert!(result.is_some(),
                     "Expected ignored test to fail, but it succeeded. Remove it from the ignore file: {}", &test.source);
             let failure = result.unwrap();
-            assert_eq!(
-                failure, *expected_failure,
-                "Expected failure differed for test, change it in the ignore file: {}",
-                &test.source
+            assert!(failure.starts_with(expected_failure),
+                "Expected failure differed for test, change it in the ignore file: {}\nExpected: {}\nActual  : {}\n",
+                &test.source, &expected_failure, &failure
             );
             ignored += 1;
         } else {

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -284,10 +284,10 @@
   // Compile failed: UnknownFlag("(?(")
   x2("(a)(?(1+0)b|c)d", "abd", 0, 3);
 
-  // Compile failed: UnknownFlag("(?\'")
+  // Compile failed: UnknownFlag
   x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "ace", 0, 3);
 
-  // Compile failed: UnknownFlag("(?\'")
+  // Compile failed: UnknownFlag
   x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "bce", 0, 3);
 
   // Compile failed: InvalidEscape("\\R")


### PR DESCRIPTION
Checking that the failure starts with the expected failure string makes it possible to just match on the error code, not the full message.

The exact matching before [broke the build](https://github.com/fancy-regex/fancy-regex/runs/2514520304?check_suite_focus=true) because regex started escaping `'` in messages differently.