### PR TITLE
Fix toy example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo run --example toy trace '\d*' '1122 33'
+      - run: cargo test --examples
 
   fmt:
     name: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,10 @@ default-features = false
 version = "0.8"
 default-features = false
 
-[dependencies]
-derive-debug = "0.1"
+[dependencies.derivative]
+version = "2.2.0"
+default-features = false
+features = ["use_core"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ default-features = false
 version = "0.8"
 default-features = false
 
+[dependencies]
+derive-debug = "0.1"
+
 [dev-dependencies]
 criterion = "0.5"
 matches = "0.1.10"

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -23,10 +23,10 @@
 use fancy_regex::internal::{analyze, compile, run_trace, Insn, Prog};
 use fancy_regex::*;
 use std::env;
+use std::fmt::{Display, Formatter, Result};
 use std::io;
 use std::io::Write;
 use std::str::FromStr;
-use std::fmt::{Display, Formatter, Result};
 
 fn main() {
     let mut args = env::args().skip(1);
@@ -39,12 +39,14 @@ fn main() {
             let re = args.next().expect("expected regexp argument");
             let stdout = io::stdout();
             let mut handle = stdout.lock();
-            write!(&mut handle, "{}", AnalyzeFormatterWrapper { regex: &re }).expect("error analyzing regexp");
+            write!(&mut handle, "{}", AnalyzeFormatterWrapper { regex: &re })
+                .expect("error analyzing regexp");
         } else if cmd == "compile" {
             let re = args.next().expect("expected regexp argument");
             let stdout = io::stdout();
             let mut handle = stdout.lock();
-            write!(&mut handle, "{}", CompileFormatterWrapper { regex: &re }).expect("error compiling regexp");
+            write!(&mut handle, "{}", CompileFormatterWrapper { regex: &re })
+                .expect("error compiling regexp");
         } else if cmd == "run" {
             let re = args.next().expect("expected regexp argument");
             let r = Regex::new(&re).unwrap();
@@ -121,14 +123,12 @@ fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let tree = Expr::parse_tree(&re).unwrap();
     let wrapped_tree = wrap_tree(tree);
     let a = analyze(&wrapped_tree);
-    write!(writer, "{:#?}\n", a)?;
-    Ok(())
+    write!(writer, "{:#?}\n", a)
 }
 
 fn show_compiled_program(re: &str, writer: &mut Formatter<'_>) -> Result {
     let r = Regex::new(&re).unwrap();
-    r.debug_print(writer)?;
-    Ok(())
+    r.debug_print(writer)
 }
 
 fn prog(re: &str) -> Prog {
@@ -158,12 +158,9 @@ impl<'a> Display for CompileFormatterWrapper<'a> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::Write;
-    use crate::graph;
-    use crate::{AnalyzeFormatterWrapper, CompileFormatterWrapper};
 
     #[test]
     fn test_simple_graph() {
@@ -263,6 +260,7 @@ digraph G {
     }
 
     fn assert_graph(re: &str, expected: &str) {
+        use crate::graph;
         let mut buf = Vec::new();
         graph(&re, &mut buf).expect("error compiling regexp");
         let output = String::from_utf8(buf).expect("string not utf8");
@@ -270,15 +268,19 @@ digraph G {
     }
 
     fn assert_compiled_prog(re: &str, expected: &str) {
+        use crate::CompileFormatterWrapper;
         let mut buf = Vec::new();
-        write!(&mut buf, "{}", CompileFormatterWrapper { regex: &re }).expect("error compiling regexp");
+        write!(&mut buf, "{}", CompileFormatterWrapper { regex: &re })
+            .expect("error compiling regexp");
         let output = String::from_utf8(buf).expect("string not utf8");
         assert_eq!(&output, &expected);
     }
 
     fn assert_analysis_succeeds(re: &str) {
+        use crate::AnalyzeFormatterWrapper;
         let mut buf = Vec::new();
-        write!(&mut buf, "{}", AnalyzeFormatterWrapper { regex: &re }).expect("error analyzing regexp");
+        write!(&mut buf, "{}", AnalyzeFormatterWrapper { regex: &re })
+            .expect("error analyzing regexp");
         let output = String::from_utf8(buf).expect("string not utf8");
         println!("{}", output);
         assert!(&output.starts_with("Ok(\n    Info {"));

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -26,7 +26,6 @@ use std::env;
 use std::io;
 use std::str::FromStr;
 
-
 fn main() {
     let mut args = env::args().skip(1);
     if let Some(cmd) = args.next() {
@@ -130,21 +129,27 @@ fn prog(re: &str) -> Prog {
 mod tests {
     #[test]
     fn test_graph() {
-        assert_graph("a+bc?", "\
+        assert_graph(
+            "a+bc?",
+            "\
 digraph G {
   0 [label=\"0: Delegate { pattern: \\\"a+bc?\\\", start_group: 0, end_group: 0 }\"];
   0 -> 1;
   1 [label=\"1: End\"];
 }
-");
+",
+        );
 
-        assert_graph("a+(?<b>b*)(?=c)\\k<b>", "\
+        assert_graph(
+            "a+(?<b>b*)(?=c)\\k<b>",
+            "\
 digraph G {
   0 [label=\"0: Delegate { pattern: \\\"a+bc?\\\", start_group: 0, end_group: 0 }\"];
   0 -> 1;
   1 [label=\"1: End\"];
 }
-");
+",
+        );
     }
 
     fn assert_graph(re: &str, expected: &str) {
@@ -157,8 +162,8 @@ digraph G {
 
     #[test]
     fn test_compilation_debug_output() {
-        let expected = " ".to_owned() +
-" 0: Split(3, 1)
+        let expected = " ".to_owned()
+            + " 0: Split(3, 1)
   1: Any
   2: Jmp(0)
   3: Save(0)

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -162,8 +162,9 @@ digraph G {
 
     #[test]
     fn test_compilation_debug_output() {
-        let expected = " ".to_owned()
-            + " 0: Split(3, 1)
+        let expected = "  ".to_owned()
+            + "\
+  0: Split(3, 1)
   1: Any
   2: Jmp(0)
   3: Save(0)

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -29,21 +29,18 @@ fn main() {
     let mut args = env::args().skip(1);
     if let Some(cmd) = args.next() {
         if cmd == "parse" {
-            if let Some(re) = args.next() {
-                let e = Expr::parse_tree(&re);
-                println!("{:#?}", e);
-            }
+            let re = args.next().expect("expected regexp argument");
+            let e = Expr::parse_tree(&re);
+            println!("{:#?}", e);
         } else if cmd == "analyze" {
-            if let Some(re) = args.next() {
-                let tree = Expr::parse_tree(&re).unwrap();
-                let a = analyze(&tree);
-                println!("{:#?}", a);
-            }
+            let re = args.next().expect("expected regexp argument");
+            let tree = Expr::parse_tree(&re).unwrap();
+            let a = analyze(&tree);
+            println!("{:#?}", a);
         } else if cmd == "compile" {
-            if let Some(re) = args.next() {
-                let r = Regex::new(&re).unwrap();
-                r.debug_print();
-            }
+            let re = args.next().expect("expected regexp argument");
+            let r = Regex::new(&re).unwrap();
+            r.debug_print();
         } else if cmd == "run" {
             let re = args.next().expect("expected regexp argument");
             let r = Regex::new(&re).unwrap();
@@ -70,21 +67,17 @@ fn main() {
                 println!("no match");
             }
         } else if cmd == "trace" {
-            if let Some(re) = args.next() {
-                let prog = prog(&re);
-                if let Some(s) = args.next() {
-                    run_trace(&prog, &s, 0).unwrap();
-                }
-            }
+            let re = args.next().expect("expected regexp argument");
+            let prog = prog(&re);
+            let text = args.next().expect("expected text argument");
+            run_trace(&prog, &text, 0).unwrap();
         } else if cmd == "trace-inner" {
-            if let Some(re) = args.next() {
-                let tree = Expr::parse_tree(&re).unwrap();
-                let a = analyze(&tree).unwrap();
-                let p = compile(&a).unwrap();
-                if let Some(s) = args.next() {
-                    run_trace(&p, &s, 0).unwrap();
-                }
-            }
+            let re = args.next().expect("expected regexp argument");
+            let tree = Expr::parse_tree(&re).unwrap();
+            let text = args.next().expect("expected text argument");
+            let a = analyze(&tree).unwrap();
+            let p = compile(&a).unwrap();
+            run_trace(&p, &text, 0).unwrap();
         } else if cmd == "graph" {
             let re = args.next().expect("expected regexp argument");
             graph(&re);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -578,6 +578,7 @@ impl DelegateBuilder {
 
         Ok(Insn::Delegate {
             inner: compiled,
+            pattern: self.re.clone(),
             start_group,
             end_group,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,18 +641,7 @@ impl Regex {
 
         // wrapper to search for re at arbitrary start position,
         // and to capture the match bounds
-        let tree = ExprTree {
-            expr: Expr::Concat(vec![
-                Expr::Repeat {
-                    child: Box::new(Expr::Any { newline: true }),
-                    lo: 0,
-                    hi: usize::MAX,
-                    greedy: false,
-                },
-                Expr::Group(Box::new(raw_tree.expr)),
-            ]),
-            ..raw_tree
-        };
+        let tree = wrap_tree(raw_tree);
 
         let info = analyze(&tree)?;
 
@@ -1758,6 +1747,23 @@ pub fn detect_possible_backref(re: &str) -> bool {
     }
 }
 */
+
+/// wrapper to search for re at arbitrary start position,
+/// and to capture the match bounds
+pub fn wrap_tree(raw_tree: ExprTree) -> ExprTree {
+    return ExprTree {
+        expr: Expr::Concat(vec![
+            Expr::Repeat {
+                child: Box::new(Expr::Any { newline: true }),
+                lo: 0,
+                hi: usize::MAX,
+                greedy: false,
+            },
+            Expr::Group(Box::new(raw_tree.expr)),
+        ]),
+        ..raw_tree
+    };
+}
 
 /// The internal module only exists so that the toy example can access internals for debugging and
 /// experimenting.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,12 +932,12 @@ impl Regex {
 
     // for debugging only
     #[doc(hidden)]
-    pub fn debug_print(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    pub fn debug_print(&self, writer: &mut Formatter<'_>) -> fmt::Result {
         match &self.inner {
-            #[cfg(feature = "std")]
+            //#[cfg(feature = "std")]
             RegexImpl::Wrap { inner, .. } => write!(writer, "wrapped {:?}", inner),
-            #[cfg(not(feature = "std"))]
-            RegexImpl::Wrap { .. } => {}
+            //#[cfg(not(feature = "std"))]
+            //RegexImpl::Wrap { .. } => Ok(()),
             RegexImpl::Fancy { prog, .. } => prog.debug_print(writer),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -943,13 +943,13 @@ impl Regex {
 
     // for debugging only
     #[doc(hidden)]
-    pub fn debug_print(&self) {
+    pub fn debug_print(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
         match &self.inner {
             #[cfg(feature = "std")]
-            RegexImpl::Wrap { inner, .. } => println!("wrapped {:?}", inner),
+            RegexImpl::Wrap { inner, .. } => write!(writer, "wrapped {:?}", inner),
             #[cfg(not(feature = "std"))]
             RegexImpl::Wrap { .. } => {}
-            RegexImpl::Fancy { prog, .. } => prog.debug_print(),
+            RegexImpl::Fancy { prog, .. } => prog.debug_print(writer),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,10 +934,7 @@ impl Regex {
     #[doc(hidden)]
     pub fn debug_print(&self, writer: &mut Formatter<'_>) -> fmt::Result {
         match &self.inner {
-            //#[cfg(feature = "std")]
             RegexImpl::Wrap { inner, .. } => write!(writer, "wrapped {:?}", inner),
-            //#[cfg(not(feature = "std"))]
-            //RegexImpl::Wrap { .. } => Ok(()),
             RegexImpl::Fancy { prog, .. } => prog.debug_print(writer),
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -89,7 +89,6 @@ use crate::Formatter;
 use crate::Result;
 use crate::{codepoint_len, RegexOptions};
 
-
 /// Enable tracing of VM execution. Only for debugging/investigating.
 const OPTION_TRACE: u32 = 1 << 0;
 /// When iterating over all matches within a text (e.g. with `find_iter`), empty matches need to be
@@ -185,7 +184,7 @@ pub enum Insn {
     /// Delegate matching to the regex crate
     Delegate {
         /// The regex
-        #[derivative(Debug="ignore")]
+        #[derivative(Debug = "ignore")]
         inner: Regex,
         /// The regex pattern as a string
         pattern: String,
@@ -215,7 +214,6 @@ impl Prog {
 
     #[doc(hidden)]
     pub(crate) fn debug_print(&self, writer: &mut Formatter<'_>) -> core::fmt::Result {
-        //#[cfg(feature = "std")]
         for (i, insn) in self.body.iter().enumerate() {
             write!(writer, "{:3}: {:?}\n", i, insn)?;
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -211,11 +211,12 @@ impl Prog {
     }
 
     #[doc(hidden)]
-    pub(crate) fn debug_print(&self) {
+    pub(crate) fn debug_print(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
         #[cfg(feature = "std")]
         for (i, insn) in self.body.iter().enumerate() {
-            println!("{:3}: {:?}", i, insn);
+            write!(writer, "{:3}: {:?}\n", i, insn)?;
         }
+        Ok(())
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -74,6 +74,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::usize;
+use derive_debug::Dbg;
 use regex_automata::meta::Regex;
 use regex_automata::util::look::LookMatcher;
 use regex_automata::util::primitives::NonMaxUsize;
@@ -101,7 +102,7 @@ pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 1 << 1;
 const MAX_STACK: usize = 1_000_000;
 
 /// Instruction of the VM.
-#[derive(Debug, Clone)]
+#[derive(Clone, Dbg)]
 pub enum Insn {
     /// Successful end of program
     End,
@@ -181,7 +182,10 @@ pub enum Insn {
     /// Delegate matching to the regex crate
     Delegate {
         /// The regex
+        #[dbg(skip)]
         inner: Regex,
+        /// The regex pattern as a string
+        pattern: String,
         /// The first group number that this regex captures (if it contains groups)
         start_group: usize,
         /// The last group number
@@ -664,6 +668,7 @@ pub(crate) fn run(
                 }
                 Insn::Delegate {
                     ref inner,
+                    pattern: _,
                     start_group,
                     end_group,
                 } => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -74,7 +74,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::usize;
-use derive_debug::Dbg;
+use derivative::Derivative;
 use regex_automata::meta::Regex;
 use regex_automata::util::look::LookMatcher;
 use regex_automata::util::primitives::NonMaxUsize;
@@ -85,8 +85,10 @@ use crate::error::RuntimeError;
 use crate::prev_codepoint_ix;
 use crate::Assertion;
 use crate::Error;
+use crate::Formatter;
 use crate::Result;
 use crate::{codepoint_len, RegexOptions};
+
 
 /// Enable tracing of VM execution. Only for debugging/investigating.
 const OPTION_TRACE: u32 = 1 << 0;
@@ -102,7 +104,8 @@ pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 1 << 1;
 const MAX_STACK: usize = 1_000_000;
 
 /// Instruction of the VM.
-#[derive(Clone, Dbg)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub enum Insn {
     /// Successful end of program
     End,
@@ -182,7 +185,7 @@ pub enum Insn {
     /// Delegate matching to the regex crate
     Delegate {
         /// The regex
-        #[dbg(skip)]
+        #[derivative(Debug="ignore")]
         inner: Regex,
         /// The regex pattern as a string
         pattern: String,
@@ -211,8 +214,8 @@ impl Prog {
     }
 
     #[doc(hidden)]
-    pub(crate) fn debug_print(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
-        #[cfg(feature = "std")]
+    pub(crate) fn debug_print(&self, writer: &mut Formatter<'_>) -> core::fmt::Result {
+        //#[cfg(feature = "std")]
         for (i, insn) in self.body.iter().enumerate() {
             write!(writer, "{:3}: {:?}\n", i, insn)?;
         }


### PR DESCRIPTION
The `toy` example had a number of shortcomings:
- the debug output was too verbose - it showed the PikeVM debug output instead of the regex pattern for example, making the graph unreadably big
- it panicked with regex patterns which include backrefs etc. due to the analyzed expression tree missing instructions for the 0th group

This PR fixes those problems and adds some tests which verify the output from the `toy` example, and runs those tests in CI.