### PR TITLE
CI: Run schedule less frequently, don't run coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '00 01 * * *'
+    - cron: '17 01 * * 0'
 jobs:
   check:
     name: check
@@ -113,6 +113,7 @@ jobs:
           args: --all -- --check
 
   coverage:
+    if: ${{ github.event_name != 'schedule' }}
     name: coverage
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Coverage step would [fail](https://github.com/fancy-regex/fancy-regex/actions/runs/5340844781/jobs/9681088791) after a while with "Too many uploads to this commit", so don't run coverage on schedule (not necessary anyway).