### PR TITLE
Introduce `R` opt-in flag for the CRLF mode

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -120,11 +120,14 @@ impl Compiler {
                     self.compile_delegate(info)?;
                 }
             }
-            Expr::Any { newline: true } => {
+            Expr::Any { newline: true, .. } => {
                 self.b.add(Insn::Any);
             }
-            Expr::Any { newline: false } => {
-                self.b.add(Insn::AnyNoNL);
+            Expr::Any { newline: false, crlf: false } => {
+                self.b.add(Insn::AnyExceptLF);
+            }
+            Expr::Any { newline: false, crlf: true } => {
+                self.b.add(Insn::AnyExceptCRLF);
             }
             Expr::Concat(_) => {
                 self.compile_concat(info, hard)?;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -123,10 +123,16 @@ impl Compiler {
             Expr::Any { newline: true, .. } => {
                 self.b.add(Insn::Any);
             }
-            Expr::Any { newline: false, crlf: false } => {
+            Expr::Any {
+                newline: false,
+                crlf: false,
+            } => {
                 self.b.add(Insn::AnyExceptLF);
             }
-            Expr::Any { newline: false, crlf: true } => {
+            Expr::Any {
+                newline: false,
+                crlf: true,
+            } => {
                 self.b.add(Insn::AnyExceptCRLF);
             }
             Expr::Concat(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,10 @@ impl Regex {
         let tree = ExprTree {
             expr: Expr::Concat(vec![
                 Expr::Repeat {
-                    child: Box::new(Expr::Any { newline: true, crlf: true }),
+                    child: Box::new(Expr::Any {
+                        newline: true,
+                        crlf: true,
+                    }),
                     lo: 0,
                     hi: usize::MAX,
                     greedy: false,
@@ -1413,10 +1416,22 @@ impl Expr {
     pub fn to_str(&self, buf: &mut String, precedence: u8) {
         match *self {
             Expr::Empty => (),
-            Expr::Any { newline: true, crlf: true } => buf.push_str("(?sR:.)"),
-            Expr::Any { newline: true, crlf: false } => buf.push_str("(?s:.)"),
-            Expr::Any { newline: false, crlf: true } => buf.push_str("(?R:.)"),
-            Expr::Any { newline: false, crlf: false } => buf.push_str("."),
+            Expr::Any {
+                newline: true,
+                crlf: true,
+            } => buf.push_str("(?sR:.)"),
+            Expr::Any {
+                newline: true,
+                crlf: false,
+            } => buf.push_str("(?s:.)"),
+            Expr::Any {
+                newline: false,
+                crlf: true,
+            } => buf.push_str("(?R:.)"),
+            Expr::Any {
+                newline: false,
+                crlf: false,
+            } => buf.push_str("."),
             Expr::Literal { ref val, casei } => {
                 if casei {
                     buf.push_str("(?i:");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,8 +566,9 @@ impl RegexOptions {
             Self::get_flag_value(self.syntaxc.get_ignore_whitespace(), FLAG_IGNORE_SPACE);
         let dotnl = Self::get_flag_value(self.syntaxc.get_dot_matches_new_line(), FLAG_DOTNL);
         let unicode = Self::get_flag_value(self.syntaxc.get_unicode(), FLAG_UNICODE);
+        let crlf = Self::get_flag_value(self.syntaxc.get_crlf(), FLAG_CRLF);
 
-        let all_flags = insensitive | multiline | whitespace | dotnl | unicode | unicode;
+        let all_flags = insensitive | multiline | whitespace | dotnl | unicode | crlf;
         all_flags
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1376,7 +1376,7 @@ pub enum Assertion {
     /// End of a line
     EndLine {
         /// CRLF mode.
-        /// If true, this assertion matches at the starting position of the input text, or at the position immediately
+        /// If true, this assertion matches at the ending position of the input text, or at the position immediately
         /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1377,7 +1377,7 @@ pub enum Assertion {
     EndLine {
         /// CRLF mode.
         /// If true, this assertion matches at the ending position of the input text, or at the position immediately
-        /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
+        /// preceding either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
     },
     /// Left word boundary

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -248,7 +248,9 @@ impl<'a> Parser<'a> {
             b'^' => Ok((
                 ix + 1,
                 if self.flag(FLAG_MULTI) {
-                    Expr::Assertion(Assertion::StartLine { crlf: self.flag(FLAG_CRLF) })
+                    Expr::Assertion(Assertion::StartLine {
+                        crlf: self.flag(FLAG_CRLF),
+                    })
                 } else {
                     Expr::Assertion(Assertion::StartText)
                 },
@@ -256,7 +258,9 @@ impl<'a> Parser<'a> {
             b'$' => Ok((
                 ix + 1,
                 if self.flag(FLAG_MULTI) {
-                    Expr::Assertion(Assertion::EndLine { crlf: self.flag(FLAG_CRLF) })
+                    Expr::Assertion(Assertion::EndLine {
+                        crlf: self.flag(FLAG_CRLF),
+                    })
                 } else {
                     Expr::Assertion(Assertion::EndText)
                 },
@@ -948,10 +952,34 @@ mod tests {
 
     #[test]
     fn any() {
-        assert_eq!(p("."), Expr::Any { newline: false, crlf: false });
-        assert_eq!(p("(?s:.)"), Expr::Any { newline: true, crlf: false });
-        assert_eq!(p("(?R:.)"), Expr::Any { newline: false, crlf: true });
-        assert_eq!(p("(?sR:.)"), Expr::Any { newline: true, crlf: true });
+        assert_eq!(
+            p("."),
+            Expr::Any {
+                newline: false,
+                crlf: false
+            }
+        );
+        assert_eq!(
+            p("(?s:.)"),
+            Expr::Any {
+                newline: true,
+                crlf: false
+            }
+        );
+        assert_eq!(
+            p("(?R:.)"),
+            Expr::Any {
+                newline: false,
+                crlf: true
+            }
+        );
+        assert_eq!(
+            p("(?sR:.)"),
+            Expr::Any {
+                newline: true,
+                crlf: true
+            }
+        );
     }
 
     #[test]
@@ -1265,7 +1293,10 @@ mod tests {
         assert_eq!(
             p("(.)\\1"),
             Expr::Concat(vec![
-                Expr::Group(Box::new(Expr::Any { newline: false, crlf: false })),
+                Expr::Group(Box::new(Expr::Any {
+                    newline: false,
+                    crlf: false
+                })),
                 Expr::Backref(1),
             ])
         );
@@ -1276,7 +1307,10 @@ mod tests {
         assert_eq!(
             p("(?<i>.)\\k<i>"),
             Expr::Concat(vec![
-                Expr::Group(Box::new(Expr::Any { newline: false, crlf: false })),
+                Expr::Group(Box::new(Expr::Any {
+                    newline: false,
+                    crlf: false
+                })),
                 Expr::Backref(1),
             ])
         );
@@ -1288,7 +1322,10 @@ mod tests {
             p("(a)(.)\\k<-1>"),
             Expr::Concat(vec![
                 Expr::Group(Box::new(make_literal("a"))),
-                Expr::Group(Box::new(Expr::Any { newline: false, crlf: false })),
+                Expr::Group(Box::new(Expr::Any {
+                    newline: false,
+                    crlf: false
+                })),
                 Expr::Backref(2)
             ])
         );
@@ -1329,20 +1366,44 @@ mod tests {
 
     #[test]
     fn flag_state() {
-        assert_eq!(p("(?s)."), Expr::Any { newline: true, crlf: false });
-        assert_eq!(p("(?s:(?-s:.))"), Expr::Any { newline: false, crlf: false });
+        assert_eq!(
+            p("(?s)."),
+            Expr::Any {
+                newline: true,
+                crlf: false
+            }
+        );
+        assert_eq!(
+            p("(?s:(?-s:.))"),
+            Expr::Any {
+                newline: false,
+                crlf: false
+            }
+        );
         assert_eq!(
             p("(?s:.)."),
             Expr::Concat(vec![
-                Expr::Any { newline: true, crlf: false },
-                Expr::Any { newline: false, crlf: false },
+                Expr::Any {
+                    newline: true,
+                    crlf: false
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
         assert_eq!(
             p("(?:(?s).)."),
             Expr::Concat(vec![
-                Expr::Any { newline: true, crlf: false },
-                Expr::Any { newline: false, crlf: false },
+                Expr::Any {
+                    newline: true,
+                    crlf: false
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
     }
@@ -1369,20 +1430,44 @@ mod tests {
 
     #[test]
     fn flag_crlf() {
-        assert_eq!(p("(?R)."), Expr::Any { newline: false, crlf: true });
-        assert_eq!(p("(?R:(?-R:.))"), Expr::Any { newline: false, crlf: false });
+        assert_eq!(
+            p("(?R)."),
+            Expr::Any {
+                newline: false,
+                crlf: true
+            }
+        );
+        assert_eq!(
+            p("(?R:(?-R:.))"),
+            Expr::Any {
+                newline: false,
+                crlf: false
+            }
+        );
         assert_eq!(
             p("(?R:.)."),
             Expr::Concat(vec![
-                Expr::Any { newline: false, crlf: true },
-                Expr::Any { newline: false, crlf: false },
+                Expr::Any {
+                    newline: false,
+                    crlf: true
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
         assert_eq!(
             p("(?:(?R).)."),
             Expr::Concat(vec![
-                Expr::Any { newline: false, crlf: true },
-                Expr::Any { newline: false, crlf: false },
+                Expr::Any {
+                    newline: false,
+                    crlf: true
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
 
@@ -1406,7 +1491,7 @@ mod tests {
 
         assert_eq!(p("\\z"), Expr::Assertion(Assertion::EndText));
         assert_eq!(p("(?R:\\z)"), Expr::Assertion(Assertion::EndText));
-        assert_eq!(p("(?mR:\\z)"), Expr::Assertion(Assertion::EndText) );
+        assert_eq!(p("(?mR:\\z)"), Expr::Assertion(Assertion::EndText));
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -107,8 +107,10 @@ pub enum Insn {
     End,
     /// Match any character (including newline)
     Any,
-    /// Match any character (not including newline)
-    AnyNoNL,
+    /// Match any character (including a Line Feed (`\n`) but not including other newline characters)
+    AnyExceptLF,
+    /// Match any character (not including a Line Feed (`\n`) or a Carriage Return (`\r`)
+    AnyExceptCRLF,
     /// Assertions
     Assertion(Assertion),
     /// Match the literal string at the current index
@@ -475,8 +477,16 @@ pub(crate) fn run(
                         break 'fail;
                     }
                 }
-                Insn::AnyNoNL => {
+                Insn::AnyExceptLF => {
                     if ix < s.len() && s.as_bytes()[ix] != b'\n' {
+                        ix += codepoint_len_at(s, ix);
+                    } else {
+                        break 'fail;
+                    }
+                }
+                Insn::AnyExceptCRLF => {
+                    let byte_at = s.as_bytes()[ix];
+                    if ix < s.len() && (byte_at != b'\r' || byte_at != b'\n') {
                         ix += codepoint_len_at(s, ix);
                     } else {
                         break 'fail;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -485,8 +485,7 @@ pub(crate) fn run(
                     }
                 }
                 Insn::AnyExceptCRLF => {
-                    let byte_at = s.as_bytes()[ix];
-                    if ix < s.len() && (byte_at != b'\r' || byte_at != b'\n') {
+                    if ix < s.len() && (s.as_bytes()[ix] != b'\r' || s.as_bytes()[ix] != b'\n') {
                         ix += codepoint_len_at(s, ix);
                     } else {
                         break 'fail;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -107,9 +107,9 @@ pub enum Insn {
     End,
     /// Match any character (including newline)
     Any,
-    /// Match any character (including a Line Feed (`\n`) but not including other newline characters)
+    /// Match any character excluding a Line Feed (`\n`) but not other newline characters
     AnyExceptLF,
-    /// Match any character (not including a Line Feed (`\n`) or a Carriage Return (`\r`)
+    /// Match any character excluding a Line Feed (`\n`) or a Carriage Return (`\r`)
     AnyExceptCRLF,
     /// Assertions
     Assertion(Assertion),

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -105,93 +105,90 @@ fn capture_with_crlf_flag() {
         r"(?mR)^[a-z]+$",
         "abc\r\ndef\r\nxyz",
         vec!["abc", "def", "xyz"],
-        vec![(0..3), (5..8), (10..13)]
+        vec![(0..3), (5..8), (10..13)],
     );
-    assert_capture_with_crlf_flag(
-        r"(?mR)^$",
-        "abc\r\ndef\r\nxyz",
-        vec![],
-        vec![]
-    );
-    assert_capture_with_crlf_flag(
-        r"(?mR)^$",
-        "",
-        vec![""],
-        vec![(0..0)]
-    );
-    assert_capture_with_crlf_flag(
-        r"(?mR)^$",
-        "\r\n",
-        vec!["", ""],
-        vec![(0..0), (2..2)]
-    );
+    assert_capture_with_crlf_flag(r"(?mR)^$", "abc\r\ndef\r\nxyz", vec![], vec![]);
+    assert_capture_with_crlf_flag(r"(?mR)^$", "", vec![""], vec![(0..0)]);
+    assert_capture_with_crlf_flag(r"(?mR)^$", "\r\n", vec!["", ""], vec![(0..0), (2..2)]);
     assert_capture_with_crlf_flag(
         r"(?mR)^",
         "abc\r\ndef\r\nxyz",
         vec!["", "", ""],
-        vec![(0..0), (5..5), (10..10)]
+        vec![(0..0), (5..5), (10..10)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)^",
         "\r\n\r\n\r\n",
         vec!["", "", "", ""],
-        vec![(0..0), (2..2), (4..4), (6..6)]
+        vec![(0..0), (2..2), (4..4), (6..6)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)^",
         "\r\r\r",
         vec!["", "", "", ""],
-        vec![(0..0), (1..1), (2..2), (3..3)]
+        vec![(0..0), (1..1), (2..2), (3..3)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)^",
         "\n\n\n",
         vec!["", "", "", ""],
-        vec![(0..0), (1..1), (2..2), (3..3)]
+        vec![(0..0), (1..1), (2..2), (3..3)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)$",
         "abc\r\ndef\r\nxyz",
         vec!["", "", ""],
-        vec![(3..3), (8..8), (13..13)]
+        vec![(3..3), (8..8), (13..13)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)$",
         "\r\n\r\n\r\n",
         vec!["", "", "", ""],
-        vec![(0..0), (2..2), (4..4), (6..6)]
+        vec![(0..0), (2..2), (4..4), (6..6)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)$",
         "\r\r\r",
         vec!["", "", "", ""],
-        vec![(0..0), (1..1), (2..2), (3..3)]
+        vec![(0..0), (1..1), (2..2), (3..3)],
     );
     assert_capture_with_crlf_flag(
         r"(?mR)$",
         "\n\n\n",
         vec!["", "", "", ""],
-        vec![(0..0), (1..1), (2..2), (3..3)]
+        vec![(0..0), (1..1), (2..2), (3..3)],
     );
-    assert_capture_with_crlf_flag(
-        r"(?R).",
-        "\r\n\r\n\r\n",
-        vec![],
-        vec![]
-    );
+    assert_capture_with_crlf_flag(r"(?R).", "\r\n\r\n\r\n", vec![], vec![]);
 }
 
-fn assert_capture_with_crlf_flag(regex_src: &str, text: &str, expected_texts: Vec<&str>, expected_spans: Vec::<Range<usize>>) {
-    fn assert_capture_matches(regex_src: &str, text: &str, expected_texts: Vec<&str>, expected_spans: Vec::<Range<usize>>) {
+fn assert_capture_with_crlf_flag(
+    regex_src: &str,
+    text: &str,
+    expected_texts: Vec<&str>,
+    expected_spans: Vec<Range<usize>>,
+) {
+    fn assert_capture_matches(
+        regex_src: &str,
+        text: &str,
+        expected_texts: Vec<&str>,
+        expected_spans: Vec<Range<usize>>,
+    ) {
         let regex = common::regex(regex_src);
         let capture_matches = regex.captures_iter(text);
         assert_eq!(expected_texts.len(), expected_spans.len());
-        capture_matches.zip(expected_texts.iter().zip(expected_spans.iter())).for_each(|(captures, (&expected_text, expected_span))| {
-            let captures = captures.unwrap();
-            assert_match(captures.get(0),  expected_text, expected_span.start, expected_span.end);
-        });
+        capture_matches
+            .zip(expected_texts.iter().zip(expected_spans.iter()))
+            .for_each(|(captures, (&expected_text, expected_span))| {
+                let captures = captures.unwrap();
+                assert_match(
+                    captures.get(0),
+                    expected_text,
+                    expected_span.start,
+                    expected_span.end,
+                );
+            });
     }
-    
+
     fn make_harder(regex_src: &str) -> String {
         // Wrap the original regex source in an atomic group to make it `hard` so that the execution of the regex is
         // handled by the backtracking VM engine implemented in `fancy-regex` rather than delegated to the engine of
@@ -200,10 +197,20 @@ fn assert_capture_with_crlf_flag(regex_src: &str, text: &str, expected_texts: Ve
     }
 
     // Verify that the regex-automata's engine is able to handle the CRLF flag.
-    assert_capture_matches(regex_src, text, expected_texts.clone(), expected_spans.clone());
+    assert_capture_matches(
+        regex_src,
+        text,
+        expected_texts.clone(),
+        expected_spans.clone(),
+    );
 
     // Verify that the fancy-regex's backtracking VM engine is able to handle the CRLF flag.
-    assert_capture_matches(make_harder(regex_src).as_str(), text, expected_texts.clone(), expected_spans.clone());
+    assert_capture_matches(
+        make_harder(regex_src).as_str(),
+        text,
+        expected_texts.clone(),
+        expected_spans.clone(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR introduces the inline regex flag `R` (`(?R:)`) for switching on and off the CRLF mode.

## Changes

- Extended the parser to support a new opt-in regex flag `R` for switching the CRLF mode. 
- Extended the backtracking VM engine to support the CRLF mode.

## Background

The CRLF mode has been available in the Rust `regex` crate via an opt-in flag since [v1.9.0](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#190-2023-07-05) and in the corresponding versions of the `regex-automata` crate, 

> A new inline flag, `R`, which enables CRLF mode. This makes `.` match any Unicode scalar value except for `\r` and `\n`, and also makes `(?m:^)` and `(?m:$)` match after and before both `\r` and `\n`, respectively, but never between a `\r` and `\n`.

but it is still not supported in the `fancy-regex` crate:

> regex must be valid: ParseError(2, UnknownFlag("(?R"))

The CRLF mode was introduced to the Rust `regex` crate to make the treatment of a carriage return `r` by any character or byte (`.`) and line anchors (`^`, `$`) more aligned with that of a line feed `\n` in a backward-compatible way.

Before the introduction of the CRLF mode or with the CRLF mode turned off, which is by default in the `regex` crate, a carriage return `r` is not fully handled as a new line character unlike `\n` and is treated more like an ordinary, non- new line character:

- When the multiline mode is on and the state (dot new line) mode is off (`(?m-s)`), the any syntax (`.`) matches ~~`\n`~~`\r` but not ~~`\r`~~`\n` in the Rust `regex` crate engine as if `. ＝ [^\n]` not `. ＝ [^\r\n]`. This behavior is [in line with default behavior of other major regex engines](https://github.com/BurntSushi/rebar/blob/11a62af1c9175654aa8bdf4135fc2912bc36c3ff/benchmarks/definitions/test/dot.toml#L133-L196), but some use cases might prefer `\r` being treated as a new line character just like `\n`.
- Line anchors (`^` and `$` in the multiline mode (`(?m:)`) could find a match at a boundary between `\r` and `\n` of `\r\n` in the rust `regex` crate engine although it is not an end of a line in a strict sense. In Oniguruma and some other regex engines, `^` and `$` do not match at the middle of `\r\n`, or how to treat `\r`, `\n`, and other less common new line Unicode characters is configurable as in PCRE2.

Being able to selectively enable the CRLF mode in the `fancy-regex` would be useful in some special cases, e.g., when porting regex strings written for the PCRE2 engine compiled with the `PCRE2_NEWLINE_ANYCRLF` option.


## Note

~~The CRLF mode is a bit tricky to understand since the `R` inline flag indirectly changes matching behaviors by altering the effects of two other inline flags: multiline (`m`) and state (dot new line) (`s`).
In a nutshell,~~

As BurntSushi has pointed out in the comment below, we can think about CRLF mode as changing a single thing: the line terminator goes from `\n` to `\r\n|\r|\n`. Everything else follows from that, including the behavior of the `s` and `m` flags.

Specifically, from the perspective of the developers of `fancy-regex`, this implies the following branching of behaviors of `^`, `$` and `.` based on the presence or absence of the `R` flag:

| Flags | `^` and `$` behave as | Effects on matching  |
| --- | --- | --- |
| `(?)`, `(?R)` | `Assertion::StartText`, <br>`Assertion::EndText` | `^` and `$` match the start and end of the whole input text. That is, `R` flag makes no difference. |
| `(?m)` | `Assertion::StartLine { crlf: false }`,  <br>`Assertion::EndLine { crlf: false }` | `^` and `$` match starts and end of lines. They could match at between `\r` and `\n` of `\r\n`. |
| `(?mR)` | `Assertion::StartLine { crlf: true }`, <br>`Assertion::EndLine { crlf: true }` | `^` and `$` match start and end of lines. They never match at between `\r` and `\n` of `\r\n`. `\r\n` as a whole is treated like a newline. |

| Flags |  `.` behaves as | Effects on matching |
| --- | --- | --- |
| `(?s)`, `(?sR)` | `Insn::Any` | `.` matches any character including `\r` and `\n`. That is, `R` flag makes no difference. |
| `(?)` | `Insn::AnyExceptLF` | `.` matches any character including `\r` but excluding `\n`.  |
| `(?R)` | `Insn::AnyExceptCRLF` | `.` matches any character excluding `\r` and `\n`.  |




## Related discussion and commits

- $ doesn't match CRLF · Issue #244 · rust-lang/regex: https://github.com/rust-lang/regex/issues/244#issuecomment-1451258260
- syntax: add support for CRLF-aware line anchors · rust-lang/regex@b6085a9: https://github.com/rust-lang/regex/commit/b6085a96c246c61b8ad41ec5e2bfb95b52618943
