### PR TITLE
Implement some common traits on Regex & Captures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,13 @@ impl fmt::Debug for Regex {
     }
 }
 
+impl fmt::Display for Regex {
+    /// Shows the original regular expression
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 impl Regex {
     /// Parse and compile a regex with default options, see `RegexBuilder`.
     ///
@@ -1273,6 +1280,13 @@ mod tests {
         let regex = Regex::new(s).unwrap();
         assert_eq!(s, regex.as_str());
         assert_eq!(s, format!("{:?}", regex));
+    }
+
+    #[test]
+    fn display() {
+        let s = r"(a+)b\1";
+        let regex = Regex::new(s).unwrap();
+        assert_eq!(s, format!("{}", regex));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ assert!(!re.is_match("abc").unwrap());
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Index, Range};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::usize;
 
@@ -428,6 +429,15 @@ impl fmt::Display for Regex {
     /// Shows the original regular expression
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for Regex {
+    type Err = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn from_str(s: &str) -> Result<Regex> {
+        Regex::new(s)
     }
 }
 
@@ -1334,6 +1344,13 @@ mod tests {
         let s = r"(a+)b\1";
         let regex = Regex::new(s).unwrap();
         assert_eq!(s, format!("{}", regex));
+    }
+
+    #[test]
+    fn from_str() {
+        let s = r"(a+)b\1";
+        let regex = s.parse::<Regex>().unwrap();
+        assert_eq!(regex.as_str(), s);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,12 +177,14 @@ const MAX_RECURSION: usize = 64;
 pub struct RegexBuilder(RegexOptions);
 
 /// A compiled regular expression.
+#[derive(Clone)]
 pub struct Regex {
     inner: RegexImpl,
     named_groups: Arc<NamedGroups>,
 }
 
 // Separate enum because we don't want to expose any of this
+#[derive(Clone)]
 enum RegexImpl {
     // Do we want to box this? It's pretty big...
     Wrap {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ assert!(!re.is_match("abc").unwrap());
 
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::ops::Range;
+use std::ops::{Index, Range};
 use std::sync::Arc;
 use std::usize;
 
@@ -867,6 +867,53 @@ impl<'t> Captures<'t> {
             CapturesImpl::Wrap { locations, .. } => locations.len(),
             CapturesImpl::Fancy { saves, .. } => saves.len() / 2,
         }
+    }
+}
+
+/// Copied from [`regex::Captures`]...
+///
+/// Get a group by index.
+///
+/// `'t` is the lifetime of the matched text.
+///
+/// The text can't outlive the `Captures` object if this method is
+/// used, because of how `Index` is defined (normally `a[i]` is part
+/// of `a` and can't outlive it); to do that, use `get()` instead.
+///
+/// # Panics
+///
+/// If there is no group at the given index.
+impl<'t> Index<usize> for Captures<'t> {
+    type Output = str;
+
+    fn index(&self, i: usize) -> &str {
+        self.get(i)
+            .map(|m| m.as_str())
+            .unwrap_or_else(|| panic!("no group at index '{}'", i))
+    }
+}
+
+/// Copied from [`regex::Captures`]...
+///
+/// Get a group by name.
+///
+/// `'t` is the lifetime of the matched text and `'i` is the lifetime
+/// of the group name (the index).
+///
+/// The text can't outlive the `Captures` object if this method is
+/// used, because of how `Index` is defined (normally `a[i]` is part
+/// of `a` and can't outlive it); to do that, use `name` instead.
+///
+/// # Panics
+///
+/// If there is no group named by the given value.
+impl<'t, 'i> Index<&'i str> for Captures<'t> {
+    type Output = str;
+
+    fn index<'a>(&'a self, name: &'i str) -> &'a str {
+        self.name(name)
+            .map(|m| m.as_str())
+            .unwrap_or_else(|| panic!("no group named '{}'", name))
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -84,7 +84,7 @@ const OPTION_TRACE: u32 = 1;
 const MAX_STACK: usize = 1_000_000;
 
 /// Instruction of the VM.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Insn {
     /// Successful end of program
     End,
@@ -184,7 +184,7 @@ pub enum Insn {
 }
 
 /// Sequence of instructions for the VM to execute.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Prog {
     /// Instructions of the program
     pub body: Vec<Insn>,

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -1,5 +1,6 @@
 use fancy_regex::{Captures, Error, Expander, Match, Result};
 use std::borrow::Cow;
+use std::ops::Index;
 
 mod common;
 
@@ -25,6 +26,8 @@ fn captures_fancy_named() {
     assert_eq!(captures.len(), 2);
     assert_match(captures.get(0), " bar", 3, 7);
     assert_match(captures.name("name"), "bar", 4, 7);
+    assert_eq!(captures.index(0), " bar");
+    assert_eq!(captures.index("name"), "bar");
     assert!(captures.get(2).is_none());
 }
 


### PR DESCRIPTION
Adds the following implementations on the `Regex` and `Captures` structs. These implementations follow those in the `regex` crate, and in some cases are direct copies.

* `impl fmt::Display for Regex`
* `impl<'t> Index<usize> for Captures<'t>` (index capture groups by `usize`)
* `impl<'t, 'i> Index<&'i str> for Captures<'t>` (index capture groups by name)
* `impl Clone for Regex` (also implements for `RegexImpl`, `vm::Insn`, `vm::Prog`, which `Regex` relies on)

Addresses #72 and at least part of #71 (not sure if it totally covers the need described there).