### PR TITLE
Add support for \G - anchor to previous match end

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google LLC
 Raph Levien
 Robin Stocker
+Keith Hall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## Unreleased
+### Added
+- Support for `\G` (anchor to end of previous match): Using a regex
+  like `\G\w` will match each letter of `foo` in `foo bar` but
+  nothing else.
+
 ## [0.9.0] - 2022-04-21
 ### Added
 - Support for `\K` (keep out): Using a regex like `@\K\w+` will match

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -189,6 +189,10 @@ impl<'a> Analyzer<'a> {
                 hard = true;
                 const_size = true;
             }
+            Expr::ContinueFromPreviousMatchEnd => {
+                hard = true;
+                const_size = true;
+            }
         };
 
         Ok(Info {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -167,6 +167,9 @@ impl Compiler {
             Expr::KeepOut => {
                 self.b.add(Insn::Save(0));
             }
+            Expr::ContinueFromPreviousMatchEnd => {
+                self.b.add(Insn::ContinueFromPreviousMatchEnd);
+            }
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1190,6 +1190,8 @@ pub enum Expr {
     AtomicGroup(Box<Expr>),
     /// Keep matched text so far out of overall match
     KeepOut,
+    /// Anchor to match at the position where the previous match ended
+    ContinueFromPreviousMatchEnd,
 }
 
 /// Type of look-around assertion as used for a look-around expression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod vm;
 use crate::analyze::analyze;
 use crate::compile::compile;
 use crate::parse::{ExprTree, NamedGroups, Parser};
-use crate::vm::Prog;
+use crate::vm::{Prog, OPTION_SKIPPED_EMPTY_MATCH};
 
 pub use crate::error::{Error, Result};
 pub use crate::expand::Expander;
@@ -247,11 +247,24 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
             return None;
         }
 
-        let mat = match self.re.find_from_pos(self.text, self.last_end) {
-            Err(error) => return Some(Err(error)),
-            Ok(None) => return None,
-            Ok(Some(mat)) => mat,
+        let option_flags = if let Some(last_match) = self.last_match {
+            if self.last_end > last_match {
+                OPTION_SKIPPED_EMPTY_MATCH
+            } else {
+                0
+            }
+        } else {
+            0
         };
+        let mat =
+            match self
+                .re
+                .find_from_pos_with_option_flags(self.text, self.last_end, option_flags)
+            {
+                Err(error) => return Some(Err(error)),
+                Ok(None) => return None,
+                Ok(Some(mat)) => mat,
+            };
 
         if mat.start == mat.end {
             // This is an empty match. To ensure we make progress, start
@@ -610,12 +623,21 @@ impl Regex {
     /// Note that in some cases this is not the same as using the `find`
     /// method and passing a slice of the string, see [Regex::captures_from_pos()] for details.
     pub fn find_from_pos<'t>(&self, text: &'t str, pos: usize) -> Result<Option<Match<'t>>> {
+        self.find_from_pos_with_option_flags(text, pos, 0)
+    }
+
+    fn find_from_pos_with_option_flags<'t>(
+        &self,
+        text: &'t str,
+        pos: usize,
+        option_flags: u32,
+    ) -> Result<Option<Match<'t>>> {
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner
                 .find_at(text, pos)
                 .map(|m| Match::new(text, m.start(), m.end()))),
             RegexImpl::Fancy { prog, options, .. } => {
-                let result = vm::run(prog, text, pos, 0, options)?;
+                let result = vm::run(prog, text, pos, option_flags, options)?;
                 Ok(result.map(|saves| Match::new(text, saves[0], saves[1])))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@ Escapes:
 `\e`
 : escape control character (`\x1B`) \
 `\K`
-: keep text matched so far out of the overall match
+: keep text matched so far out of the overall match \
+`\G`
+: anchor to where the previous match ended
 
 Backreferences:
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -387,6 +387,8 @@ impl<'a> Parser<'a> {
             }
         } else if b == b'K' {
             return Ok((end, Expr::KeepOut));
+        } else if b == b'G' {
+            return Ok((end, Expr::ContinueFromPreviousMatchEnd));
         } else if b'a' <= (b | 32) && (b | 32) <= b'z' {
             return Err(Error::InvalidEscape(format!("\\{}", &self.re[ix + 1..end])));
         } else if 0x20 <= b && b <= 0x7f {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -181,6 +181,8 @@ pub enum Insn {
         /// The last group number
         end_group: usize,
     },
+    /// Anchor to match at the position where the previous match ended
+    ContinueFromPreviousMatchEnd,
 }
 
 /// Sequence of instructions for the VM to execute.
@@ -651,6 +653,11 @@ pub(crate) fn run(
                         } else {
                             break 'fail;
                         }
+                    }
+                }
+                Insn::ContinueFromPreviousMatchEnd => {
+                    if ix > pos {
+                        break 'fail;
                     }
                 }
             }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -79,6 +79,7 @@ use crate::Result;
 use crate::{codepoint_len, RegexOptions};
 
 const OPTION_TRACE: u32 = 1;
+pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 2;
 
 // TODO: make configurable
 const MAX_STACK: usize = 1_000_000;
@@ -656,7 +657,7 @@ pub(crate) fn run(
                     }
                 }
                 Insn::ContinueFromPreviousMatchEnd => {
-                    if ix > pos {
+                    if ix > pos || option_flags & OPTION_SKIPPED_EMPTY_MATCH != 0 {
                         break 'fail;
                     }
                 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -78,8 +78,8 @@ use crate::Error;
 use crate::Result;
 use crate::{codepoint_len, RegexOptions};
 
-const OPTION_TRACE: u32 = 1;
-pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 2;
+const OPTION_TRACE: u32 = 1 << 0;
+pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 1 << 1;
 
 // TODO: make configurable
 const MAX_STACK: usize = 1_000_000;

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -151,6 +151,11 @@ fn keepout_in_lookarounds_match_in_correct_place() {
 }
 
 #[test]
+fn find_no_matches_when_continuing_from_previous_match_end_and_no_match_at_start_of_text() {
+    assert_eq!(find(r"\G(\d)\d", " 1122 33"), None);
+}
+
+#[test]
 fn find_iter() {
     let text = "11 22 33";
 
@@ -211,6 +216,21 @@ fn find_iter_zero_length_longer_codepoint() {
             0 => assert_eq!((mat.start(), mat.end()), (0, 0)),
             1 => assert_eq!((mat.start(), mat.end()), (2, 3)),
             i => panic!("Expected 2 captures, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn find_iter_continue_from_previous_match_end() {
+    let text = "1122 33";
+
+    for (i, mat) in common::regex(r"\G(\d)\d").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 2)),
+            1 => assert_eq!((mat.start(), mat.end()), (2, 4)),
+            i => panic!("Expected 2 results, got {}", i + 1),
         }
     }
 }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -236,6 +236,20 @@ fn find_iter_continue_from_previous_match_end() {
 }
 
 #[test]
+fn find_iter_continue_from_previous_match_end_with_zero_width_match() {
+    let text = "1122 33";
+
+    for (i, mat) in common::regex(r"\G\d*").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (0, 4)),
+            i => panic!("Expected 1 result, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
 fn find_iter_attributes() {
     let text = "ab1c2";
     let regex = common::regex(r"\d*(?=[a-z])");

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -10,9 +10,6 @@
   // Compile failed: InvalidEscape("\\O")
   x2("$\\O", "bb\n", 2, 3);
 
-  // Compile failed: InvalidEscape("\\G")
-  x2("\\G", "", 0, 0);
-
   // Compile failed: InvalidEscape("\\Z")
   x2("\\Z", "", 0, 0);
 
@@ -56,9 +53,6 @@
   // Compile failed: InvalidEscape("\\Z")
   x2("a\\Z", "a", 0, 1);
 
-  // Compile failed: InvalidEscape("\\G")
-  x2("\\Gaz", "az", 0, 2);
-
   // No match found
   x2("(?i:ss)", "\xc3\x9f", 0, 2);
 
@@ -91,12 +85,6 @@
 
   // No match found
   x2("(?m:.b)", "a\nb", 1, 3);
-
-  // Compile failed: InvalidEscape("\\G")
-  x2("a|\\Gz", "bza", 2, 3);
-
-  // Compile failed: InvalidEscape("\\G")
-  x2("a|\\Gz", "za", 0, 1);
 
   // Compile failed: InvalidEscape("\\Z")
   x2("a|b\\Z", "ba", 1, 2);
@@ -503,20 +491,11 @@
   // Compile failed: InvalidEscape("\\Z")
   x2("かきく\\Z", "かきく\n", 0, 9);
 
-  // Compile failed: InvalidEscape("\\G")
-  x2("\\Gぽぴ", "ぽぴ", 0, 6);
-
   // No match found
   x2("(?m:よ.)", "よ\n", 0, 4);
 
   // No match found
   x2("(?m:.め)", "ま\nめ", 3, 7);
-
-  // Compile failed: InvalidEscape("\\G")
-  x2("鬼|\\G車", "け車鬼", 6, 9);
-
-  // Compile failed: InvalidEscape("\\G")
-  x2("鬼|\\G車", "車鬼", 0, 3);
 
   // Compile failed: InvalidEscape("\\Z")
   x2("鬼|車\\Z", "車鬼", 3, 6);


### PR DESCRIPTION
Adds support for `\G` - anchor to where the previous match ended. https://www.regular-expressions.info/continue.html
