### PR TITLE
Refactor to avoid wrapping exprtree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo check
       - run: cargo check --no-default-features
+      - run: cargo check --examples
+      - run: cargo check --benches
 
   test:
     name: test

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -55,13 +55,15 @@ fn parse_misc(c: &mut Criterion) {
 fn analyze_literal_re(c: &mut Criterion) {
     let re = "^\\\\([!-/:-@\\[-`\\{-~aftnrv]|[0-7]{1,3}|x[0-9a-fA-F]{2}|x\\{[0-9a-fA-F]{1,6}\\})";
     let tree = Expr::parse_tree(re).unwrap();
-    c.bench_function("analyze_literal_re", |b| b.iter(|| analyze(&tree).unwrap()));
+    c.bench_function("analyze_literal_re", |b| {
+        b.iter(|| analyze(&tree, 1).unwrap())
+    });
 }
 
 fn run_backtrack(c: &mut Criterion) {
     let tree = Expr::parse_tree("^.*?(([ab]+)\\1b)").unwrap();
-    let a = analyze(&tree).unwrap();
-    let p = compile(&a).unwrap();
+    let a = analyze(&tree, 0).unwrap();
+    let p = compile(&a, true).unwrap();
     c.bench_function("run_backtrack", |b| {
         b.iter(|| {
             let result = run_default(&p, "babab", 0).unwrap();
@@ -75,8 +77,8 @@ fn run_backtrack(c: &mut Criterion) {
 // implementations, see README.md:
 fn run_tricky(c: &mut Criterion) {
     let tree = Expr::parse_tree("(a|b|ab)*bc").unwrap();
-    let a = analyze(&tree).unwrap();
-    let p = compile(&a).unwrap();
+    let a = analyze(&tree, 1).unwrap();
+    let p = compile(&a, false).unwrap();
     let mut s = String::new();
     for _ in 0..28 {
         s.push_str("ab");
@@ -87,8 +89,8 @@ fn run_tricky(c: &mut Criterion) {
 
 fn run_backtrack_limit(c: &mut Criterion) {
     let tree = Expr::parse_tree("(?i)(a|b|ab)*(?=c)").unwrap();
-    let a = analyze(&tree).unwrap();
-    let p = compile(&a).unwrap();
+    let a = analyze(&tree, 1).unwrap();
+    let p = compile(&a, false).unwrap();
     let s = "abababababababababababababababababababababababababababab";
     c.bench_function("run_backtrack_limit", |b| {
         b.iter(|| run_default(&p, &s, 0).unwrap_err())

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -81,8 +81,8 @@ fn main() {
             let re = args.next().expect("expected regexp argument");
             let tree = Expr::parse_tree(&re).unwrap();
             let text = args.next().expect("expected text argument");
-            let a = analyze(&tree).unwrap();
-            let p = compile(&a).unwrap();
+            let a = analyze(&tree, 1).unwrap();
+            let p = compile(&a, true).unwrap();
             run_trace(&p, &text, 0).unwrap();
         } else if cmd == "graph" {
             let re = args.next().expect("expected regexp argument");
@@ -122,7 +122,7 @@ fn graph(re: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
 fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let tree = Expr::parse_tree(&re).unwrap();
     let wrapped_tree = wrap_tree(tree);
-    let a = analyze(&wrapped_tree);
+    let a = analyze(&wrapped_tree, 0);
     write!(writer, "{:#?}\n", a)
 }
 
@@ -134,8 +134,8 @@ fn show_compiled_program(re: &str, writer: &mut Formatter<'_>) -> Result {
 fn prog(re: &str) -> Prog {
     let tree = Expr::parse_tree(re).expect("Expected parsing regex to work");
     let wrapped_tree = wrap_tree(tree);
-    let result = analyze(&wrapped_tree).expect("Expected analyze to succeed");
-    compile(&result).expect("Expected compile to succeed")
+    let result = analyze(&wrapped_tree, 0).expect("Expected analyze to succeed");
+    compile(&result, false).expect("Expected compile to succeed")
 }
 
 struct AnalyzeFormatterWrapper<'a> {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -250,7 +250,9 @@ pub fn analyze<'a>(tree: &'a ExprTree, start_group: usize) -> Result<Info<'a>> {
     analyzed
 }
 
-/// Determine if the expression will always only ever match at position 0
+/// Determine if the expression will always only ever match at position 0.
+/// Note that false negatives are possible - it can return false even if it could be anchored.
+/// This should therefore only be treated as an optimization.
 pub fn can_compile_as_anchored(root_expr: &Expr) -> bool {
     use crate::Assertion;
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -714,6 +714,23 @@ mod tests {
         assert_matches!(prog[7], End);
     }
 
+    #[test]
+    fn lazy_any_can_be_compiled_explicit_capture_group_zero() {
+        let prog = compile_prog(r"\O*?((?!a))");
+
+        assert_eq!(prog.len(), 9, "prog: {:?}", prog);
+
+        assert_matches!(prog[0], Split(3, 1));
+        assert_matches!(prog[1], Any);
+        assert_matches!(prog[2], Jmp(0));
+        assert_matches!(prog[3], Save(0));
+        assert_matches!(prog[4], Split(5, 7));
+        assert_matches!(prog[5], Lit(ref l) if l == "a");
+        assert_matches!(prog[6], FailNegativeLookAround);
+        assert_matches!(prog[7], Save(1));
+        assert_matches!(prog[8], End);
+    }
+
     fn compile_prog(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
         let info = analyze(&tree).unwrap();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -531,7 +531,15 @@ pub fn compile(info: &Info<'_>, anchored: bool) -> Result<Prog> {
         c.b.add(Insn::Any);
         c.b.add(Insn::Jmp(0));
     }
+    if info.start_group == 1 {
+        // add implicit capture group 0 begin
+        c.b.add(Insn::Save(0));
+    }
     c.visit(info, false)?;
+    if info.start_group == 1 {
+        // add implicit capture group 0 end
+        c.b.add(Insn::Save(1));
+    }
     c.b.add(Insn::End);
     Ok(c.b.build())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ pub enum CompileError {
     /// Invalid group id in escape sequence
     InvalidGroupNameBackref(String),
     /// Invalid back reference
-    InvalidBackref,
+    InvalidBackref(usize),
     /// Once named groups are used you cannot refer to groups by number
     NamedBackrefOnly,
     /// Feature not supported yet
@@ -132,7 +132,7 @@ impl fmt::Display for CompileError {
             },
             CompileError::InvalidGroupName => write!(f, "Could not parse group name"),
             CompileError::InvalidGroupNameBackref(s) => write!(f, "Invalid group name in back reference: {}", s),
-            CompileError::InvalidBackref => write!(f, "Invalid back reference"),
+            CompileError::InvalidBackref(g) => write!(f, "Invalid back reference to group {}", g),
             CompileError::NamedBackrefOnly => write!(f, "Numbered backref/call not allowed because named group was used, use a named backref instead"),
             CompileError::FeatureNotYetSupported(s) => write!(f, "Regex uses currently unimplemented feature: {}", s),
             CompileError::SubroutineCallTargetNotFound(s, ix) => {

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -76,7 +76,7 @@ impl Expander {
             } else if num < regex.captures_len() {
                 Ok(())
             } else {
-                Err(Error::CompileError(CompileError::InvalidBackref))
+                Err(Error::CompileError(CompileError::InvalidBackref(num)))
             }
         };
         self.exec(template, |step| match step {
@@ -87,7 +87,9 @@ impl Expander {
                 } else if let Ok(num) = name.parse() {
                     on_group_num(num)
                 } else {
-                    Err(Error::CompileError(CompileError::InvalidBackref))
+                    Err(Error::CompileError(CompileError::InvalidGroupNameBackref(
+                        name.to_string(),
+                    )))
                 }
             }
             Step::GroupNum(num) => on_group_num(num),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,10 +741,6 @@ impl Regex {
             });
         }
 
-        // wrapper to capture the match bounds
-        let tree = wrap_tree(tree);
-        let info = analyze(&tree, 0)?;
-
         let prog = compile(&info, false)?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
@@ -1851,14 +1847,6 @@ pub fn detect_possible_backref(re: &str) -> bool {
     }
 }
 */
-
-/// wrap in explicit capture group 0 to capture the match bounds
-pub fn wrap_tree(raw_tree: ExprTree) -> ExprTree {
-    return ExprTree {
-        expr: Expr::Concat(vec![Expr::Group(Box::new(raw_tree.expr))]),
-        ..raw_tree
-    };
-}
 
 /// The internal module only exists so that the toy example can access internals for debugging and
 /// experimenting.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ mod replacer;
 mod vm;
 
 use crate::analyze::analyze;
+use crate::analyze::can_compile_as_anchored;
 use crate::compile::compile;
 use crate::flags::*;
 use crate::parse::{ExprTree, NamedGroups, Parser};
@@ -741,17 +742,7 @@ impl Regex {
             });
         }
 
-        let anchored = match tree.expr {
-            Expr::Concat(ref children) => {
-                match children[0] {
-                    Expr::Assertion(assertion) => assertion == Assertion::StartText,
-                    _ => false,
-                }
-            }
-            Expr::Assertion(assertion) => assertion == Assertion::StartText,
-            _ => false,
-        };
-        let prog = compile(&info, anchored)?;
+        let prog = compile(&info, can_compile_as_anchored(&tree.expr))?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
                 prog,
@@ -1862,7 +1853,7 @@ pub fn detect_possible_backref(re: &str) -> bool {
 /// experimenting.
 #[doc(hidden)]
 pub mod internal {
-    pub use crate::analyze::analyze;
+    pub use crate::analyze::{analyze, can_compile_as_anchored};
     pub use crate::compile::compile;
     pub use crate::vm::{run_default, run_trace, Insn, Prog};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,17 @@ impl Regex {
             });
         }
 
-        let prog = compile(&info, false)?;
+        let anchored = match tree.expr {
+            Expr::Concat(ref children) => {
+                match children[0] {
+                    Expr::Assertion(assertion) => assertion == Assertion::StartText,
+                    _ => false,
+                }
+            }
+            Expr::Assertion(assertion) => assertion == Assertion::StartText,
+            _ => false,
+        };
+        let prog = compile(&info, anchored)?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
                 prog,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,29 +724,16 @@ impl Regex {
     }
 
     fn new_options(options: RegexOptions) -> Result<Regex> {
-        let raw_tree = Expr::parse_tree_with_flags(&options.pattern, options.compute_flags())?;
+        let tree = Expr::parse_tree_with_flags(&options.pattern, options.compute_flags())?;
 
-        // wrapper to search for re at arbitrary start position,
-        // and to capture the match bounds
-        let tree = wrap_tree(raw_tree);
+        let info = analyze(&tree, 1)?;
 
-        let info = analyze(&tree)?;
-
-        let inner_info = &info.children[1].children[0]; // references inner expr
-        if !inner_info.hard {
+        if !info.hard {
             // easy case, wrap regex
 
             // we do our own to_str because escapes are different
             let mut re_cooked = String::new();
-            // same as raw_tree.expr above, but it was moved, so traverse to find it
-            let raw_e = match tree.expr {
-                Expr::Concat(ref v) => match v[1] {
-                    Expr::Group(ref child) => child,
-                    _ => unreachable!(),
-                },
-                _ => unreachable!(),
-            };
-            raw_e.to_str(&mut re_cooked, 0);
+            tree.expr.to_str(&mut re_cooked, 0);
             let inner = compile::compile_inner(&re_cooked, &options)?;
             return Ok(Regex {
                 inner: RegexImpl::Wrap { inner, options },
@@ -754,7 +741,11 @@ impl Regex {
             });
         }
 
-        let prog = compile(&info)?;
+        // wrapper to capture the match bounds
+        let tree = wrap_tree(tree);
+        let info = analyze(&tree, 0)?;
+
+        let prog = compile(&info, false)?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
                 prog,
@@ -1861,19 +1852,10 @@ pub fn detect_possible_backref(re: &str) -> bool {
 }
 */
 
-/// wrapper to search for re at arbitrary start position,
-/// and to capture the match bounds
+/// wrap in explicit capture group 0 to capture the match bounds
 pub fn wrap_tree(raw_tree: ExprTree) -> ExprTree {
     return ExprTree {
-        expr: Expr::Concat(vec![
-            Expr::Repeat {
-                child: Box::new(Expr::Any { newline: true }),
-                lo: 0,
-                hi: usize::MAX,
-                greedy: false,
-            },
-            Expr::Group(Box::new(raw_tree.expr)),
-        ]),
+        expr: Expr::Concat(vec![Expr::Group(Box::new(raw_tree.expr))]),
         ..raw_tree
     };
 }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -363,20 +363,18 @@ fn expander_errors() {
     // Unmatched group number.
     assert_err!(
         exp.check("$2", &without_names),
-        Error::CompileError(CompileError::InvalidBackref)
+        Error::CompileError(CompileError::InvalidBackref(2))
     );
     assert_err!(
         exp.check("${2}", &without_names),
-        Error::CompileError(CompileError::InvalidBackref)
+        Error::CompileError(CompileError::InvalidBackref(2))
     );
 
     // Unmatched group name.
-    assert_err!(
-        exp.check("$xx", &with_names),
-        Error::CompileError(CompileError::InvalidBackref)
+    assert!(
+        matches!(exp.check("$xx", &with_names), Err(Error::CompileError(CompileError::InvalidGroupNameBackref(ref name))) if name == "xx"),
     );
-    assert_err!(
+    assert!(matches!(
         exp.check("${xx}", &with_names),
-        Error::CompileError(CompileError::InvalidBackref)
-    );
+        Err(Error::CompileError(CompileError::InvalidGroupNameBackref(ref name))) if name == "xx"));
 }

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -82,9 +82,6 @@
   // No match found
   x3("((?m:a.c))", "a\nc", 0, 3, 1);
 
-  // Compile failed: CompileError(InvalidBackref)
-  x2("(?:(?:\\1|z)(a))+$", "zaaa", 0, 4);
-
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(a)\\g<1>", "aa", 0, 2);
 
@@ -160,7 +157,7 @@
   // No match found
   x2("(?:()|())*\\1\\2", "", 0, 0);
 
-  // Compile failed: CompileError(InvalidBackref)
+  // Expected group to exist
   x3("(?:\\1a|())*", "a", 0, 0, 1);
 
   // No match found
@@ -180,9 +177,6 @@
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("(?i)\\A(a|b\\g<1>c)\\k<1+2>\\z", "bBACcbac", 0, 8);
-
-  // Compile failed: CompileError(InvalidBackref)
-  x2("(?:\\k'+1'B|(A)C)*", "ACAB", 0, 4);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Subroutine Call"))
   x2("\\g<+2>(abc)(ABC){0}", "ABCabc", 0, 6);


### PR DESCRIPTION
as discussed in #167, this PR removes the need to wrap the `ExprTree` to get the match bounds or allow the match to start at any position. This opens up the optimization to perform an anchored search when the regex pattern begins with `^` meaning start of text (as opposed to start of line), by not emitting instructions to bump the index in the haystack. The end result being that it should fail faster for non-matches. (I'm leaving it as a future optimization to let regex-automata perform unanchored regex searches for the first `Delegate` etc.)

- instead of prepending `(?m:.*?)` to the `ExprTree`, add the instructions at compile time

Other changes:
- also ensure that benchmarks compile as part of CI
- the CompileError for an invalid (numbered) backref has been updated to mention which backref was invalid
- fixed a bug whereby sometimes a capture group containing a backref to itself would cause a compile error, when it is valid - this fixes a few Oniguruma test cases