### PR TITLE
Fix index out of bounds caused by parse_conditional

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -775,8 +775,9 @@ impl<'a> Parser<'a> {
             condition
         };
 
+        let after = self.check_for_close_paren(end)?;
         Ok((
-            end + 1,
+            after,
             if if_true == Expr::Empty && if_false == Expr::Empty {
                 inner_condition
             } else {
@@ -1796,5 +1797,11 @@ mod tests {
     #[test]
     fn fuzz_2() {
         p(r"\pä");
+    }
+
+    #[test]
+    fn fuzz_3() {
+        fail(r"(?()^");
+        fail(r#"!w(?()\"Kuz>"#);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -743,7 +743,8 @@ impl<'a> Parser<'a> {
         if end == next {
             // Backreference validity checker
             if let Expr::Backref(group) = condition {
-                return Ok((end + 1, Expr::BackrefExistsCondition(group)));
+                let after = self.check_for_close_paren(end)?;
+                return Ok((after, Expr::BackrefExistsCondition(group)));
             } else {
                 return Err(Error::ParseError(
                     end,
@@ -931,7 +932,11 @@ mod tests {
     #[cfg_attr(feature = "track_caller", track_caller)]
     fn assert_error(re: &str, expected_error: &str) {
         let result = Expr::parse_tree(re);
-        assert!(result.is_err());
+        assert!(
+            result.is_err(),
+            "Expected parse error, but was: {:?}",
+            result
+        );
         assert_eq!(&format!("{}", result.err().unwrap()), expected_error);
     }
 
@@ -1803,5 +1808,10 @@ mod tests {
     fn fuzz_3() {
         fail(r"(?()^");
         fail(r#"!w(?()\"Kuz>"#);
+    }
+
+    #[test]
+    fn fuzz_4() {
+        fail(r"\u{2}(?(2)");
     }
 }


### PR DESCRIPTION
It wasn't checking for a closing paren but instead just incremented ix, leading to an index out of bounds later.

Fixes #122.