### PR TITLE
Support named subroutine calls defined later on in the expression

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -206,6 +206,9 @@ impl<'a> Analyzer<'a> {
                     "Subroutine Call".to_string(),
                 )));
             }
+            Expr::UnresolvedNamedSubroutineCall { ref name, .. } => {
+                return Err(Error::CompileError(CompileError::InvalidGroupNameBackref(name.to_string())));
+            }
         };
 
         Ok(Info {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -207,7 +207,9 @@ impl<'a> Analyzer<'a> {
                 )));
             }
             Expr::UnresolvedNamedSubroutineCall { ref name, .. } => {
-                return Err(Error::CompileError(CompileError::InvalidGroupNameBackref(name.to_string())));
+                return Err(Error::CompileError(CompileError::InvalidGroupNameBackref(
+                    name.to_string(),
+                )));
             }
         };
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -207,10 +207,9 @@ impl<'a> Analyzer<'a> {
                 )));
             }
             Expr::UnresolvedNamedSubroutineCall { ref name, ix } => {
-                return Err(Error::CompileError(CompileError::SubroutineCallTargetNotFound(
-                    name.to_string(),
-                    ix,
-                )));
+                return Err(Error::CompileError(
+                    CompileError::SubroutineCallTargetNotFound(name.to_string(), ix),
+                ));
             }
         };
 
@@ -292,9 +291,9 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.err(),
-            Some(Error::CompileError(CompileError::SubroutineCallTargetNotFound(
-                _, _
-            )))
+            Some(Error::CompileError(
+                CompileError::SubroutineCallTargetNotFound(_, _)
+            ))
         ));
     }
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -246,6 +246,8 @@ pub fn analyze<'a>(tree: &'a ExprTree) -> Result<Info<'a>> {
 mod tests {
     use super::analyze;
     // use super::literal_const_size;
+    use crate::CompileError;
+    use crate::Error;
     use crate::Expr;
 
     // #[test]
@@ -280,6 +282,19 @@ mod tests {
     #[test]
     fn feature_not_yet_supported() {
         assert!(analyze(&Expr::parse_tree("(a)\\g<1>").unwrap()).is_err());
+    }
+
+    #[test]
+    fn subroutine_call_undefined() {
+        let tree = &Expr::parse_tree(r"\g<wrong_name>(?<different_name>a)").unwrap();
+        let result = analyze(tree);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err(),
+            Some(Error::CompileError(CompileError::InvalidGroupNameBackref(
+                _
+            )))
+        ));
     }
 
     #[test]

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -206,9 +206,10 @@ impl<'a> Analyzer<'a> {
                     "Subroutine Call".to_string(),
                 )));
             }
-            Expr::UnresolvedNamedSubroutineCall { ref name, .. } => {
-                return Err(Error::CompileError(CompileError::InvalidGroupNameBackref(
+            Expr::UnresolvedNamedSubroutineCall { ref name, ix } => {
+                return Err(Error::CompileError(CompileError::SubroutineCallTargetNotFound(
                     name.to_string(),
+                    ix,
                 )));
             }
         };
@@ -291,8 +292,8 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.err(),
-            Some(Error::CompileError(CompileError::InvalidGroupNameBackref(
-                _
+            Some(Error::CompileError(CompileError::SubroutineCallTargetNotFound(
+                _, _
             )))
         ));
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -179,6 +179,7 @@ impl Compiler {
                     "Subroutine Call".to_string(),
                 )));
             }
+            Expr::UnresolvedNamedSubroutineCall { .. } => unreachable!(),
         }
         Ok(())
     }
@@ -614,6 +615,7 @@ mod tests {
             ]),
             backrefs: BitSet::new(),
             named_groups: Default::default(),
+            contains_subroutines: false,
         };
         let info = analyze(&tree).unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,8 @@ pub enum CompileError {
     NamedBackrefOnly,
     /// Feature not supported yet
     FeatureNotYetSupported(String),
+    /// Subroutine call to non-existent group
+    SubroutineCallTargetNotFound(String, usize),
 }
 
 /// An error as the result of executing a regex.
@@ -133,6 +135,9 @@ impl fmt::Display for CompileError {
             CompileError::InvalidBackref => write!(f, "Invalid back reference"),
             CompileError::NamedBackrefOnly => write!(f, "Numbered backref/call not allowed because named group was used, use a named backref instead"),
             CompileError::FeatureNotYetSupported(s) => write!(f, "Regex uses currently unimplemented feature: {}", s),
+            CompileError::SubroutineCallTargetNotFound(s, ix) => {
+                write!(f, "Subroutine call target not found at position {}: {}", ix, s)
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1464,6 +1464,13 @@ pub enum Expr {
     },
     /// Subroutine call to the specified group number
     SubroutineCall(usize),
+    /// Unresolved subroutine call to the specified group name
+    UnresolvedNamedSubroutineCall {
+        /// The capture group name
+        name: String,
+        /// The position in the original regex pattern where the subroutine call is made
+        ix: usize,
+    },
 }
 
 /// Type of look-around assertion as used for a look-around expression.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2143,10 +2143,10 @@ mod tests {
     #[test]
     fn named_subroutine_not_defined_later() {
         assert_eq!(
-            p(r"\g<name>(?<different_name>a)"),
+            p(r"\g<wrong_name>(?<different_name>a)"),
             Expr::Concat(vec![
                 Expr::UnresolvedNamedSubroutineCall {
-                    name: "name".to_string(),
+                    name: "wrong_name".to_string(),
                     ix: 2
                 },
                 Expr::Group(Box::new(make_literal("a"))),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -50,7 +50,7 @@ pub struct ExprTree {
     pub expr: Expr,
     pub backrefs: BitSet,
     pub named_groups: NamedGroups,
-    pub contains_subroutines: bool,
+    pub(crate) contains_subroutines: bool,
 }
 
 #[derive(Debug)]

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -100,7 +100,7 @@
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?<name_2>ab)\\g<name_2>", "abab", 0, 4);
 
-  // Compile failed: ParseError(6, InvalidGroupNameBackref("ab"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?<=\\g<ab>)|-\\zEND (?<ab>XyZ)", "XyZ", 3, 3);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
@@ -109,16 +109,16 @@
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?<n>|\\(\\g<n>\\))+$", "()(())", 0, 6);
 
-  // Compile failed: ParseError(2, InvalidGroupNameBackref("n"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x3("\\g<n>(?<n>.){0}", "X", 0, 1, 1);
 
-  // Compile failed: ParseError(2, InvalidGroupNameBackref("n"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("\\g<n>(abc|df(?<n>.YZ){2,8}){0}", "XYZ", 0, 3);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("\\A(?<n>(a\\g<n>)|)\\z", "aaaa", 0, 4);
 
-  // Compile failed: ParseError(8, InvalidGroupNameBackref("m"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("(?<n>|\\g<m>\\g<n>)\\z|\\zEND (?<m>a|(b)\\g<m>)", "bbbbabba", 0, 8);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
@@ -139,19 +139,19 @@
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x3("(?<foo>a|\\(\\g<foo>\\))", "((((((((a))))))))", 0, 17, 1);
 
-  // Compile failed: ParseError(2, InvalidGroupNameBackref("bar"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("\\g<bar>|\\zEND(?<bar>.*abc$)", "abcxxxabc", 0, 9);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("\\g<1>|\\zEND(.a.)", "bac", 0, 3);
 
-  // Compile failed: ParseError(2, InvalidGroupNameBackref("_A"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x3("\\g<_A>\\g<_A>|\\zEND(.a.)(?<_A>.b.)", "xbxyby", 3, 6, 1);
 
-  // Compile failed: ParseError(7, InvalidGroupNameBackref("pon"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("\\A(?:\\g<pon>|\\g<pan>|\\zEND  (?<pan>a|c\\g<pon>c)(?<pon>b|d\\g<pan>d))$", "cdcbcdc", 0, 7);
 
-  // Compile failed: ParseError(11, InvalidGroupNameBackref("m"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("\\A(?<n>|a\\g<m>)\\z|\\zEND (?<m>\\g<n>)", "aaaa", 0, 4);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
@@ -442,7 +442,7 @@
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?<愚か>変|\\(\\g<愚か>\\))", "((((((変))))))", 0, 15);
 
-  // Compile failed: ParseError(7, InvalidGroupNameBackref("阿_1"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call")
   x2("\\A(?:\\g<阿_1>|\\g<云_2>|\\z終了  (?<阿_1>観|自\\g<云_2>自)(?<云_2>在|菩薩\\g<阿_1>菩薩))$", "菩薩自菩薩自在自菩薩自菩薩", 0, 39);
 
   // Compile failed: CompileError(InnerError(BuildError { kind: Syntax { pid: PatternID(0), err: Parse(Error { kind: ClassRangeInvalid, pattern: "[あ-&&-あ]", span: Span(Position(o: 1, l: 1, c: 2), Position(o: 6, l: 1, c: 5)) }) } }))


### PR DESCRIPTION
Oniguruma supports calls to subroutines which haven't been parsed yet. To cater for this, when we come across such a subroutine call, we initially emit an `Expr::UnresolvedNamedSubroutineCall`. Then, once parsing of the entire regex pattern has completed, if there were any unresolved named subroutine calls, it goes through and resolves them - replacing them with a numbered `Expr::SubroutineCall`. If there are still any such `UnresolvedNamedSubroutineCall` exprs left at analyze time, then we fail immediately. The compiler will never see this expr.