### PR TITLE
Add Split Struct and split Method to Regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ let re = Regex::new(r"[ \t]+").unwrap();
 let target = "a b \t  c\td    e";
 let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
 assert_eq!(fields, vec!["a", "b", "c", "d", "e"]);
-``` 
+```
 
 # Syntax
 
@@ -420,7 +420,6 @@ pub struct Split<'r, 'h> {
     target: &'h str,
 }
 
-
 impl<'r, 'h> Iterator for Split<'r, 'h> {
     type Item = Result<&'h str>;
 
@@ -440,7 +439,7 @@ impl<'r, 'h> Iterator for Split<'r, 'h> {
                     // Next call will return None
                     let part = &self.target[self.next_start..len];
                     self.next_start = len + 1;
-                    Some(Ok(part)) 
+                    Some(Ok(part))
                 }
             }
             // Return the next substring
@@ -1067,15 +1066,15 @@ impl Regex {
         Ok(Cow::Owned(new))
     }
 
-    /// Splits the string by matches of the regex. 
-    /// 
+    /// Splits the string by matches of the regex.
+    ///
     /// Returns an iterator over the substrings of the target string
-    ///  that *aren't* matched by the regex. 
+    ///  that *aren't* matched by the regex.
     ///
     /// # Example
-    /// 
+    ///
     /// To split a string delimited by arbitrary amounts of spaces or tabs:
-    /// 
+    ///
     /// ```rust
     /// # use fancy_regex::Regex;
     /// let re = Regex::new(r"[ \t]+").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,8 @@ impl<'r, 'h> Iterator for Split<'r, 'h> {
     }
 }
 
+impl<'r, 'h> core::iter::FusedIterator for Split<'r, 'h> {}
+
 #[derive(Clone, Debug)]
 struct RegexOptions {
     pattern: String,

--- a/tests/splitting.rs
+++ b/tests/splitting.rs
@@ -1,112 +1,93 @@
 use fancy_regex::Regex;
 
+fn split_to_vec<'a>(re_str: &'a str, target: &'a str) -> Vec<&'a str> {
+    let re = Regex::new(re_str).unwrap();
+    re.split(target).map(|x| x.unwrap()).collect()
+}
+
 #[test]
-fn split_left_center_right() {
-    let re = Regex::new("1").unwrap();
-    let target = "123";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "23"]);
+fn split_left() {
+    let result: Vec<&str> = split_to_vec("1", "123");
+    assert_eq!(result, vec!["", "23"]);
+}
 
-    let re = Regex::new("2").unwrap();
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["1", "3"]);
+#[test]
+fn split_center() {
+    let result: Vec<&str> = split_to_vec("2", "123");
+    assert_eq!(result, vec!["1", "3"]);
+}
 
-    let re = Regex::new("3").unwrap();
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["12", ""]);
+#[test]
+fn split_right() {
+    let result: Vec<&str> = split_to_vec("3", "123");
+    assert_eq!(result, vec!["12", ""]);
 }
 
 #[test]
 fn split_no_matches() {
-    let re = Regex::new("4").unwrap();
-    let target = "123";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["123"]);
+    let result: Vec<&str> = split_to_vec("4", "123");
+    assert_eq!(result, vec!["123"]);
 }
 
 #[test]
 fn split_empty() {
-    let re = Regex::new("1").unwrap();
-    let target = "";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec![""]);
+    let result: Vec<&str> = split_to_vec("1", "");
+    assert_eq!(result, vec![""]);
 }
 
 #[test]
 fn split_by_empty() {
-    let re = Regex::new("").unwrap();
-    let target = "123";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "1", "2", "3", ""]);
+    let result: Vec<&str> = split_to_vec("", "123");
+    assert_eq!(result, vec!["", "1", "2", "3", ""]);
 }
 
 #[test]
 fn split_by_own() {
-    let re = Regex::new("123").unwrap();
-    let target = "123";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", ""]);
+    let result: Vec<&str> = split_to_vec("123", "123");
+    assert_eq!(result, vec!["", ""]);
 }
 
 #[test]
 fn split_consecutive_matches() {
-    let re = Regex::new("1").unwrap();
-    let target = "111";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "", "", ""]);
+    let result: Vec<&str> = split_to_vec("1", "111");
+    assert_eq!(result, vec!["", "", "", ""]);
 }
 
 #[test]
 fn split_by_substring() {
-    let re = Regex::new("123").unwrap();
-    let target = "123456";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "456"]);
+    let result: Vec<&str> = split_to_vec("123", "123456");
+    assert_eq!(result, vec!["", "456"]);
 
-    let re = Regex::new("234|678").unwrap();
-    let target = "123456789";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["1", "5", "9"]);
+    let result: Vec<&str> = split_to_vec("234|678", "123456789");
+    assert_eq!(result, vec!["1", "5", "9"]);
 }
 
 #[test]
 fn split_multiple_different_characters() {
-    let re = Regex::new("[1-3]").unwrap();
-    let target = "123456";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "", "", "456"]);
+    let result: Vec<&str> = split_to_vec("[1-3]", "123456");
+    assert_eq!(result, vec!["", "", "", "456"]);
 }
 
 #[test]
 fn split_mixed_characters() {
-    let re = Regex::new("[236]").unwrap();
-    let target = "123456";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["1", "", "45", ""]);
+    let result: Vec<&str> = split_to_vec("[236]", "123456");
+    assert_eq!(result, vec!["1", "", "45", ""]);
 }
 
 #[test]
 fn split_with_backreferences() {
-    let re = Regex::new(r"(1|2)\1").unwrap();
-    let target = "12112122";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["12", "21", ""]);
+    let result: Vec<&str> = split_to_vec(r"(1|2)\1", "12112122");
+    assert_eq!(result, vec!["12", "21", ""]);
 }
 
 #[test]
 fn split_with_look_around() {
-    let re = Regex::new(r"(?<=1)2").unwrap();
-    let target = "12112122";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["1", "11", "1", "2"]);
+    let result: Vec<&str> = split_to_vec(r"(?<=1)2", "12112122");
+    assert_eq!(result, vec!["1", "11", "1", "2"]);
 
-    let re = Regex::new(r"1(?=2)").unwrap();
-    let target = "12112122";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["", "21", "2", "22"]);
+    let result: Vec<&str> = split_to_vec(r"1(?=2)", "12112122");
+    assert_eq!(result, vec!["", "21", "2", "22"]);
 
-    let re = Regex::new(r"(?<=2)1(?=2)").unwrap();
-    let target = "12112122";
-    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["12112", "22"]);
+    let result: Vec<&str> = split_to_vec(r"(?<=2)1(?=2)", "12112122");
+    assert_eq!(result, vec!["12112", "22"]);
 }

--- a/tests/splitting.rs
+++ b/tests/splitting.rs
@@ -1,6 +1,5 @@
 use fancy_regex::Regex;
 
-
 #[test]
 fn split_left_center_right() {
     let re = Regex::new("1").unwrap();
@@ -59,7 +58,7 @@ fn split_by_substring() {
     let re = Regex::new("234|678").unwrap();
     let target = "123456789";
     let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["1", "5", "9"]); 
+    assert_eq!(fields, vec!["1", "5", "9"]);
 }
 
 #[test]
@@ -97,9 +96,9 @@ fn split_with_look_around() {
     let target = "12112122";
     let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
     assert_eq!(fields, vec!["", "21", "2", "22"]);
-   
+
     let re = Regex::new(r"(?<=2)1(?=2)").unwrap();
     let target = "12112122";
     let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
-    assert_eq!(fields, vec!["12112", "22"]); 
+    assert_eq!(fields, vec!["12112", "22"]);
 }

--- a/tests/splitting.rs
+++ b/tests/splitting.rs
@@ -33,6 +33,14 @@ fn split_empty() {
 }
 
 #[test]
+fn split_by_empty() {
+    let re = Regex::new("").unwrap();
+    let target = "123";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "1", "2", "3", ""]);
+}
+
+#[test]
 fn split_by_own() {
     let re = Regex::new("123").unwrap();
     let target = "123";

--- a/tests/splitting.rs
+++ b/tests/splitting.rs
@@ -1,0 +1,105 @@
+use fancy_regex::Regex;
+
+
+#[test]
+fn split_left_center_right() {
+    let re = Regex::new("1").unwrap();
+    let target = "123";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "23"]);
+
+    let re = Regex::new("2").unwrap();
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["1", "3"]);
+
+    let re = Regex::new("3").unwrap();
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["12", ""]);
+}
+
+#[test]
+fn split_no_matches() {
+    let re = Regex::new("4").unwrap();
+    let target = "123";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["123"]);
+}
+
+#[test]
+fn split_empty() {
+    let re = Regex::new("1").unwrap();
+    let target = "";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec![""]);
+}
+
+#[test]
+fn split_by_own() {
+    let re = Regex::new("123").unwrap();
+    let target = "123";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", ""]);
+}
+
+#[test]
+fn split_consecutive_matches() {
+    let re = Regex::new("1").unwrap();
+    let target = "111";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "", "", ""]);
+}
+
+#[test]
+fn split_by_substring() {
+    let re = Regex::new("123").unwrap();
+    let target = "123456";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "456"]);
+
+    let re = Regex::new("234|678").unwrap();
+    let target = "123456789";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["1", "5", "9"]); 
+}
+
+#[test]
+fn split_multiple_different_characters() {
+    let re = Regex::new("[1-3]").unwrap();
+    let target = "123456";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "", "", "456"]);
+}
+
+#[test]
+fn split_mixed_characters() {
+    let re = Regex::new("[236]").unwrap();
+    let target = "123456";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["1", "", "45", ""]);
+}
+
+#[test]
+fn split_with_backreferences() {
+    let re = Regex::new(r"(1|2)\1").unwrap();
+    let target = "12112122";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["12", "21", ""]);
+}
+
+#[test]
+fn split_with_look_around() {
+    let re = Regex::new(r"(?<=1)2").unwrap();
+    let target = "12112122";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["1", "11", "1", "2"]);
+
+    let re = Regex::new(r"1(?=2)").unwrap();
+    let target = "12112122";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["", "21", "2", "22"]);
+   
+    let re = Regex::new(r"(?<=2)1(?=2)").unwrap();
+    let target = "12112122";
+    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
+    assert_eq!(fields, vec!["12112", "22"]); 
+}


### PR DESCRIPTION
Closes #104

This pull request introduces a Split struct and a corresponding split method to the Regex struct. This enhancement allows users to split a target string by the matches of a regex, yielding an iterator of substrings that are not matched by the regex.

(I referenced the code in #104 .)

## Changes

- **Created `Split` Struct**: Implemented the `Iterator` trait for the `Split` struct, allowing it to return the next substring from the target string based on regex matches.
- **Added `split` Method**: Implemented the `split` method in the `Regex` struct to return an instance of the `Split` iterator.
- **Documentation**: Provided documentation for the `split` method, including usage examples.
- **Test Cases**: Added test cases in `tests/splitting.rs` to verify the functionality of the `split` method.

## Examples
Here are some examples of how to use the `split` method:

```rust
// Example usage of the new split functionality
use fancy_regex::Regex;

let re = Regex::new(r"[ \t]+").unwrap();
let target = "a b \t  c\td    e";
let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
assert_eq!(fields, vec!["a", "b", "c", "d", "e"]);
```

## Note

- In this method, an empty string is taken out as an element as in the following example. This specification conforms to the behavior of str::split.

``` rust
#[test]
fn split_by_own() {
    let re = Regex::new("123").unwrap();
    let target = "123";
    let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
    assert_eq!(fields, vec!["", ""]);
}
```

- If there are no problems with this feature addition, it should be possible to implement the same for SplitN.
- I was particularly confused about deciding on variable names, is that ok?
