### PR TITLE
Mark more expressions as non-repeatable

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -186,6 +186,9 @@ impl<'a> Parser<'a> {
             Expr::LookAround(_, _) => false,
             Expr::Empty => false,
             Expr::Assertion(_) => false,
+            Expr::KeepOut => false,
+            Expr::ContinueFromPreviousMatchEnd => false,
+            Expr::BackrefExistsCondition(_) => false,
             _ => true,
         }
     }
@@ -1663,6 +1666,22 @@ mod tests {
         assert_eq!(
             p("a\\Kb"),
             Expr::Concat(vec![make_literal("a"), Expr::KeepOut, make_literal("b"),])
+        );
+    }
+
+    #[test]
+    fn no_quantifiers_on_other_non_repeatable_expressions() {
+        assert_error(
+            r"\K?",
+            "Parsing error at position 2: Target of repeat operator is invalid",
+        );
+        assert_error(
+            r"\G*",
+            "Parsing error at position 2: Target of repeat operator is invalid",
+        );
+        assert_error(
+            r"\b+",
+            "Parsing error at position 2: Target of repeat operator is invalid",
         );
     }
 


### PR DESCRIPTION
to match Oniguruma, we should emit a parse error when quantifiers are used on assertions and other Expr nodes where it makes no sense to have a quantifier