### PR TITLE
Add support for \K keep out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Added
+- Added support for `\K` keep out
+
 ## [0.8.0] - 2022-02-22
 ### Added
 - Allow users to disable any of the `unicode` and `perf-*` features of

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -185,6 +185,9 @@ impl<'a> Analyzer<'a> {
                 hard = true; // TODO: possibly could weaken
                 children.push(child_info);
             }
+            Expr::KeepOut => {
+                hard = true;
+            }
         };
 
         Ok(Info {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -187,6 +187,7 @@ impl<'a> Analyzer<'a> {
             }
             Expr::KeepOut => {
                 hard = true;
+                const_size = true;
             }
         };
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -164,6 +164,9 @@ impl Compiler {
             Expr::NamedBackref(_) => {
                 unreachable!("named backrefs should have been eliminated");
             }
+            Expr::KeepOut => {
+                self.b.add(Insn::Save(0));
+            }
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1186,6 +1186,8 @@ pub enum Expr {
     /// Atomic non-capturing group, e.g. `(?>ab|a)` in text that contains `ab` will match `ab` and
     /// never backtrack and try `a`, even if matching fails after the atomic group.
     AtomicGroup(Box<Expr>),
+    /// Keep matched text so far out of overall match
+    KeepOut,
 }
 
 /// Type of look-around assertion as used for a look-around expression.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -385,6 +385,8 @@ impl<'a> Parser<'a> {
                     end += codepoint_len(b);
                 }
             }
+        } else if b == b'K' {
+            return Ok((end, Expr::KeepOut));
         } else if b'a' <= (b | 32) && (b | 32) <= b'z' {
             return Err(Error::InvalidEscape(format!("\\{}", &self.re[ix + 1..end])));
         } else if 0x20 <= b && b <= 0x7f {
@@ -1342,6 +1344,14 @@ mod tests {
         assert_error("(?m)^?", "Target of repeat operator is invalid");
         assert_error("(?m)${2}", "Target of repeat operator is invalid");
         assert_error("(a|b|?)", "Target of repeat operator is invalid");
+    }
+
+    #[test]
+    fn keepout() {
+        assert_eq!(
+            p("a\\Kb"),
+            Expr::Concat(vec![make_literal("a"), Expr::KeepOut, make_literal("b"),])
+        );
     }
 
     // found by cargo fuzz, then minimized

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -439,6 +439,9 @@ pub(crate) fn run(
                     if option_flags & OPTION_TRACE != 0 {
                         println!("saves: {:?}", state.saves);
                     }
+                    if state.saves[0] > state.saves[1] {
+                        state.save(0, state.saves[1]);
+                    }
                     return Ok(Some(state.saves));
                 }
                 Insn::Any => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -439,8 +439,9 @@ pub(crate) fn run(
                     if option_flags & OPTION_TRACE != 0 {
                         println!("saves: {:?}", state.saves);
                     }
-                    if state.saves[0] > state.saves[1] {
-                        state.save(0, state.saves[1]);
+                    let slot1 = state.get(1);
+                    if state.get(0) > slot1 {
+                        state.save(0, slot1);
                     }
                     return Ok(Some(state.saves));
                 }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -51,6 +51,44 @@ fn captures_after_lookbehind() {
 }
 
 #[test]
+fn captures_with_keepout_inside_at_end() {
+    let captures = captures(r"\s*(\w+\K)(?=\.)", "foo bar.");
+    assert_eq!(captures.len(), 2);
+    assert_match(captures.get(0), "", 7, 7);
+    assert_match(captures.get(1), "bar", 4, 7);
+    assert!(captures.get(2).is_none());
+}
+
+#[test]
+fn captures_with_keepout_inside_in_middle() {
+    let captures = captures(r"\s*(b\Kar)(?=\.)", "foo bar.");
+    assert_eq!(captures.len(), 2);
+    assert_match(captures.get(0), "ar", 5, 7);
+    assert_match(captures.get(1), "bar", 4, 7);
+    assert!(captures.get(2).is_none());
+}
+
+#[test]
+fn captures_with_keepout_between() {
+    let captures = captures(r"(\w+)\K\s*(\w+)(?=\.)", "foo bar.");
+    assert_eq!(captures.len(), 3);
+    assert_match(captures.get(0), " bar", 3, 7);
+    assert_match(captures.get(1), "foo", 0, 3);
+    assert_match(captures.get(2), "bar", 4, 7);
+    assert!(captures.get(3).is_none());
+}
+
+#[test]
+fn captures_with_nested_keepout() {
+    let captures = captures(r"(\w\K)+\s*(\w+)(?=\.)", "foo bar.");
+    assert_eq!(captures.len(), 3);
+    assert_match(captures.get(0), " bar", 3, 7);
+    assert_match(captures.get(1), "o", 2, 3);
+    assert_match(captures.get(2), "bar", 4, 7);
+    assert!(captures.get(3).is_none());
+}
+
+#[test]
 fn captures_iter() {
     let text = "11 21 33";
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -145,7 +145,8 @@ fn keepout_matches_in_correct_place() {
 fn keepout_in_lookarounds_match_in_correct_place() {
     assert_eq!(find(r"(?<=a\Kb)c", "abc"), Some((1, 3)));
     assert_eq!(find(r"(?<!a\Kb)c", "axc"), Some((2, 3)));
-    //assert_eq!(find(r"a(?=b\Kc)", "abc"), Some((1, 1)));
+    assert_eq!(find(r"a(?=b\Kc)", "abc"), Some((1, 1)));
+    assert_eq!(find(r"a(?=b\Kc)..", "abc"), Some((2, 3)));
     assert_eq!(find(r"a(?!b\Kc)", "abx"), Some((0, 1)));
 }
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -135,6 +135,13 @@ fn delegates_match_unicode_scalar_value() {
 }
 
 #[test]
+fn keepout_matches_in_correct_place() {
+    assert_eq!(find(r"a\Kb", "aaab"), Some((3, 4)));
+    assert_eq!(find(r".+\Kb", "aaab"), Some((3, 4)));
+    assert_eq!(find(r"(?:aaa\K)b", "aaab"), Some((3, 4)));
+}
+
+#[test]
 fn find_iter() {
     let text = "11 22 33";
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -142,6 +142,14 @@ fn keepout_matches_in_correct_place() {
 }
 
 #[test]
+fn keepout_in_lookarounds_match_in_correct_place() {
+    assert_eq!(find(r"(?<=a\Kb)c", "abc"), Some((1, 3)));
+    assert_eq!(find(r"(?<!a\Kb)c", "axc"), Some((2, 3)));
+    //assert_eq!(find(r"a(?=b\Kc)", "abc"), Some((1, 1)));
+    assert_eq!(find(r"a(?!b\Kc)", "abx"), Some((0, 1)));
+}
+
+#[test]
 fn find_iter() {
     let text = "11 22 33";
 

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -314,21 +314,6 @@
   // Compile failed: InvalidEscape("\\O")
   x2("(?-m:\\O)", "\n", 0, 1);
 
-  // Compile failed: InvalidEscape("\\K")
-  x2("\\K", "a", 0, 0);
-
-  // Compile failed: InvalidEscape("\\K")
-  x2("a\\K", "a", 1, 1);
-
-  // Compile failed: InvalidEscape("\\K")
-  x2("a\\Kb", "ab", 1, 2);
-
-  // Compile failed: InvalidEscape("\\K")
-  x2("(a\\Kb|ac\\Kd)", "acd", 2, 3);
-
-  // Compile failed: InvalidEscape("\\K")
-  x2("(a\\Kb|\\Kac\\K)*", "acababacab", 9, 10);
-
   // No match found
   x2("(?:()|())*\\1", "abc", 0, 0);
 


### PR DESCRIPTION
Fixes #87 

Note: I haven't looked into how oniguruma handles `\K` inside lookarounds yet.