### PR TITLE
Trailing positive lookahead optimization including wrap elimination

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [raphlinus, robinst]
+github: [raphlinus, robinst, keith-hall]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: cp Cargo.lock.msrv Cargo.lock
 
       - run: cargo test
+      - run: cargo test --no-default-features
 
   example:
     name: example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Added
+- Add an optimization step after the pattern is parsed but before it is analyzed.
+  Currently it only optimizes one specific use-case - where the expression is easy except
+  for a trailing positive lookahead whose contents are also easy. The optimization is to avoid the VM.
+
 ## [0.15.0] - 2025-07-06
 ### Added
 - Support `\Z` - anchor to the end of the text before any trailing newlines. (#148)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ with the exception that 0.x versions can break between minor versions.
 ### Added
 - Add an optimization step after the pattern is parsed but before it is analyzed.
   Currently it only optimizes one specific use-case - where the expression is easy except
-  for a trailing positive lookahead whose contents are also easy. The optimization is to avoid the VM.
+  for a trailing positive lookahead whose contents are also easy. The optimization is to delegate to the regex crate instead of using the backtracking VM.
 
 ## [0.15.0] - 2025-07-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ with the exception that 0.x versions can break between minor versions.
 - Add an optimization step after the pattern is parsed but before it is analyzed.
   Currently it only optimizes one specific use-case - where the expression is easy except
   for a trailing positive lookahead whose contents are also easy. The optimization is to delegate to the regex crate instead of using the backtracking VM.
+### Changed
+- Patterns which are anchored to the start of the text (i.e. with `^` when not in multiline mode) should now fail faster when there is no match, because `fancy-regex` no longer tries to match at other positions.
+- The `CompileError` for an invalid (numbered) backref has been updated to mention which backref was invalid
+### Fixed
+- Fixed a bug whereby sometimes a capture group containing a backref to itself would cause a compile error, when it is valid - this fixes a few Oniguruma test cases
 
 ## [0.15.0] - 2025-07-06
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fancy-regex"
 version = "0.15.0"
-authors = ["Raph Levien <raph@google.com>", "Robin Stocker <robin@nibor.org>"]
+authors = ["Raph Levien <raph@google.com>", "Robin Stocker <robin@nibor.org>", "Keith Hall <keith.hall@available.systems>"]
 edition = "2018"
 license = "MIT"
 description = "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around."

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ creating the excellent regex crate.
 
 ## Authors
 
-The main author is Raph Levien, with many contributions from Robin Stocker.
+The main author is Raph Levien, with many contributions from Robin Stocker
+and Keith Hall.
 
 ## Contributions
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -86,7 +86,7 @@ fn run_tricky(c: &mut Criterion) {
 }
 
 fn run_backtrack_limit(c: &mut Criterion) {
-    let tree = Expr::parse_tree("(?i)(a|b|ab)*(?=c)").unwrap();
+    let tree = Expr::parse_tree("(?i)(a|b|ab)*(?>c)").unwrap();
     let a = analyze(&tree).unwrap();
     let p = compile(&a).unwrap();
     let s = "abababababababababababababababababababababababababababab";

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -126,7 +126,7 @@ fn graph(re: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
 fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let tree = Expr::parse_tree(&re).unwrap();
     let wrapped_tree = wrap_tree(tree);
-    let (optimized_tree, _) = optimize(wrapped_tree).expect("Expected optimization to succeed");
+    let (optimized_tree, _) = optimize(wrapped_tree);
     let a = analyze(&optimized_tree);
     write!(writer, "{:#?}\n", a)
 }
@@ -142,7 +142,7 @@ fn prog(re: &str) -> Prog {
     // which means that "toy" behaves differently to tests etc.
     let tree = Expr::parse_tree(re).expect("Expected parsing regex to work");
     let wrapped_tree = wrap_tree(tree);
-    let (optimized_tree, _) = optimize(wrapped_tree).expect("Expected optimization to succeed");
+    let (optimized_tree, _) = optimize(wrapped_tree);
     let result = analyze(&optimized_tree).expect("Expected analyze to succeed");
     compile(&result).expect("Expected compile to succeed")
 }

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -20,7 +20,9 @@
 
 //! A simple test app for exercising and debugging the regex engine.
 
-use fancy_regex::internal::{analyze, can_compile_as_anchored, compile, optimize, run_trace, Insn, Prog};
+use fancy_regex::internal::{
+    analyze, can_compile_as_anchored, compile, optimize, run_trace, Insn, Prog,
+};
 use fancy_regex::*;
 use std::env;
 use std::fmt::{Display, Formatter, Result};
@@ -143,7 +145,8 @@ fn prog(re: &str, start_group: usize) -> Prog {
     // TODO: ideally don't clone the tree unnecessarily - it is cloned in optimize if needed
     let (optimized_tree, _) = optimize(tree.clone());
     let result = analyze(&optimized_tree, start_group).expect("Expected analyze to succeed");
-    compile(&result, can_compile_as_anchored(&optimized_tree.expr)).expect("Expected compile to succeed")
+    compile(&result, can_compile_as_anchored(&optimized_tree.expr))
+        .expect("Expected compile to succeed")
 }
 
 struct AnalyzeFormatterWrapper<'a> {

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -277,9 +277,16 @@ digraph G {
 
     #[test]
     fn test_compilation_wrapped_debug_output_explict_capture_group_zero() {
-        let expected = "wrapped Regex \"a+b(?=c)\", explicit_capture_group_0: true";
+        let expected = "wrapped Regex \"(a+b)c\", explicit_capture_group_0: true";
 
         assert_compiled_prog("a+b(?=c)", &expected);
+    }
+
+    #[test]
+    fn test_compilation_wrapped_debug_output_explict_capture_group_zero_with_non_capture_group() {
+        let expected = "wrapped Regex \"(a+b)(?:c|d)\", explicit_capture_group_0: true";
+
+        assert_compiled_prog("a+b(?=c|d)", &expected);
     }
 
     fn assert_graph(re: &str, expected: &str) {

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -270,9 +270,16 @@ digraph G {
 
     #[test]
     fn test_compilation_wrapped_debug_output() {
-        let expected = "wrapped Regex \"a+bc?\"";
+        let expected = "wrapped Regex \"a+bc?\", explicit_capture_group_0: false";
 
         assert_compiled_prog("a+bc?", &expected);
+    }
+
+    #[test]
+    fn test_compilation_wrapped_debug_output_explict_capture_group_zero() {
+        let expected = "wrapped Regex \"a+b(?=c)\", explicit_capture_group_0: true";
+
+        assert_compiled_prog("a+b(?=c)", &expected);
     }
 
     fn assert_graph(re: &str, expected: &str) {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -268,7 +268,7 @@ pub fn can_compile_as_anchored(root_expr: &Expr) -> bool {
 mod tests {
     use super::analyze;
     // use super::literal_const_size;
-    use crate::{CompileError, Error, Expr, can_compile_as_anchored};
+    use crate::{can_compile_as_anchored, CompileError, Error, Expr};
 
     // #[test]
     // fn case_folding_safe() {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -251,9 +251,7 @@ pub fn analyze<'a>(tree: &'a ExprTree) -> Result<Info<'a>> {
 mod tests {
     use super::analyze;
     // use super::literal_const_size;
-    use crate::CompileError;
-    use crate::Error;
-    use crate::Expr;
+    use crate::{CompileError, Error, Expr};
 
     // #[test]
     // fn case_folding_safe() {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -620,6 +620,7 @@ mod tests {
             backrefs: BitSet::new(),
             named_groups: Default::default(),
             contains_subroutines: false,
+            self_recursive: false,
         };
         let info = analyze(&tree).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,10 +752,7 @@ impl Regex {
                     inner,
                     options: RegexOptions {
                         pattern: re_cooked.clone(),
-                        syntaxc: options.syntaxc,
-                        backtrack_limit: options.backtrack_limit,
-                        delegate_size_limit: options.delegate_size_limit,
-                        delegate_dfa_size_limit: options.delegate_dfa_size_limit,
+                        ..options
                     },
                     explicit_capture_group_0: requires_capture_group_fixup,
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,10 +733,10 @@ impl Regex {
     }
 
     fn new_options(options: RegexOptions) -> Result<Regex> {
-        let tree = Expr::parse_tree_with_flags(&options.pattern, options.compute_flags())?;
+        let mut tree = Expr::parse_tree_with_flags(&options.pattern, options.compute_flags())?;
 
         // try to optimize the expression tree
-        let (tree, requires_capture_group_fixup) = optimize(tree);
+        let requires_capture_group_fixup = optimize(&mut tree);
         let info = analyze(&tree, if requires_capture_group_fixup { 0 } else { 1 })?;
 
         if !info.hard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ impl Regex {
         // - and capture the match bounds
         // try to optimize the expression tree
         let tree = wrap_tree(raw_tree);
-        let (tree, requires_capture_group_fixup) = optimize(tree)?;
+        let (tree, requires_capture_group_fixup) = optimize(tree);
         let info = analyze(&tree)?;
 
         if !info.hard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ enum RegexImpl {
     Wrap {
         inner: RaRegex,
         options: RegexOptions,
+        /// Some optimizations avoid the VM, but need to use an extra capture group to represent the match boundaries
         explicit_capture_group_0: bool,
     },
     Fancy {
@@ -411,6 +412,9 @@ enum CapturesImpl<'t> {
     Wrap {
         text: &'t str,
         locations: RaCaptures,
+        /// Some optimizations avoid the VM but need an extra capture group to represent the match boundaries.
+        /// Therefore what is actually capture group 1 should be treated as capture group 0, and all other
+        /// capture groups should have their index reduced by one as well to line up with what the pattern specifies.
         explicit_capture_group_0: bool,
     },
     Fancy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -761,6 +761,7 @@ impl Regex {
             } else {
                 match tree.expr {
                     Expr::Concat(ref v) => {
+                        // skip the `(?s:.)*?` at the beginning of the regex, we don't need it when delegating
                         for expr in v.iter().skip(1) {
                             expr.to_str(&mut re_cooked, 2);
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2057,30 +2057,29 @@ mod tests {
     fn trailing_positive_lookahead_wrap_capture_group_fixup() {
         let s = r"(a+)(?=c)";
         let regex = s.parse::<Regex>().unwrap();
-        match regex.inner {
-            RegexImpl::WrapCaptureFixup { .. } => {},
-            _ => panic!("trailing positive lookahead for an otherwise easy pattern should avoid going through the VM"),
-        }
+        assert!(matches!(regex.inner,
+            RegexImpl::WrapCaptureFixup { .. }),
+            "trailing positive lookahead for an otherwise easy pattern should avoid going through the VM");
     }
 
     #[test]
     fn easy_regex() {
         let s = r"(a+)b";
         let regex = s.parse::<Regex>().unwrap();
-        match regex.inner {
-            RegexImpl::Wrap { .. } => {}
-            _ => panic!("easy pattern should avoid going through the VM"),
-        }
+        assert!(
+            matches!(regex.inner, RegexImpl::Wrap { .. }),
+            "easy pattern should avoid going through the VM"
+        );
     }
 
     #[test]
     fn hard_regex() {
         let s = r"(a+)(?>c)";
         let regex = s.parse::<Regex>().unwrap();
-        match regex.inner {
-            RegexImpl::Fancy { .. } => {}
-            _ => panic!("hard regex should be compiled into a VM"),
-        }
+        assert!(
+            matches!(regex.inner, RegexImpl::Fancy { .. }),
+            "hard regex should be compiled into a VM"
+        );
     }
 
     /*

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -49,26 +49,24 @@ fn optimize_trailing_lookahead(tree: &mut ExprTree) -> bool {
     // to `(a)b`
 
     if let Expr::Concat(ref mut root_concat_children) = tree.expr {
-        if let Some(last_child_of_root_concat) = &mut root_concat_children.last_mut() {
-            // we get the last child if it is a positive lookahead
-            if let Expr::LookAround(_, LookAround::LookAhead) = &last_child_of_root_concat {
-                // then pop the lookahead
-                let lookahead_expr = root_concat_children
-                    .pop()
-                    .expect("lookaround should be popped");
-                // take the rest of the children from the original Concat
-                let group0_children = mem::take(root_concat_children);
+        // we get the last child if it is a positive lookahead
+        if let Some(Expr::LookAround(_, LookAround::LookAhead)) = root_concat_children.last() {
+            // then pop the lookahead
+            let lookahead_expr = root_concat_children
+                .pop()
+                .expect("lookaround should be popped");
+            // take the rest of the children from the original Concat
+            let group0_children = mem::take(root_concat_children);
 
-                // extract the inner expression from the lookahead
-                if let Expr::LookAround(inner, LookAround::LookAhead) = lookahead_expr {
-                    let group0 = Expr::Group(Box::new(Expr::Concat(group0_children)));
-                    // compose new Concat: [Group0, lookahead inner expr]
-                    let new_concat = Expr::Concat(vec![group0, *inner]);
-                    tree.expr = new_concat;
-                    return true;
-                } else {
-                    unreachable!("already check it is a lookahead");
-                }
+            // extract the inner expression from the lookahead
+            if let Expr::LookAround(inner, LookAround::LookAhead) = lookahead_expr {
+                let group0 = Expr::Group(Box::new(Expr::Concat(group0_children)));
+                // compose new Concat: [Group0, lookahead inner expr]
+                let new_concat = Expr::Concat(vec![group0, *inner]);
+                tree.expr = new_concat;
+                return true;
+            } else {
+                unreachable!("already checked it is a lookahead");
             }
         }
     } else if let Expr::LookAround(ref mut inner, LookAround::LookAhead) = &mut tree.expr {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,0 +1,141 @@
+// Copyright 2025 The Fancy Regex Authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Optimization of regex expressions.
+
+use crate::parse::ExprTree;
+use crate::LookAround;
+use crate::{Expr, Result};
+
+/// Rewrite the expression tree to help the VM compile an efficient program.
+/// Expects the tree to have been wrapped ready for the VM, such that the first capture group will be 0.
+pub fn optimize(tree: ExprTree) -> Result<(ExprTree, bool)> {
+    // self recursion prevents us from moving the trailing lookahead out of group 0
+    if !tree.self_recursive {
+        let mut optimized_tree = tree.clone();
+        let requires_capture_group_fixup = optimize_trailing_lookahead(&mut optimized_tree)?;
+        Ok((optimized_tree, requires_capture_group_fixup))
+    } else {
+        Ok((tree, false))
+    }
+}
+
+fn optimize_trailing_lookahead(tree: &mut ExprTree) -> Result<bool> {
+    // returns a boolean to say whether the optimization was applied.
+    // - if it was applied, capture group 0 is no longer implicit, but explicit
+    //   if/when the whole expression gets delegated to regex-automata
+    // converts i.e. original pattern `a(?=b)` when wrapped in the capture group 0
+    // as `(?s:.)*?(a(?=b))`
+    // to `(?s:.)*?(a)b`
+
+    // here we traverse the tree to find capture group 0
+    // we start with the root concat, and get the last child
+    if let Expr::Concat(ref mut root_concat_children) = tree.expr {
+        if let Some(last_child_of_root_concat) = &mut root_concat_children.last_mut() {
+            // we get the last child if it is a capture group
+            if let Expr::Group(ref mut inner) = last_child_of_root_concat {
+                // if the inner expression to the capture group is a concatenation
+                if let Expr::Concat(ref mut children) = **inner {
+                    // whose last child is a positive lookahead
+                    if let Some(Expr::LookAround(_, LookAround::LookAhead)) = &children.last_mut() {
+                        // then pop the lookahead and attach the inner expression to the root concat
+                        // after capture group 0 ends
+                        let inner_box = children.pop().expect("lookaround should be popped");
+                        if let Expr::LookAround(inner, LookAround::LookAhead) = inner_box {
+                            root_concat_children.push(*inner);
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::optimize;
+    use crate::parse::make_literal;
+    use crate::{wrap_tree, Expr};
+
+    #[test]
+    fn trailing_positive_lookahead_optimized() {
+        let tree = Expr::parse_tree("a(?=b)").unwrap();
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrap_tree(tree)).unwrap();
+        assert_eq!(requires_capture_group_fixup, true);
+        let mut s = String::new();
+        optimized_tree.expr.to_str(&mut s, 0);
+        assert_eq!(s, "(?s:.)*?(a)b");
+    }
+
+    #[test]
+    fn trailing_positive_lookahead_moved_even_if_not_easy() {
+        let tree = Expr::parse_tree(r"(a)\1(?=c)").unwrap();
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrap_tree(tree)).unwrap();
+        assert_eq!(requires_capture_group_fixup, true);
+        assert_eq!(
+            optimized_tree.expr,
+            Expr::Concat(vec![
+                Expr::Repeat {
+                    child: Box::new(Expr::Any { newline: true }),
+                    lo: 0,
+                    hi: usize::MAX,
+                    greedy: false
+                },
+                Expr::Group(Box::new(Expr::Concat(vec![
+                    Expr::Group(Box::new(make_literal("a"))),
+                    Expr::Backref {
+                        group: 1,
+                        casei: false
+                    }
+                ]))),
+                make_literal("c"),
+            ])
+        );
+    }
+
+    #[test]
+    fn trailing_positive_lookahead_left_alone_when_self_recursive() {
+        let wrapped_tree = wrap_tree(Expr::parse_tree(r"ab?\g<0>?(?=a|$)").unwrap());
+        let (optimized_tree, requires_capture_group_fixup) =
+            optimize(wrapped_tree.clone()).unwrap();
+        assert_eq!(requires_capture_group_fixup, false);
+        assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
+    }
+
+    #[test]
+    fn trailing_negative_lookahead_left_alone() {
+        let wrapped_tree = wrap_tree(Expr::parse_tree(r"a(?!b)").unwrap());
+        let (optimized_tree, requires_capture_group_fixup) =
+            optimize(wrapped_tree.clone()).unwrap();
+        assert_eq!(requires_capture_group_fixup, false);
+        assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
+    }
+
+    #[test]
+    fn trailing_positive_lookbehind_left_alone() {
+        let wrapped_tree = wrap_tree(Expr::parse_tree(r"(?<=b)").unwrap());
+        let (optimized_tree, requires_capture_group_fixup) =
+            optimize(wrapped_tree.clone()).unwrap();
+        assert_eq!(requires_capture_group_fixup, false);
+        assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
+    }
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -87,6 +87,16 @@ mod tests {
     }
 
     #[test]
+    fn trailing_positive_lookahead_with_alternative_optimized() {
+        let tree = Expr::parse_tree("a(?=b|c)").unwrap();
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrap_tree(tree)).unwrap();
+        assert_eq!(requires_capture_group_fixup, true);
+        let mut s = String::new();
+        optimized_tree.expr.to_str(&mut s, 0);
+        assert_eq!(s, "(?s:.)*?(a)(?:b|c)");
+    }
+
+    #[test]
     fn trailing_positive_lookahead_moved_even_if_not_easy() {
         let tree = Expr::parse_tree(r"(a)\1(?=c)").unwrap();
         let (optimized_tree, requires_capture_group_fixup) = optimize(wrap_tree(tree)).unwrap();

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -21,8 +21,8 @@
 //! Optimization of regex expressions.
 
 use crate::parse::ExprTree;
-use crate::LookAround;
 use crate::Expr;
+use crate::LookAround;
 
 /// Rewrite the expression tree to help the VM compile an efficient program.
 /// Expects the tree to have been wrapped ready for the VM, such that the first capture group will be 0.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -22,7 +22,7 @@
 
 use crate::parse::ExprTree;
 use crate::LookAround;
-use crate::{Expr, Result};
+use crate::Expr;
 
 /// Rewrite the expression tree to help the VM compile an efficient program.
 /// Expects the tree to have been wrapped ready for the VM, such that the first capture group will be 0.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -125,8 +125,7 @@ mod tests {
     #[test]
     fn trailing_positive_lookahead_left_alone_when_self_recursive() {
         let wrapped_tree = wrap_tree(Expr::parse_tree(r"ab?\g<0>?(?=a|$)").unwrap());
-        let (optimized_tree, requires_capture_group_fixup) =
-            optimize(wrapped_tree.clone());
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrapped_tree.clone());
         assert_eq!(requires_capture_group_fixup, false);
         assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
     }
@@ -134,8 +133,7 @@ mod tests {
     #[test]
     fn trailing_negative_lookahead_left_alone() {
         let wrapped_tree = wrap_tree(Expr::parse_tree(r"a(?!b)").unwrap());
-        let (optimized_tree, requires_capture_group_fixup) =
-            optimize(wrapped_tree.clone());
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrapped_tree.clone());
         assert_eq!(requires_capture_group_fixup, false);
         assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
     }
@@ -143,8 +141,7 @@ mod tests {
     #[test]
     fn trailing_positive_lookbehind_left_alone() {
         let wrapped_tree = wrap_tree(Expr::parse_tree(r"(?<=b)").unwrap());
-        let (optimized_tree, requires_capture_group_fixup) =
-            optimize(wrapped_tree.clone());
+        let (optimized_tree, requires_capture_group_fixup) = optimize(wrapped_tree.clone());
         assert_eq!(requires_capture_group_fixup, false);
         assert_eq!(&optimized_tree.expr, &wrapped_tree.expr);
     }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -201,12 +201,14 @@ fn captures_from_pos_looking_left() {
 #[test]
 fn captures_iter_collect_when_backtrack_limit_hit() {
     use fancy_regex::RegexBuilder;
-    let r = RegexBuilder::new("(x+x+)+(?=y)")
+    let r = RegexBuilder::new("(x+x+)+(?>y)")
         .backtrack_limit(1)
         .build()
         .unwrap();
     let result: Vec<_> = r.captures_iter("xxxxxxxxxxy").collect();
+    println!("{:?}", result);
     assert_eq!(result.len(), 1);
+    assert!(result[0].is_err());
 }
 
 #[cfg_attr(feature = "track_caller", track_caller)]

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -92,7 +92,7 @@ fn atomic_group() {
 
 #[test]
 fn backtrack_limit() {
-    let re = RegexBuilder::new("(?i)(a|b|ab)*(?=c)")
+    let re = RegexBuilder::new("(?i)(a|b|ab)*(?>c)")
         .backtrack_limit(100_000)
         .build()
         .unwrap();

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -180,6 +180,23 @@ fn backrefs() {
     assert_no_match(r"(.)(?i:\1)", "įĖ");
 }
 
+#[test]
+fn easy_trailing_positive_lookaheads() {
+    assert_match(r"(?=c)", "abcabc");
+    assert_match(r"abc(?=abc)", "abcabc");
+    assert_no_match(r"abc(?=abc)", "abcdef");
+    assert_match(r"abc(?=a|b)", "abcabc");
+    assert_no_match(r"abc(?=a|f)", "f");
+}
+
+#[test]
+fn hard_trailing_positive_lookaheads() {
+    assert_match(r"(abc|def)(?=\1)", "defdef");
+    assert_match(r"(abc|def)(?=a(?!b))", "abca");
+    assert_match(r"(abc|def)(?=a(?!b))", "abcaa");
+    assert_no_match(r"(abc|def)(?=a(?!b))", "abcabc");
+}
+
 #[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_match(re: &str, text: &str) {
     let result = match_text(re, text);


### PR DESCRIPTION
Basically combines https://github.com/fancy-regex/fancy-regex/pull/167 and https://github.com/fancy-regex/fancy-regex/pull/170 (and adapts the trailing lookahead optimization now that the `ExprTree` isn't wrapped) - as I had made those PRs from my fork, it wasn't trivial to stack them...