### PR TITLE
Add no-std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           command: check
 
+      - name: Run cargo check --no-default-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
+
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.42.0 # MSRV (minimum supported Rust version)
+          - 1.61.0 # MSRV (minimum supported Rust version)
           - stable
           - beta
         include:
-          - rust: 1.42.0
+          - rust: 1.61.0
             msrv: true
     steps:
       - name: Checkout sources
@@ -63,7 +63,7 @@ jobs:
 
       # See https://github.com/matklad/once_cell/issues/201
       # To test locally, enable the lock file and then run:
-      # $ docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp rust:1.42.0 cargo test
+      # $ docker run --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp rust:1.61.0 cargo test
       - name: Use Cargo.lock for MSRV
         if: ${{ matrix.msrv }}
         run: cp Cargo.lock.msrv Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fancy-regex"
-version = "0.11.0" # remember to update html_root_url
+# remember to update html_root_url
+version = "0.11.0"
 authors = ["Raph Levien <raph@google.com>", "Robin Stocker <robin@nibor.org>"]
 edition = "2018"
 license = "MIT"
@@ -12,28 +13,34 @@ categories = ["text-processing"]
 exclude = ["/.github/*", "/Cargo.lock.msrv"]
 
 [features]
-default = ["unicode", "perf"]
+default = ["unicode", "perf", "std"]
 # Enable #[track_caller] in unit tests.
 track_caller = []
+
+std = ["regex/std"]
+
 perf = ["regex/perf"]
 perf-dfa = ["regex/perf-dfa"]
+perf-onepass = ["regex/perf-onepass"]
+perf-backtrack = ["regex/perf-backtrack"]
 perf-inline = ["regex/perf-inline"]
 perf-literal = ["regex/perf-literal"]
 perf-cache = ["regex/perf-cache"]
+
 unicode = ["regex/unicode"]
 
 [dependencies.regex]
-version = "1.3.8"
+version = "1.9.1"
 default-features = false
-features = ["std"]
 
-[dependencies]
-bit-set = "0.5"
+[dependencies.bit-set]
+version = "0.5"
+default-features = false
 
 [dev-dependencies]
-criterion = "0.3.0"
-matches = "0.1.8"
-quickcheck = "1.0.1"
+criterion = "0.5.1"
+matches = "0.1.10"
+quickcheck = "1.0.3"
 
 [[bench]]
 name = "bench"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -20,15 +20,14 @@
 
 //! Analysis of regex expressions.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::min;
+
 use bit_set::BitSet;
-use std::cmp::min;
-use std::usize;
 
 use crate::parse::ExprTree;
-use crate::CompileError;
-use crate::Error;
-use crate::Expr;
-use crate::Result;
+use crate::{CompileError, Error, Expr, Result};
 
 #[derive(Debug)]
 pub struct Info<'a> {
@@ -254,8 +253,7 @@ pub fn analyze<'a>(tree: &'a ExprTree) -> Result<Info<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use super::analyze;
-    use super::literal_const_size;
+    use super::{analyze, literal_const_size};
     use crate::Expr;
     use regex;
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -20,17 +20,14 @@
 
 //! Compilation of regexes to VM.
 
-use std::usize;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use crate::analyze::Info;
 use crate::vm::{Insn, Prog};
-use crate::CompileError;
-use crate::Error;
-use crate::Expr;
-use crate::LookAround;
 use crate::LookAround::*;
-use crate::RegexOptions;
-use crate::Result;
+use crate::{CompileError, Error, Expr, LookAround, RegexOptions, Result};
 
 // I'm thinking it probably doesn't make a lot of sense having this split
 // out from Compiler.
@@ -587,6 +584,7 @@ mod tests {
     use crate::analyze::analyze;
     use crate::parse::ExprTree;
     use crate::vm::Insn::*;
+    use alloc::vec;
     use bit_set::BitSet;
     use matches::assert_matches;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 /// Result type for this crate with specific error enum.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::core::result::Result<T, Error>;
 
 pub type ParseErrorPosition = usize;
 
@@ -101,6 +102,7 @@ pub enum RuntimeError {
     __Nonexhaustive,
 }
 
+#[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
 
 impl fmt::Display for ParseError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,13 +159,21 @@ Conditionals - if/then/else:
 #![doc(html_root_url = "https://docs.rs/fancy-regex/0.11.0")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-use std::fmt;
-use std::fmt::{Debug, Formatter};
-use std::ops::{Index, Range};
-use std::str::FromStr;
-use std::sync::Arc;
-use std::usize;
+extern crate alloc;
+
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::fmt::{Debug, Formatter};
+use core::ops::{Index, Range};
+use core::str::FromStr;
+use core::{fmt, usize};
 
 mod analyze;
 mod compile;
@@ -183,7 +191,6 @@ use crate::vm::{Prog, OPTION_SKIPPED_EMPTY_MATCH};
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
 pub use crate::expand::Expander;
 pub use crate::replacer::{NoExpand, Replacer, ReplacerRef};
-use std::borrow::Cow;
 
 const MAX_RECURSION: usize = 64;
 
@@ -794,7 +801,10 @@ impl Regex {
     #[doc(hidden)]
     pub fn debug_print(&self) {
         match &self.inner {
+            #[cfg(feature = "std")]
             RegexImpl::Wrap { inner, .. } => println!("wrapped {:?}", inner),
+            #[cfg(not(feature = "std"))]
+            RegexImpl::Wrap { .. } => {}
             RegexImpl::Fancy { prog, .. } => prog.debug_print(),
         }
     }
@@ -1034,7 +1044,7 @@ impl<'t> Captures<'t> {
                     return None;
                 }
                 let lo = saves[slot];
-                if lo == std::usize::MAX {
+                if lo == usize::MAX {
                     return None;
                 }
                 let hi = saves[slot + 1];
@@ -1255,10 +1265,10 @@ pub enum LookAround {
 /// returns the name of each group, or [None] if the group has
 /// no name.  Because capture group 0 cannot have a name, the
 /// first item returned is always [None].
-pub struct CaptureNames<'r>(std::vec::IntoIter<Option<&'r str>>);
+pub struct CaptureNames<'r>(vec::IntoIter<Option<&'r str>>);
 
 impl Debug for CaptureNames<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("<CaptureNames>")
     }
 }
@@ -1498,11 +1508,14 @@ pub mod internal {
 
 #[cfg(test)]
 mod tests {
+    use alloc::borrow::Cow;
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use alloc::{format, vec};
+
     use crate::parse::make_literal;
-    use crate::Expr;
-    use crate::Regex;
-    use std::borrow::Cow;
-    use std::usize;
+    use crate::{Expr, Regex};
+
     //use detect_possible_backref;
 
     // tests for to_str

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -1,5 +1,7 @@
+use alloc::borrow::Cow;
+use alloc::string::String;
+
 use crate::Captures;
-use std::borrow::Cow;
 
 /// Replacer describes types that can be used to replace matches in a string.
 ///


### PR DESCRIPTION
[The `regex` crate added `no_std` support in a recent release](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#190-2023-07-05). This PR adds `no_std` support to `fancy_regex`, which mostly consists of just changing some imports from `std::` to their `core::` and `alloc::` counterparts.

~~The largest change is switching from the standard `HashMap` to the one provided by `hashbrown`.~~