### PR TITLE
Allow custom `Expander` configuration

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -9,10 +9,15 @@ use crate::{Captures, CompileError, Error, ParseError, Regex};
 /// of capture groups.
 #[derive(Debug)]
 pub struct Expander {
-    sub_char: char,
-    open: &'static str,
-    close: &'static str,
-    allow_undelimited_name: bool,
+    /// Substitution character. For example, if `sub_char` is `'$'`, replacement groups should be
+    /// named $1, $2, etc. Defaults to `'$'`.
+    pub sub_char: char,
+    /// Group opening delimiter. Defaults to `"{"`.
+    pub open: &'static str,
+    /// Group closing delimiter. Defaults to `"}"`.
+    pub close: &'static str,
+    /// Allow group names without delimiters. Defaults to `true`.
+    pub allow_undelimited_name: bool,
 }
 
 impl Default for Expander {


### PR DESCRIPTION
# Description

This PR allows for creating custom `Expander` configurations beyond the provided `Expander::default()` and `Expander::python()` configurations.

# Changes

- Marked all fields of `Expander` as public.

# Motivation

In my application, I need to support Lua-style captures using `'%'` as the substitution character. In other words, instead of $1, $2, $3, etc., it should be %1, %2, %3 etc. Rather than adding another custom configuration (`Expander::lua() -> Self`), I figured it would be more straightforward to simply allow developers to create their own custom configurations.