### PR TITLE
Disallow quantifers on lookarounds and other zero-width assertion expressions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     /// Once named groups are used you cannot refer to groups by number
     NamedBackrefOnly,
 
+    /// Quantifier on lookaround
+    TargetNotRepeatable,
+
     // Run time errors
     /// Max stack size exceeded for backtracking while executing regex.
     StackOverflow,
@@ -89,6 +92,7 @@ impl fmt::Display for Error {
             Error::__Nonexhaustive => unreachable!(),
             Error::InvalidGroupName => write!(f, "Could not parse group name"),
             Error::InvalidGroupNameBackref(s) => write!(f, "Invalid group name in back reference: {}", s),
+            Error::TargetNotRepeatable => write!(f, "Target of repeat operator is invalid"),
             Error::NamedBackrefOnly => write!(f, "Numbered backref/call not allowed because named group was used, use a named backref instead"),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     /// Once named groups are used you cannot refer to groups by number
     NamedBackrefOnly,
 
-    /// Quantifier on lookaround
+    /// Quantifier on lookaround or other zero-width assertion
     TargetNotRepeatable,
 
     // Run time errors

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -149,6 +149,9 @@ impl<'a> Parser<'a> {
                 }
                 _ => return Ok((ix, child)),
             };
+            if let Expr::LookAround(_, _) = child {
+                return Err(Error::TargetNotRepeatable);
+            }
             ix += 1;
             ix = self.optional_whitespace(ix)?;
             let mut greedy = true;
@@ -1314,6 +1317,13 @@ mod tests {
         assert_error("(?--)", "Unknown group flag: (?--");
         // Check that we don't split on char boundary
         assert_error("(?\u{1F60A})", "Unknown group flag: (?\u{1F60A}");
+    }
+
+    #[test]
+    fn no_quantifiers_on_lookarounds() {
+        assert_error("(?=hello)+", "Target of repeat operator is invalid");
+        assert_error("(?<!hello)+", "Target of repeat operator is invalid");
+        assert_error("(?<=hello){2,3}", "Target of repeat operator is invalid");
     }
 
     // found by cargo fuzz, then minimized

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -918,24 +918,10 @@
   // Compile failed: UnknownFlag("(?(")
   x2("((?()0+)+++(((0\\g<0>)0)|())++++((?(1)(0\\g<0>))++++++0*())++++((?(1)(0\\g<1>)+)++++++++++*())++++((?(1)((0)\\g<0>)+)++())+0++*+++(((0\\g<0>))*())++++((?(1)(0\\g<0>)+)++++++++++*|)++++*+++((?(1)((0)\\g<0>)+)+++++++++())++*|)++++((?()0))|", "abcde", 0, 0);
 
-  // Compile failed: InnerError(Syntax(
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // regex parse error:
-  //     (?:[ab]|(*MAX{2}).)*
-  //              ^
-  // error: repetition operator missing expression
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // ))
+  // Compile failed: TargetNotRepeatable
   x2("(?:[ab]|(*MAX{2}).)*", "abcbaaccaaa", 0, 7);
 
-  // Compile failed: InnerError(Syntax(
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // regex parse error:
-  //     (?:(*COUNT[AB]\{X\})[ab]|(*COUNT[CD]\{X\})[cd])*(*CMP\{AB,<,CD\})
-  //         ^
-  // error: repetition operator missing expression
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // ))
+  // Compile failed: TargetNotRepeatable
   x2("(?:(*COUNT[AB]{X})[ab]|(*COUNT[CD]{X})[cd])*(*CMP{AB,<,CD})",
      "abababcdab", 5, 8);
 


### PR DESCRIPTION
Fixes #68 and matches Oniguruma behavior