### PR TITLE
support \O to match any character including a newline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,9 @@ Escapes:
 `\G`
 : anchor to where the previous match ended ([docs](https://www.regular-expressions.info/continue.html))\
 `\Z`
-: anchor to the end of the text before any trailing newlines
+: anchor to the end of the text before any trailing newlines\
+`\O`
+: any character including newline
 
 Backreferences:
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -448,6 +448,8 @@ impl<'a> Parser<'a> {
             (end, Expr::KeepOut)
         } else if b == b'G' && !in_class {
             (end, Expr::ContinueFromPreviousMatchEnd)
+        } else if b == b'O' && !in_class {
+            (end, Expr::Any { newline: true })
         } else if b == b'g' && !in_class {
             if end == self.re.len() {
                 return Err(Error::ParseError(

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -7,7 +7,7 @@
   // No match found
   x2("^a", "\na", 1, 2);
 
-  // Compile failed: ParseError(1, InvalidEscape("\\O"))
+  // No match found
   x2("$\\O", "bb\n", 2, 3);
 
   // Compile failed: ParseError(0, InvalidEscape("\\c"))
@@ -237,18 +237,6 @@
 
   // Compile failed: ParseError(0, InvalidEscape("\\N"))
   x2("\\N", "a", 0, 1);
-
-  // Compile failed: ParseError(0, InvalidEscape("\\O"))
-  x2("\\O", "a", 0, 1);
-
-  // Compile failed: ParseError(0, InvalidEscape("\\O"))
-  x2("\\O", "\n", 0, 1);
-
-  // Compile failed: ParseError(4, InvalidEscape("\\O"))
-  x2("(?m:\\O)", "\n", 0, 1);
-
-  // Compile failed: ParseError(5, InvalidEscape("\\O"))
-  x2("(?-m:\\O)", "\n", 0, 1);
 
   // No match found
   x2("(?:()|())*\\1", "abc", 0, 0);


### PR DESCRIPTION
this simple change gets a few more Oniguruma test cases passing, no need for any new Exprs or anything :) 