### PR TITLE
Update parser to support backrefs with a relative recursion level

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -286,7 +286,25 @@ mod tests {
 
     #[test]
     fn feature_not_yet_supported() {
-        assert!(analyze(&Expr::parse_tree("(a)\\g<1>").unwrap()).is_err());
+        let tree = &Expr::parse_tree(r"(a)\g<1>").unwrap();
+        let result = analyze(tree);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err(),
+            Some(Error::CompileError(CompileError::FeatureNotYetSupported(
+                _
+            )))
+        ));
+
+        let tree = &Expr::parse_tree(r"(a)\k<1-0>").unwrap();
+        let result = analyze(tree);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err(),
+            Some(Error::CompileError(CompileError::FeatureNotYetSupported(
+                _
+            )))
+        ));
     }
 
     #[test]

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -291,9 +291,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.err(),
-            Some(Error::CompileError(CompileError::FeatureNotYetSupported(
-                _
-            )))
+            Some(Error::CompileError(CompileError::FeatureNotYetSupported(_)))
         ));
 
         let tree = &Expr::parse_tree(r"(a)\k<1-0>").unwrap();
@@ -301,9 +299,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.err(),
-            Some(Error::CompileError(CompileError::FeatureNotYetSupported(
-                _
-            )))
+            Some(Error::CompileError(CompileError::FeatureNotYetSupported(_)))
         ));
     }
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -211,6 +211,11 @@ impl<'a> Analyzer<'a> {
                     name.to_string(),
                 )));
             }
+            Expr::BackrefWithRelativeRecursionLevel(_, _) => {
+                return Err(Error::CompileError(CompileError::FeatureNotYetSupported(
+                    "Backref at recursion level".to_string(),
+                )));
+            }
         };
 
         Ok(Info {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -180,6 +180,7 @@ impl Compiler {
                 )));
             }
             Expr::UnresolvedNamedSubroutineCall { .. } => unreachable!(),
+            Expr::BackrefWithRelativeRecursionLevel(_, _) => unreachable!(),
         }
         Ok(())
     }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -227,7 +227,7 @@ impl Expander {
                 let skip = if tail.starts_with(self.sub_char) {
                     f(Step::Char(self.sub_char))?;
                     1
-                } else if let Some((id, skip)) = parse_id(tail, self.open, self.close, false)
+                } else if let Some((id, None, skip)) = parse_id(tail, self.open, self.close, false)
                     .or_else(|| {
                         if self.allow_undelimited_name {
                             parse_id(tail, "", "", false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1448,6 +1448,8 @@ pub enum Expr {
     /// Back reference to a capture group, e.g. `\1` in `(abc|def)\1` references the captured group
     /// and the whole regex matches either `abcabc` or `defdef`.
     Backref(usize),
+    /// Back reference to a capture group at the given specified relative recursion level.
+    BackrefWithRelativeRecursionLevel(usize, isize),
     /// Atomic non-capturing group, e.g. `(?>ab|a)` in text that contains `ab` will match `ab` and
     /// never backtrack and try `a`, even if matching fails after the atomic group.
     AtomicGroup(Box<Expr>),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -301,7 +301,14 @@ impl<'a> Parser<'a> {
             self.parse_named_backref_or_subroutine(ix, open, close, allow_relative)?;
         if let Some(group) = group {
             self.backrefs.insert(group);
-            return Ok((end, if let Some(recursion_level) = recursion_level { Expr::BackrefWithRelativeRecursionLevel(group, recursion_level) } else { Expr::Backref(group) }));
+            return Ok((
+                end,
+                if let Some(recursion_level) = recursion_level {
+                    Expr::BackrefWithRelativeRecursionLevel(group, recursion_level)
+                } else {
+                    Expr::Backref(group)
+                },
+            ));
         }
         if let Some(id) = id {
             // here the name was parsed but doesn't match a capture group we have already parsed
@@ -323,10 +330,7 @@ impl<'a> Parser<'a> {
         let (end, group, id, recursion_level) =
             self.parse_named_backref_or_subroutine(ix, open, close, allow_relative)?;
         if let Some(_) = recursion_level {
-            return Err(Error::ParseError(
-                ix,
-                ParseError::InvalidGroupName,
-            ));
+            return Err(Error::ParseError(ix, ParseError::InvalidGroupName));
         }
         if let Some(group) = group {
             self.contains_subroutines = true;
@@ -345,7 +349,6 @@ impl<'a> Parser<'a> {
         unreachable!()
     }
 
-
     // Returns Ok(ix, resolved group number, unresolved group name, recursion level)
     fn parse_named_backref_or_subroutine(
         &self,
@@ -354,7 +357,9 @@ impl<'a> Parser<'a> {
         close: &str,
         allow_relative: bool,
     ) -> Result<(usize, Option<usize>, Option<&str>, Option<isize>)> {
-        if let Some((id, mut relative, skip)) = parse_id(&self.re[ix..], open, close, allow_relative) {
+        if let Some((id, mut relative, skip)) =
+            parse_id(&self.re[ix..], open, close, allow_relative)
+        {
             let group = if let Some(group) = self.named_groups.get(id) {
                 Some(*group)
             } else if let Ok(group) = id.parse::<usize>() {
@@ -362,7 +367,11 @@ impl<'a> Parser<'a> {
             } else if let Some(relative_group) = relative {
                 if id.is_empty() {
                     relative = None;
-                    self.curr_group.checked_add_signed(if relative_group < 0 { relative_group + 1 } else { relative_group })
+                    self.curr_group.checked_add_signed(if relative_group < 0 {
+                        relative_group + 1
+                    } else {
+                        relative_group
+                    })
                 } else {
                     None
                 }
@@ -1004,7 +1013,7 @@ pub(crate) fn parse_id<'a>(
     allow_relative: bool,
 ) -> Option<(&'a str, Option<isize>, usize)> {
     debug_assert!(!close.starts_with(is_id_char));
-    
+
     if !s.starts_with(open) || s.len() <= open.len() + close.len() {
         return None;
     }
@@ -1012,13 +1021,13 @@ pub(crate) fn parse_id<'a>(
     let id_start = open.len();
     let mut iter = s[id_start..].char_indices().peekable();
     let after_id = iter.find(|(_, ch)| !is_id_char(*ch));
-    
+
     let id_len = match after_id.map(|(i, _)| i) {
         Some(id_len) => id_len,
         None if close.is_empty() => s.len(),
         _ => 0,
     };
-    
+
     let id_end = id_start + id_len;
     if id_len > 0 && s[id_end..].starts_with(close) {
         return Some((&s[id_start..id_end], None, id_end + close.len()));
@@ -1036,7 +1045,11 @@ pub(crate) fn parse_id<'a>(
                 if relative_sign == b'-' {
                     relative_amount_signed = 0 - relative_amount_signed;
                 }
-                return Some((&s[id_start..id_end], Some(relative_amount_signed), end + close.len()));
+                return Some((
+                    &s[id_start..id_end],
+                    Some(relative_amount_signed),
+                    end + close.len(),
+                ));
             }
         }
     }
@@ -1566,14 +1579,16 @@ mod tests {
             Expr::Concat(vec![
                 Expr::Assertion(Assertion::StartText),
                 Expr::Group(Box::new(Expr::Alt(vec![
-                    Expr::Empty, Expr::Any { newline: false },
+                    Expr::Empty,
+                    Expr::Any { newline: false },
                     Expr::Concat(vec![
                         Expr::Group(Box::new(Expr::Any { newline: false })),
                         Expr::SubroutineCall(1),
                         Expr::BackrefWithRelativeRecursionLevel(2, 0),
                     ])
                 ]))),
-                Expr::Assertion(Assertion::EndText)]),
+                Expr::Assertion(Assertion::EndText)
+            ]),
         );
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1538,6 +1538,9 @@ mod tests {
         fail("(.)(?P=-)");
         fail(r"(a)\k<-0>(.)");
         fail(r"(a)\k<+0>(.)");
+        fail(r"(a)\k<+>(.)");
+        fail(r"(a)\k<->(.)");
+        fail(r"(a)\k<>(.)");
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1988,6 +1988,18 @@ mod tests {
     }
 
     #[test]
+    fn subroutine_call_name_includes_dash() {
+        assert_error(
+            r"\g<1-0>(a)",
+            "Parsing error at position 2: Could not parse group name",
+        );
+        assert_error(
+            r"\g<name+1>(?'name'a)",
+            "Parsing error at position 2: Could not parse group name",
+        );
+    }
+
+    #[test]
     fn backref_condition_with_one_two_or_three_branches() {
         assert_eq!(
             p("(h)?(?(1)i|x)"),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1596,6 +1596,33 @@ mod tests {
     }
 
     #[test]
+    fn relative_subroutine_call() {
+        assert_eq!(
+            p(r"(a)(.)\g<-1>"),
+            Expr::Concat(vec![
+                Expr::Group(Box::new(make_literal("a"))),
+                Expr::Group(Box::new(Expr::Any { newline: false })),
+                Expr::SubroutineCall(2),
+            ])
+        );
+
+        assert_eq!(
+            p(r"(a)\g<+1>(.)"),
+            Expr::Concat(vec![
+                Expr::Group(Box::new(make_literal("a"))),
+                Expr::SubroutineCall(2),
+                Expr::Group(Box::new(Expr::Any { newline: false })),
+            ])
+        );
+
+        fail(r"(a)\g<-0>(.)");
+        fail(r"(a)\g<+0>(.)");
+        fail(r"(a)\g<+>(.)");
+        fail(r"(a)\g<->(.)");
+        fail(r"(a)\g<>(.)");
+    }
+
+    #[test]
     fn lookaround() {
         assert_eq!(
             p("(?=a)"),

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -187,19 +187,19 @@
   // Compile failed: ParseError(0, InvalidEscape("\\o"))
   x2("\\o{101}", "A", 0, 1);
 
-  // Compile failed: ParseError(15, InvalidGroupName)
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("\\A(a|b\\g<1>c)\\k<1+3>\\z", "bbacca", 0, 6);
 
-  // Compile failed: ParseError(19, InvalidGroupName)
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?i)\\A(a|b\\g<1>c)\\k<1+2>\\z", "bBACcbac", 0, 8);
 
   // No match found
   x2("(?i)(?<X>aa)|(?<X>bb)\\k<X>", "BBbb", 0, 4);
 
-  // Compile failed: ParseError(5, InvalidGroupName)
+  // Compile failed: CompileError(InvalidBackref)
   x2("(?:\\k'+1'B|(A)C)*", "ACAB", 0, 4);
 
-  // Compile failed: ParseError(2, InvalidGroupName)
+  // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("\\g<+2>(abc)(ABC){0}", "ABCabc", 0, 6);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
@@ -208,10 +208,7 @@
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x3("(A\\g'0')|B", "AAAAB", 0, 5, 1);
 
-  // Compile failed: ParseError(10, GeneralParseError("expected conditional to be a backreference or at least an expression for when the condition is true"))
-  x2("(a*)(?(-1))aa", "aaaaa", 0, 5);
-
-  // Compile failed: ParseError(7, GeneralParseError("expected close paren"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Backref at recursion level"))
   x2("(a)(?(1+0)b|c)d", "abd", 0, 3);
 
   // No match found


### PR DESCRIPTION
Basically a backref can either be to a relative group number like `(1)\k<-1>)` or it can be specifying a relative recursion level, but not both. When specifying a relative recursion level, the group number has to be absolute. So I updated `parse_id` to handle that, and callers then choose how to interpret the relative part based on the context.