### PR TITLE
Use CODECOV_TOKEN to avoid sporadic errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,5 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Error:

> Unable to locate build via Github Actions API. Please upload with the
> Codecov repository upload token to resolve issue.

See https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954