### PR TITLE
Fix behavior of repetition on an empty match

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -645,7 +645,7 @@ pub(crate) fn run(
                     check,
                 } => {
                     let repcount = state.get(repeat);
-                    if repcount > lo && state.get(check) == ix {
+                    if repcount > 0 && state.get(check) == ix {
                         // zero-length match on repeat, then move to next instruction
                         pc = next;
                         continue;
@@ -663,9 +663,10 @@ pub(crate) fn run(
                     check,
                 } => {
                     let repcount = state.get(repeat);
-                    if repcount > lo && state.get(check) == ix {
-                        // prevent zero-length match on repeat
-                        break 'fail;
+                    if repcount > 0 && state.get(check) == ix {
+                        // zero-length match on repeat, then move to next instruction
+                        pc = next;
+                        continue;
                     }
                     state.save(repeat, repcount + 1);
                     if repcount >= lo {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -646,8 +646,9 @@ pub(crate) fn run(
                 } => {
                     let repcount = state.get(repeat);
                     if repcount > lo && state.get(check) == ix {
-                        // prevent zero-length match on repeat
-                        break 'fail;
+                        // zero-length match on repeat, then move to next instruction
+                        pc = next;
+                        continue;
                     }
                     state.save(repeat, repcount + 1);
                     if repcount >= lo {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -285,14 +285,23 @@ fn find_iter_empty_repeat_issue70() {
     assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*");
 }
 
+#[test]
 fn find_iter_collect_when_backtrack_limit_hit() {
+    use fancy_regex::Error;
     use fancy_regex::RegexBuilder;
-    let r = RegexBuilder::new("(x+x+)+(?=y)")
+    use fancy_regex::RuntimeError;
+
+    let r = RegexBuilder::new("(x+x+)+(?>y)")
         .backtrack_limit(1)
         .build()
         .unwrap();
     let result: Vec<_> = r.find_iter("xxxxxxxxxxy").collect();
     assert_eq!(result.len(), 1);
+    assert!(result[0].is_err());
+    match &result[0].as_ref().err() {
+        Some(Error::RuntimeError(RuntimeError::BacktrackLimitExceeded)) => {}
+        _ => panic!("Expected RuntimeError::BacktrackLimitExceeded"),
+    }
 }
 
 #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -283,8 +283,62 @@ fn find_iter_empty_repeat_issue70() {
 
     assert_expected_matches(r"(?m)(?:^|a)+");
     assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*");
-    assert_expected_matches(r"(?m)(?>^|a)+");
-    assert_expected_matches(r"(?m)(?>^|a)(?:^|a)*");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)+");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)(?:^|a)*");
+}
+
+#[test]
+fn find_iter_empty_repeat_non_greedy_issue70() {
+    fn assert_expected_matches(pattern: &str) {
+        let text = "a\naaa\n";
+        let regex = common::regex(pattern);
+
+        let matches: Vec<_> = regex.find_iter(text).collect();
+        assert_eq!(matches.len(), 5);
+
+        for i in 0..matches.len() {
+            let mat = &matches[i].as_ref().unwrap();
+            match i {
+                0 => assert_eq!((mat.start(), mat.end()), (0, 0)),
+                1 => assert_eq!((mat.start(), mat.end()), (2, 2)),
+                2 => assert_eq!((mat.start(), mat.end()), (3, 4)),
+                3 => assert_eq!((mat.start(), mat.end()), (4, 5)),
+                4 => assert_eq!((mat.start(), mat.end()), (6, 6)),
+                i => panic!("Expected 4 results, got {}", i + 1),
+            }
+        }
+    }
+
+    assert_expected_matches(r"(?m)(?:^|a)+?");
+    assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*?");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)+?");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)(?:^|a)*?");
+}
+
+#[test]
+fn find_iter_empty_repeat_anchored_non_greedy_issue70() {
+    fn assert_expected_matches(pattern: &str) {
+        let text = "a\naaa\n";
+        let regex = common::regex(pattern);
+
+        let matches: Vec<_> = regex.find_iter(text).collect();
+        assert_eq!(matches.len(), 3);
+
+        for i in 0..matches.len() {
+            let mat = &matches[i].as_ref().unwrap();
+            match i {
+                0 => assert_eq!((mat.start(), mat.end()), (0, 1)),
+                1 => assert_eq!((mat.start(), mat.end()), (2, 5)),
+                2 => assert_eq!((mat.start(), mat.end()), (6, 6)),
+                i => panic!("Expected 4 results, got {}", i + 1),
+            }
+        }
+    }
+
+    assert_expected_matches(r"(?m)(?:^|a)+?$");
+    assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*?$");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)+?$");
+    assert_expected_matches(r"(?m)(?>)(?:^|a)(?:^|a)*?$");
 }
 
 #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -283,6 +283,8 @@ fn find_iter_empty_repeat_issue70() {
 
     assert_expected_matches(r"(?m)(?:^|a)+");
     assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*");
+    assert_expected_matches(r"(?m)(?>^|a)+");
+    assert_expected_matches(r"(?m)(?>^|a)(?:^|a)*");
 }
 
 #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -261,6 +261,30 @@ fn find_iter_attributes() {
 }
 
 #[test]
+fn find_iter_empty_repeat_issue70() {
+    fn assert_expected_matches(pattern: &str) {
+        let text = "a\naaa\n";
+        let regex = common::regex(pattern);
+
+        let matches: Vec<_> = regex.find_iter(text).collect();
+        assert_eq!(matches.len(), 4);
+
+        for i in 0..matches.len() {
+            let mat = &matches[i].as_ref().unwrap();
+            match i {
+                0 => assert_eq!((mat.start(), mat.end()), (0, 0)),
+                1 => assert_eq!((mat.start(), mat.end()), (2, 2)),
+                2 => assert_eq!((mat.start(), mat.end()), (3, 5)),
+                3 => assert_eq!((mat.start(), mat.end()), (6, 6)),
+                i => panic!("Expected 4 results, got {}", i + 1),
+            }
+        }
+    }
+
+    assert_expected_matches(r"(?m)(?:^|a)+");
+    assert_expected_matches(r"(?m)(?:^|a)(?:^|a)*");
+}
+
 fn find_iter_collect_when_backtrack_limit_hit() {
     use fancy_regex::RegexBuilder;
     let r = RegexBuilder::new("(x+x+)+(?=y)")

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -152,13 +152,7 @@
   x2("(?<pare>\\(([^\\(\\)]++|\\g<pare>)*+\\))", "((a))", 0, 5);
 
   // No match found
-  x2("()*\\1", "", 0, 0);
-
-  // No match found
   x2("(?:()|())*\\1\\2", "", 0, 0);
-
-  // Expected group to exist
-  x3("(?:\\1a|())*", "a", 0, 0, 1);
 
   // No match found
   x2("(?:()|()|()|()|()|())*\\2\\5", "", 0, 0);
@@ -210,12 +204,6 @@
 
   // Compile failed: ParseError(0, InvalidEscape("\\N"))
   x2("\\N", "a", 0, 1);
-
-  // No match found
-  x2("(?:()|())*\\1", "abc", 0, 0);
-
-  // No match found
-  x2("(?:()|())*\\2", "abc", 0, 0);
 
   // No match found
   x2("(?:()|()|())*\\3\\1", "abc", 0, 0);


### PR DESCRIPTION
Previously it would fail the branch when a repetition resulted in an empty match, but Oniguruma treats it as success if enough iterations were completed and breaks out the repetition. So the change is to match Oniguruma behavior. Fixes #70 

I also noticed a test case which after the trailing lookahead optimizations, wasn't testing what it should, so I fixed it.