### PR TITLE
Enable selection of regex crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,22 @@ documentation = "https://docs.rs/fancy-regex"
 categories = ["text-processing"]
 
 [features]
+default = ["unicode", "perf"]
 # Enable #[track_caller] in unit tests.
 track_caller = []
+perf = ["regex/perf"]
+perf-dfa = ["regex/perf-dfa"]
+perf-inline = ["regex/perf-inline"]
+perf-literal = ["regex/perf-literal"]
+perf-cache = ["regex/perf-cache"]
+unicode = ["regex/unicode"]
+
+[dependencies.regex]
+version = "1.3" # when we go to >= 1.3.8, we can get rid of the `contains_empty` workaround, see https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#138-2020-05-28
+default-features = false
+features = ["std"]
 
 [dependencies]
-regex = "1.2" # when we go to >= 1.3.8, we can get rid of the `contains_empty` workaround, see https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#138-2020-05-28
 bit-set = "0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Allow users to disable any of the `unicode` and `perf-*` features of the `regex` crate.  Disabling these features can reduce compile time and/or binary size for use cases where these features are not needed.  (All features remain enabled by default.)