### PR TITLE
support const-size backrefs in lookbehinds

### DIFF
--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -75,6 +75,11 @@ fn negative_lookbehind_variable_sized_alt() {
 }
 
 #[test]
+fn lookbehind_containing_const_size_backref() {
+    assert_eq!(find(r"(..)(?<=\1\1)", "yyxxxx"), Some((4, 6)));
+}
+
+#[test]
 fn lookahead_looks_left() {
     assert_eq!(find(r"a(?=\b)", "ab"), None);
     assert_eq!(find(r"a(?=\b)", "a."), Some((0, 1)));


### PR DESCRIPTION
I noticed that backrefs were not supported in lookbehinds, always failing with the `LookBehindNotConst` error, even if the group being backreferenced *was* a constant size. This fixes that by updating the analyzer to store the min size and const size properties of the capture group, for later reference by the backreference.