### PR TITLE
Add SplitN Struct and splitn Method to Regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,9 @@ let re = Regex::new(r"[ \t]+").unwrap();
 let target = "a b \t  c\td    e";
 let fields: Vec<&str> = re.split(target).map(|x| x.unwrap()).collect();
 assert_eq!(fields, vec!["a", "b", "c", "d", "e"]);
+
+let fields: Vec<&str> = re.splitn(target, 3).map(|x| x.unwrap()).collect();
+assert_eq!(fields, vec!["a", "b", "c\td    e"]);
 ```
 
 # Syntax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,6 @@ pub struct SubCaptureMatches<'c, 't> {
     i: usize,
 }
 
-#[derive(Debug)]
 /// An iterator over all substrings delimited by a regex.
 ///
 /// This iterator yields `Result<&'h str>`, where each item is a substring of the
@@ -413,7 +412,8 @@ pub struct SubCaptureMatches<'c, 't> {
 /// `'r` is the lifetime of the compiled regular expression, and `'h` is the
 /// lifetime of the target string being split.
 ///
-/// This iterator can be created via the [`Regex::split`] method.
+/// This iterator can be created by the [`Regex::split`] method.
+#[derive(Debug)]
 pub struct Split<'r, 'h> {
     matches: Matches<'r, 'h>,
     next_start: usize,

--- a/tests/splitting.rs
+++ b/tests/splitting.rs
@@ -1,93 +1,172 @@
 use fancy_regex::Regex;
 
-fn split_to_vec<'a>(re_str: &'a str, target: &'a str) -> Vec<&'a str> {
-    let re = Regex::new(re_str).unwrap();
-    re.split(target).map(|x| x.unwrap()).collect()
+#[cfg(test)]
+mod split_tests {
+    use super::*;
+
+    fn split_to_vec<'a>(re_str: &'a str, target: &'a str) -> Vec<&'a str> {
+        let re = Regex::new(re_str).unwrap();
+        re.split(target).map(|x| x.unwrap()).collect()
+    }
+
+    #[test]
+    fn split_left() {
+        let result: Vec<&str> = split_to_vec("1", "123");
+        assert_eq!(result, vec!["", "23"]);
+    }
+
+    #[test]
+    fn split_center() {
+        let result: Vec<&str> = split_to_vec("2", "123");
+        assert_eq!(result, vec!["1", "3"]);
+    }
+
+    #[test]
+    fn split_right() {
+        let result: Vec<&str> = split_to_vec("3", "123");
+        assert_eq!(result, vec!["12", ""]);
+    }
+
+    #[test]
+    fn split_no_matches() {
+        let result: Vec<&str> = split_to_vec("4", "123");
+        assert_eq!(result, vec!["123"]);
+    }
+
+    #[test]
+    fn split_empty() {
+        let result: Vec<&str> = split_to_vec("1", "");
+        assert_eq!(result, vec![""]);
+    }
+
+    #[test]
+    fn split_by_empty() {
+        let result: Vec<&str> = split_to_vec("", "123");
+        assert_eq!(result, vec!["", "1", "2", "3", ""]);
+    }
+
+    #[test]
+    fn split_by_own() {
+        let result: Vec<&str> = split_to_vec("123", "123");
+        assert_eq!(result, vec!["", ""]);
+    }
+
+    #[test]
+    fn split_consecutive_matches() {
+        let result: Vec<&str> = split_to_vec("1", "111");
+        assert_eq!(result, vec!["", "", "", ""]);
+    }
+
+    #[test]
+    fn split_by_substring() {
+        let result: Vec<&str> = split_to_vec("123", "123456");
+        assert_eq!(result, vec!["", "456"]);
+
+        let result: Vec<&str> = split_to_vec("234|678", "123456789");
+        assert_eq!(result, vec!["1", "5", "9"]);
+    }
+
+    #[test]
+    fn split_multiple_different_characters() {
+        let result: Vec<&str> = split_to_vec("[1-3]", "123456");
+        assert_eq!(result, vec!["", "", "", "456"]);
+    }
+
+    #[test]
+    fn split_mixed_characters() {
+        let result: Vec<&str> = split_to_vec("[236]", "123456");
+        assert_eq!(result, vec!["1", "", "45", ""]);
+    }
+
+    #[test]
+    fn split_with_backreferences() {
+        let result: Vec<&str> = split_to_vec(r"(1|2)\1", "12112122");
+        assert_eq!(result, vec!["12", "21", ""]);
+    }
+
+    #[test]
+    fn split_with_look_around() {
+        let result: Vec<&str> = split_to_vec(r"(?<=1)2", "12112122");
+        assert_eq!(result, vec!["1", "11", "1", "2"]);
+
+        let result: Vec<&str> = split_to_vec(r"1(?=2)", "12112122");
+        assert_eq!(result, vec!["", "21", "2", "22"]);
+
+        let result: Vec<&str> = split_to_vec(r"(?<=2)1(?=2)", "12112122");
+        assert_eq!(result, vec!["12112", "22"]);
+    }
 }
 
-#[test]
-fn split_left() {
-    let result: Vec<&str> = split_to_vec("1", "123");
-    assert_eq!(result, vec!["", "23"]);
-}
+#[cfg(test)]
+mod splitn_tests {
+    use super::*;
 
-#[test]
-fn split_center() {
-    let result: Vec<&str> = split_to_vec("2", "123");
-    assert_eq!(result, vec!["1", "3"]);
-}
+    fn splitn_to_vec<'a>(re_str: &'a str, target: &'a str, limit: usize) -> Vec<&'a str> {
+        let re = Regex::new(re_str).unwrap();
+        re.splitn(target, limit).map(|x| x.unwrap()).collect()
+    }
 
-#[test]
-fn split_right() {
-    let result: Vec<&str> = split_to_vec("3", "123");
-    assert_eq!(result, vec!["12", ""]);
-}
+    #[test]
+    fn splitn_limit_lt_num_mathes() {
+        let splitn_test_cases = [
+            ("1", "123", vec!["", "23"]),
+            ("2", "123", vec!["1", "3"]),
+            ("3", "123", vec!["12", ""]),
+            ("", "123", vec!["", "1", "2", "3", ""]),
+            ("1", "", vec![""]),
+        ];
 
-#[test]
-fn split_no_matches() {
-    let result: Vec<&str> = split_to_vec("4", "123");
-    assert_eq!(result, vec!["123"]);
-}
+        for (re_str, target, expected) in splitn_test_cases {
+            let result: Vec<&str> = splitn_to_vec(re_str, target, 6);
+            assert_eq!(result, expected);
+        }
+    }
 
-#[test]
-fn split_empty() {
-    let result: Vec<&str> = split_to_vec("1", "");
-    assert_eq!(result, vec![""]);
-}
+    #[test]
+    fn splitn_limit_eq_num_mathes() {
+        let splitn_test_cases = [
+            ("1", "123", vec!["", "23"]),
+            ("2", "123", vec!["1", "3"]),
+            ("3", "123", vec!["12", ""]),
+            ("", "123", vec!["", "1", "2", "3", ""]),
+            ("1", "", vec![""]),
+        ];
 
-#[test]
-fn split_by_empty() {
-    let result: Vec<&str> = split_to_vec("", "123");
-    assert_eq!(result, vec!["", "1", "2", "3", ""]);
-}
+        for (re_str, target, expected) in splitn_test_cases {
+            let result: Vec<&str> = splitn_to_vec(re_str, target, expected.len());
+            assert_eq!(result, expected);
+        }
+    }
 
-#[test]
-fn split_by_own() {
-    let result: Vec<&str> = split_to_vec("123", "123");
-    assert_eq!(result, vec!["", ""]);
-}
+    #[test]
+    fn splitn_limit_st_num_mathes() {
+        let splitn_test_cases = [
+            ("1", "123", vec!["123"]),
+            ("2", "123", vec!["123"]),
+            ("3", "123", vec!["123"]),
+            ("", "123", vec!["123"]),
+        ];
 
-#[test]
-fn split_consecutive_matches() {
-    let result: Vec<&str> = split_to_vec("1", "111");
-    assert_eq!(result, vec!["", "", "", ""]);
-}
+        for (re_str, target, expected) in splitn_test_cases {
+            let result: Vec<&str> = splitn_to_vec(re_str, target, 1);
+            assert_eq!(result, expected);
+        }
+    }
 
-#[test]
-fn split_by_substring() {
-    let result: Vec<&str> = split_to_vec("123", "123456");
-    assert_eq!(result, vec!["", "456"]);
+    #[test]
+    fn splitn_limit_zero() {
+        let vec_empty: Vec<&str> = Vec::new();
+        let splitn_test_cases = [
+            ("1", "123", &vec_empty),
+            ("2", "123", &vec_empty),
+            ("3", "123", &vec_empty),
+            ("", "123", &vec_empty),
+            ("1", "", &vec_empty),
+        ];
 
-    let result: Vec<&str> = split_to_vec("234|678", "123456789");
-    assert_eq!(result, vec!["1", "5", "9"]);
-}
-
-#[test]
-fn split_multiple_different_characters() {
-    let result: Vec<&str> = split_to_vec("[1-3]", "123456");
-    assert_eq!(result, vec!["", "", "", "456"]);
-}
-
-#[test]
-fn split_mixed_characters() {
-    let result: Vec<&str> = split_to_vec("[236]", "123456");
-    assert_eq!(result, vec!["1", "", "45", ""]);
-}
-
-#[test]
-fn split_with_backreferences() {
-    let result: Vec<&str> = split_to_vec(r"(1|2)\1", "12112122");
-    assert_eq!(result, vec!["12", "21", ""]);
-}
-
-#[test]
-fn split_with_look_around() {
-    let result: Vec<&str> = split_to_vec(r"(?<=1)2", "12112122");
-    assert_eq!(result, vec!["1", "11", "1", "2"]);
-
-    let result: Vec<&str> = split_to_vec(r"1(?=2)", "12112122");
-    assert_eq!(result, vec!["", "21", "2", "22"]);
-
-    let result: Vec<&str> = split_to_vec(r"(?<=2)1(?=2)", "12112122");
-    assert_eq!(result, vec!["12112", "22"]);
+        for (re_str, target, expected) in splitn_test_cases {
+            let result: Vec<&str> = splitn_to_vec(re_str, target, 0);
+            assert_eq!(&result, expected);
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces the `SplitN` functionality to the `Regex` struct, allowing users to split a target string by the matches of a regex with a limit on the number of splits (`N`). The last substring returned is the remainder of the target string.

## Changes

- **Created `SplitN` Struct**: Implemented the `Iterator` trait for the `SplitN` struct, which contains a`Split` and a `limit` for the maximum remaining splits.
- **Added `splitn` Method**: Added the `splitn` method to the `Regex` struct to return an instance of the `SplitN` iterator.
- **Documentation**: Updated the documentation with examples on how to use the `splitn` method.
- **Test Cases**: Updated test cases in `tests/splitting.rs` to verify the functionality of the `splitn` method.

## Examples

```rust
use fancy_regex::Regex;

let re = Regex::new(r"[ \t]+").unwrap();
let target = "a b \t  c\td    e";
let fields: Vec<&str> = re.splitn(target, 3).map(|x| x.unwrap()).collect();
assert_eq!(fields, vec!["a", "b", "c\td    e"]);
```

## Note

- Referenced [the code in regex](https://github.com/rust-lang/regex/blob/bcbe40342628b15ab2543d386c745f7f0811b791/regex-automata/src/meta/regex.rs#L2223-L2279).