### PR TITLE
Add support for named captures using (?'name'...) syntax

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -636,20 +636,12 @@ impl<'a> Parser<'a> {
         } else if self.re[ix..].starts_with("?<") || self.re[ix..].starts_with("?'") {
             // Named capture group using Oniguruma syntax: (?<name>...) or (?'name'...)
             self.curr_group += 1;
-            if let Some((id, skip)) = parse_id(
-                &self.re[ix + 1..],
-                if self.re[ix..].starts_with("?<") {
-                    "<"
-                } else {
-                    "'"
-                },
-                if self.re[ix..].starts_with("?<") {
-                    ">"
-                } else {
-                    "'"
-                },
-                false,
-            ) {
+            let (open, close) = if self.re[ix..].starts_with("?<") {
+                ("<", ">")
+            } else {
+                ("'", "'")
+            };
+            if let Some((id, skip)) = parse_id(&self.re[ix + 1..], open, close, false) {
                 self.named_groups.insert(id.to_string(), self.curr_group);
                 (None, skip + 1)
             } else {

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -214,11 +214,8 @@
   // Compile failed: ParseError(7, GeneralParseError("expected close paren"))
   x2("(a)(?(1+0)b|c)d", "abd", 0, 3);
 
-  // Compile failed: ParseError(5, UnknownFlag("(?'"))
+  // No match found
   x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "ace", 0, 3);
-
-  // Compile failed: ParseError(5, UnknownFlag("(?'"))
-  x2("(?:(?'name'a)|(?'name'b))(?('name')c|d)e", "bce", 0, 3);
 
   // Compile failed: ParseError(0, InvalidEscape("\\R"))
   x2("\\R", "\r\n", 0, 2);


### PR DESCRIPTION
We previously supported the angle bracket `(?<name>...)` syntax but missed the single quoted variant which Oniguruma supports