### PR TITLE
Fix panic when group end index is not known yet (fixes #103)

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -63,7 +63,11 @@ fn run_backtrack(c: &mut Criterion) {
     let a = analyze(&tree).unwrap();
     let p = compile(&a).unwrap();
     c.bench_function("run_backtrack", |b| {
-        b.iter(|| run_default(&p, "babab", 0).unwrap())
+        b.iter(|| {
+            let result = run_default(&p, "babab", 0).unwrap();
+            assert_eq!(result, Some(vec![0, 5, 0, 2]));
+            return result;
+        })
     });
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -595,6 +595,10 @@ pub(crate) fn run(
                         break 'fail;
                     }
                     let hi = state.get(slot + 1);
+                    if hi == usize::MAX {
+                        // Referenced group hasn't matched, so the backref doesn't match either
+                        break 'fail;
+                    }
                     let ref_text = &s[lo..hi];
                     let ix_end = ix + ref_text.len();
                     if !matches_literal(s, ix, ix_end, ref_text) {

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -112,6 +112,11 @@ fn end_of_hard_expression_cannot_be_delegated() {
     assert_match(r"((?!x)(?:a|ab))c", "abc");
 }
 
+#[test]
+fn issue103() {
+    assert_no_match(r"(([ab]+)\1b)", "babab");
+}
+
 #[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_match(re: &str, text: &str) {
     let result = match_text(re, text);


### PR DESCRIPTION
This can happen when a backref is used within the group it references, see added test case.

Note that in the bench, a similar regex is used but because it's using a lower level API, the `\1` refers to the second set of parentheses (the first is the match itself).