### PR TITLE
Update fuzzing harness, use correct name to parse expr

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,4 +1,3 @@
-
 target
 corpus
 artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,17 +1,18 @@
-
 [package]
 name = "fancy-regex-fuzz"
-version = "0.0.1"
+version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
+edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true
 
+[dependencies]
+libfuzzer-sys = "0.4"
+
 [dependencies.fancy-regex]
 path = ".."
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -20,3 +21,5 @@ members = ["."]
 [[bin]]
 name = "fuzz_parser"
 path = "fuzz_targets/fuzz_parser.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_parser.rs
@@ -1,13 +1,6 @@
 #![no_main]
+use libfuzzer_sys::fuzz_target;
 
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate fancy_regex;
-
-use fancy_regex::Expr;
-
-fuzz_target!(|data: &[u8]| {
-    if let Ok(s) = std::str::from_utf8(data) {
-        let _ = Expr::parse(s);
-    }
+fuzz_target!(|data: &str| {
+    let _ = fancy_regex::Expr::parse_tree(data);
 });


### PR DESCRIPTION
I just deleted the fuzzer and regenerated it so that I can use `data: &str`