### PR TITLE
Add `try_replacen`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -950,7 +950,12 @@ impl Regex {
             let mut new = String::with_capacity(text.len());
             let mut last_match = 0;
             for (i, m) in it {
-                let m = m.unwrap();
+                // let m = m.unwrap();
+                let m = match m {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+
                 if limit > 0 && i >= limit {
                     break;
                 }
@@ -971,7 +976,11 @@ impl Regex {
         let mut new = String::with_capacity(text.len());
         let mut last_match = 0;
         for (i, cap) in it {
-            let cap = cap.unwrap();
+            let cap = match cap {
+                Ok(cap) => cap,
+                Err(_) => continue,
+            };
+
             if limit > 0 && i >= limit {
                 break;
             }


### PR DESCRIPTION
Adds a `try_replacen` function that returns a `Result` and propagates any errors. `replacen` now wraps this.