### PR TITLE
Fix highlighted text misalignment in playground when multi-byte chars are present

### DIFF
--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -170,17 +170,20 @@ class FancyRegexPlayground {
         // Sort matches by start position (descending) to avoid position shifts during insertion
         const sortedMatches = [...matches].sort((a, b) => b.start - a.start);
         
-        let highlightedText = text;
+        const originalText = new Utf8String(text);
+        let highlightedTextChunks = [];
+        let latestOffset = originalText.buffer.length;
         
         sortedMatches.forEach((match, index) => {
-            const before = highlightedText.substring(0, match.start);
-            const matchText = highlightedText.substring(match.start, match.end);
-            const after = highlightedText.substring(match.end);
-            
-            highlightedText = before + 
-                `<span class="match-highlight" title="Match ${sortedMatches.length - index}: ${match.start}-${match.end}">${this.escapeHtml(matchText)}</span>` + 
-                after;
+            const matchText = originalText.substr(match.start, match.end);
+            highlightedTextChunks.push(originalText.substr(match.end, latestOffset));
+            highlightedTextChunks.push(
+                /*html*/`<span class="match-highlight" title="Match ${sortedMatches.length - index}: ${match.start}-${match.end}">${this.escapeHtml(matchText)}</span>`
+            );
+            latestOffset = match.start;
         });
+        highlightedTextChunks.push(originalText.substr(0, latestOffset));
+        const highlightedText = highlightedTextChunks.reverse().join('');
 
         this.elements.highlightedText.innerHTML = highlightedText;
     }
@@ -300,6 +303,7 @@ class FancyRegexPlayground {
         this.elements.textInput.value = `This is a test test with some some repeated words.
 Another line line with more more examples.
 Single words here.
+Here are some Greek letters and an emoji: δ Δ 🎯
 And and final test test case.`;
         
         // Trigger initial update

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -88,7 +88,10 @@ class FancyRegexPlayground {
             this.setLoading(true);
             const flags = this.getFlags();
 
-            // Test if pattern is valid by checking if it matches anything
+            this.updateParseTreeIfVisible(pattern, flags);
+            this.updateAnalysisIfVisible(pattern, flags);
+
+            // Test if pattern is valid
             const isValid = await this.testRegexValidity(pattern, flags);
             if (!isValid) return;
 
@@ -99,8 +102,6 @@ class FancyRegexPlayground {
             const matches = captures.map(capture => capture.full_match).filter(match => match !== null);
             
             this.displayResults(matches, captures, text);
-            this.updateParseTreeIfVisible(pattern, flags);
-            this.updateAnalysisIfVisible(pattern, flags);
 
         } catch (error) {
             this.displayError(error.toString());
@@ -115,7 +116,7 @@ class FancyRegexPlayground {
             parse_regex(pattern, flags);
             return true;
         } catch (error) {
-            this.displayError(`Pattern error: ${error.toString()}`);
+            this.displayError(error.toString());
             return false;
         }
     }
@@ -242,7 +243,7 @@ class FancyRegexPlayground {
             const parseTree = parse_regex(pattern, flags);
             this.elements.parseTreeDisplay.textContent = parseTree;
         } catch (error) {
-            this.elements.parseTreeDisplay.textContent = `Parse error: ${error.toString()}`;
+            this.elements.parseTreeDisplay.textContent = error.toString();
         }
     }
 
@@ -258,7 +259,7 @@ class FancyRegexPlayground {
             const analysis = analyze_regex(pattern, flags);
             this.elements.analysisDisplay.textContent = analysis;
         } catch (error) {
-            this.elements.analysisDisplay.textContent = `Analysis error: ${error.toString()}`;
+            this.elements.analysisDisplay.textContent = error.toString();
         }
     }
 

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -238,11 +238,6 @@ class FancyRegexPlayground {
             flags = this.getFlags();
         }
 
-        if (!pattern) {
-            this.elements.parseTreeDisplay.textContent = 'Enter a regex pattern to see its parse tree';
-            return;
-        }
-
         try {
             const parseTree = parse_regex(pattern, flags);
             this.elements.parseTreeDisplay.textContent = parseTree;
@@ -257,11 +252,6 @@ class FancyRegexPlayground {
         }
         if (flags === null) {
             flags = this.getFlags();
-        }
-
-        if (!pattern) {
-            this.elements.analysisDisplay.textContent = 'Enter a regex pattern to see its analysis';
-            return;
         }
 
         try {

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>/fancy-regex playground/</title>
     <link rel="stylesheet" type="text/css" href="playground.css" />
+    <script type="text/javascript" src="utf8_string.js"></script>
 </head>
 <body>
     <div class="header">

--- a/playground/web/utf8_string.js
+++ b/playground/web/utf8_string.js
@@ -1,0 +1,52 @@
+class Utf8String {
+  constructor(str) {
+    this.str = str;
+    this.encoder = new TextEncoder();
+    this.decoder = new TextDecoder("utf-8");
+    this.utf8 = this.encoder.encode(str);
+  }
+
+  /**
+   * Get a single substring by byte offsets
+   * @param {number} start - UTF-8 byte start
+   * @param {number} end - UTF-8 byte end
+   * @returns {string}
+   */
+  substr(start, end) {
+    return this.decoder.decode(this.utf8.subarray(start, end));
+  }
+
+  /**
+   * Get multiple substrings at once
+   * @param {[number, number][]} ranges - Array of [start, end] byte ranges
+   * @returns {string[]}
+   */
+  substrRanges(ranges) {
+    return ranges.map(([start, end]) =>
+      this.decoder.decode(this.utf8.subarray(start, end))
+    );
+  }
+
+  /**
+   * Expose underlying UTF-8 buffer (if needed for WASM interop)
+   */
+  get buffer() {
+    return this.utf8;
+  }
+}
+
+/*
+// Example usage:
+const s = new Utf8String("Hello 🌍, こんにちは");
+console.log(s.substr(0, 5)); // "Hello"
+
+// Multiple ranges
+const ranges = [
+  [0, 5],          // "Hello"
+  [6, 10],         // " 🌍"
+  [12, 28],        // "こんにちは"
+];
+
+console.log(s.substrRanges(ranges)); 
+// → ["Hello", " 🌍", "こんにちは"]
+*/


### PR DESCRIPTION
Fix highlighting when multibyte characters are in the test text, and update the default example text to demonstrate that it works.

Plus a few other misc changes in the playground:
- show analysis and parse tree even for an empty pattern
- keep the parse tree and analysis in sync when there is a parse error. Previously it kept the previous output which could be confusing. Also the redundant/duplicated error prefixes have now been removed.