### PR TITLE
Fix broken link to "Static Analysis for Regular Expression" paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ implementation has asymptotic running time linear in the length of the
 input, while in the general case a backtracking implementation has
 exponential blowup. An example given in [Static Analysis for Regular
 Expression Exponential Runtime via Substructural
-Logics](https://www.cs.bham.ac.uk/~hxt/research/redos_full.pdf) is:
+Logics](https://arxiv.org/pdf/1405.7058.pdf) is:
 
 ```python
 import re


### PR DESCRIPTION
Replace broken link to paper on the authors homepage with a version hosted on arXiv. In the current version, the example in the README appears on page 2.