### PR TITLE
Add replace*() methods similar to regex crate

### DIFF
--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -1,0 +1,160 @@
+use crate::Captures;
+use std::borrow::Cow;
+
+/// Replacer describes types that can be used to replace matches in a string.
+///
+/// In general, users of this crate shouldn't need to implement this trait,
+/// since implementations are already provided for `&str` along with other
+/// variants of string types and `FnMut(&Captures) -> String` (or any
+/// `FnMut(&Captures) -> T` where `T: AsRef<str>`), which covers most use cases.
+pub trait Replacer {
+    /// Appends text to `dst` to replace the current match.
+    ///
+    /// The current match is represented by `caps`, which is guaranteed to
+    /// have a match at capture group `0`.
+    ///
+    /// For example, a no-op replacement would be
+    /// `dst.push_str(caps.get(0).unwrap().as_str())`.
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String);
+
+    /// Return a fixed unchanging replacement string.
+    ///
+    /// When doing replacements, if access to `Captures` is not needed (e.g.,
+    /// the replacement byte string does not need `$` expansion), then it can
+    /// be beneficial to avoid finding sub-captures.
+    ///
+    /// In general, this is called once for every call to `replacen`.
+    fn no_expansion(&mut self) -> Option<Cow<str>> {
+        None
+    }
+
+    /// Return a `Replacer` that borrows and wraps this `Replacer`.
+    ///
+    /// This is useful when you want to take a generic `Replacer` (which might
+    /// not be cloneable) and use it without consuming it, so it can be used
+    /// more than once.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use fancy_regex::{Regex, Replacer};
+    ///
+    /// fn replace_all_twice<R: Replacer>(
+    ///     re: Regex,
+    ///     src: &str,
+    ///     mut rep: R,
+    /// ) -> String {
+    ///     let dst = re.replace_all(src, rep.by_ref());
+    ///     let dst = re.replace_all(&dst, rep.by_ref());
+    ///     dst.into_owned()
+    /// }
+    /// ```
+    fn by_ref(&mut self) -> ReplacerRef<Self> {
+        ReplacerRef(self)
+    }
+}
+
+/// By-reference adaptor for a `Replacer`
+///
+/// Returned by [`Replacer::by_ref`](trait.Replacer.html#method.by_ref).
+#[derive(Debug)]
+pub struct ReplacerRef<'a, R: ?Sized>(&'a mut R);
+
+impl<'a, R: Replacer + ?Sized + 'a> Replacer for ReplacerRef<'a, R> {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        self.0.replace_append(caps, dst)
+    }
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        self.0.no_expansion()
+    }
+}
+
+impl<'a> Replacer for &'a str {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        caps.expand(*self, dst);
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        no_expansion(self)
+    }
+}
+
+impl<'a> Replacer for &'a String {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        self.as_str().replace_append(caps, dst)
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        no_expansion(self)
+    }
+}
+
+impl Replacer for String {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        self.as_str().replace_append(caps, dst)
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        no_expansion(self)
+    }
+}
+
+impl<'a> Replacer for Cow<'a, str> {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        self.as_ref().replace_append(caps, dst)
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        no_expansion(self)
+    }
+}
+
+impl<'a> Replacer for &'a Cow<'a, str> {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        self.as_ref().replace_append(caps, dst)
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        no_expansion(self)
+    }
+}
+
+fn no_expansion<T: AsRef<str>>(t: &T) -> Option<Cow<'_, str>> {
+    let s = t.as_ref();
+    if s.contains('$') {
+        None
+    } else {
+        Some(Cow::Borrowed(s))
+    }
+}
+
+impl<F, T> Replacer for F
+where
+    F: FnMut(&Captures<'_>) -> T,
+    T: AsRef<str>,
+{
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        dst.push_str((*self)(caps).as_ref());
+    }
+}
+
+/// `NoExpand` indicates literal string replacement.
+///
+/// It can be used with `replace` and `replace_all` to do a literal string
+/// replacement without expanding `$name` to their corresponding capture
+/// groups. This can be both convenient (to avoid escaping `$`, for example)
+/// and performant (since capture groups don't need to be found).
+///
+/// `'t` is the lifetime of the literal text.
+#[derive(Clone, Debug)]
+pub struct NoExpand<'t>(pub &'t str);
+
+impl<'t> Replacer for NoExpand<'t> {
+    fn replace_append(&mut self, _: &Captures<'_>, dst: &mut String) {
+        dst.push_str(self.0);
+    }
+
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
+        Some(Cow::Borrowed(self.0))
+    }
+}

--- a/tests/replace.rs
+++ b/tests/replace.rs
@@ -1,0 +1,82 @@
+use fancy_regex::{Captures, NoExpand};
+use std::borrow::Cow;
+
+mod common;
+
+#[test]
+fn replacer_string() {
+    let regex = common::regex(
+        r"\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b",
+    );
+
+    // Replacer impl for &str
+    let result = regex.replace("a sucessful b", "${1}ucce$2");
+    assert_eq!(result, "a successful b");
+
+    // Replacer impl for &String
+    let repl_string = "${1}ucce$2".to_string();
+    let result = regex.replace("a Suceeded b", &repl_string);
+    assert_eq!(result, "a Succeeded b");
+
+    // Replacer impl for String
+    let result = regex.replace("a sucessor b", repl_string);
+    assert_eq!(result, "a successor b");
+}
+
+#[test]
+fn replacer_cow() {
+    let regex = common::regex(r"\b([oO])mmi(?=t)t?(t(?:ed|ing)|s)\b");
+
+    // Replacer impl for &Cow<str>
+    let result = regex.replace("a ommiting b", &Cow::from("${1}mit$2"));
+    assert_eq!(result, "a omitting b");
+
+    // Replacer for Cow<str>::Borrowed
+    let result = regex.replace("a ommited b", Cow::Borrowed("${1}mit$2"));
+    assert_eq!(result, "a omitted b");
+
+    // Replacer for Cow<str>::Owned
+    let result = regex.replace("a Ommits b", Cow::Owned("${1}mit$2".to_string()));
+    assert_eq!(result, "a Omits b");
+}
+
+#[test]
+fn replacer_noexpand() {
+    let regex = common::regex(r"\b([aA])n+ull(ar|ments?|s?)\b");
+
+    // Replacer impl for NoExpand
+    let result = regex.replace("a anullment b", NoExpand("${1}nnul$2"));
+    assert_eq!(result, "a ${1}nnul$2 b");
+}
+
+#[test]
+fn replacer_callback() {
+    let regex = common::regex(r"\b([aA])p(?:p[or]|ro)x\.?(?=[ \)\n])");
+
+    // Replacer impl for FnMut(&Captures)
+    let result = regex.replace("a Aprox b", |cap: &Captures| {
+        format!("{}pprox.", cap.get(1).unwrap().as_str())
+    });
+    assert_eq!(result, "a Approx. b");
+}
+
+/// `replace()` does only one replacement
+#[test]
+fn replace_one() {
+    let regex = common::regex("bla");
+    assert_eq!(regex.replace("blabla", "foo"), "foobla");
+}
+
+/// `replace_all()` replaces all non-overlapping matches
+#[test]
+fn replace_all() {
+    let regex = common::regex("aa");
+    assert_eq!(regex.replace_all("aaaa aaa aa a", "xx"), "xxxx xxa xx a");
+}
+
+/// `replacen()` replaces predefined number of times
+#[test]
+fn replacen() {
+    let regex = common::regex("bla");
+    assert_eq!(regex.replacen("blablabla", 2, "foo"), "foofoobla");
+}


### PR DESCRIPTION
Closes #49

Most of this code is verbatim copy from the `regex` crate.

License: MIT OR Apache-2.0
Author: Andrew Gallant <jamslam@gmail.com>
Author: Alex Crichton <alex@alexcrichton.com>
Author: Lapinot <peio.borthelle@ens-lyon.fr>
Author: tom <nooberfsh@gmail.com>
Author: Matt Brubeck <mbrubeck@limpet.net>
Author: Marti Raudsepp <marti@juffo.org>

Methods:
* Regex::replace() -- single replacement
* Regex::replace_all() -- replace all non-overlapping matches
* Regex::replacen() -- configurable number of replacements

Traits:
* Replacer -- describes logic for replacing matches

  Trait implementations included for `&str`, `String`, `NoExpand`, `FnMut(&Captures)->str`

Structs:
* NoExpand -- Replacer that performs no substitutions
* ReplacerRef -- by-reference adaptor