### PR TITLE
Fix clippy lints

### DIFF
--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -131,11 +131,11 @@ fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let mut tree = Expr::parse_tree(&re).unwrap();
     let requires_capture_group_fixup = optimize(&mut tree);
     let a = analyze(&tree, requires_capture_group_fixup);
-    write!(writer, "{:#?}\n", a)
+    writeln!(writer, "{:#?}", a)
 }
 
 fn show_compiled_program(re: &str, writer: &mut Formatter<'_>) -> Result {
-    let r = Regex::new(&re).unwrap();
+    let r = Regex::new(re).unwrap();
     r.debug_print(writer)
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -22,7 +22,6 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use core::usize;
 use regex_automata::meta::Regex as RaRegex;
 use regex_automata::meta::{Builder as RaBuilder, Config as RaConfig};
 #[cfg(all(test, feature = "std"))]

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -194,22 +194,23 @@ impl Expander {
         captures: &Captures<'_>,
     ) -> core::fmt::Result {
         self.exec(template, |step| match step {
-            Step::Char(c) => Ok(dst.extend(c.to_string().as_bytes())),
+            Step::Char(c) => {
+                dst.extend(c.to_string().as_bytes());
+                Ok(())
+            },
             Step::GroupName(name) => {
                 if let Some(m) = captures.name(name) {
-                    Ok(dst.extend(m.as_str().as_bytes()))
+                    dst.extend(m.as_str().as_bytes());
                 } else if let Some(m) = name.parse().ok().and_then(|num| captures.get(num)) {
-                    Ok(dst.extend(m.as_str().as_bytes()))
-                } else {
-                    Ok(())
+                    dst.extend(m.as_str().as_bytes());
                 }
+                Ok(())
             }
             Step::GroupNum(num) => {
                 if let Some(m) = captures.get(num) {
-                    Ok(dst.extend(m.as_str().as_bytes()))
-                } else {
-                    Ok(())
+                    dst.extend(m.as_str().as_bytes());
                 }
+                Ok(())
             }
             Step::Error => Ok(()),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ use core::convert::TryFrom;
 use core::fmt::{Debug, Formatter};
 use core::ops::{Index, Range};
 use core::str::FromStr;
-use core::{fmt, usize};
+use core::{fmt};
 use regex_automata::meta::Regex as RaRegex;
 use regex_automata::util::captures::Captures as RaCaptures;
 use regex_automata::util::syntax::Config as SyntaxConfig;
@@ -1085,7 +1085,7 @@ impl Regex {
     }
 
     /// Returns an iterator over the capture names.
-    pub fn capture_names(&self) -> CaptureNames {
+    pub fn capture_names(&self) -> CaptureNames<'_> {
         let mut names = Vec::new();
         names.resize(self.captures_len(), None);
         for (name, &i) in self.named_groups.iter() {
@@ -1349,7 +1349,7 @@ impl Regex {
     pub fn splitn<'r, 'h>(&'r self, target: &'h str, limit: usize) -> SplitN<'r, 'h> {
         SplitN {
             splits: self.split(target),
-            limit: limit,
+            limit,
         }
     }
 }
@@ -1724,7 +1724,7 @@ fn push_quoted(buf: &mut String, s: &str) {
 
 /// Escapes special characters in `text` with '\\'.  Returns a string which, when interpreted
 /// as a regex, matches exactly `text`.
-pub fn escape(text: &str) -> Cow<str> {
+pub fn escape(text: &str) -> Cow<'_, str> {
     // Using bytes() is OK because all special characters are single bytes.
     match text.bytes().filter(|&b| is_special(b as char)).count() {
         0 => Cow::Borrowed(text),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl<'r, 't> Matches<'r, 't> {
 
     /// Return the underlying regex.
     pub fn regex(&self) -> &'r Regex {
-        &self.re
+        self.re
     }
 }
 
@@ -359,7 +359,7 @@ impl<'r, 't> CaptureMatches<'r, 't> {
 
     /// Return the underlying regex.
     pub fn regex(&self) -> &'r Regex {
-        &self.0.re
+        self.0.re
     }
 }
 
@@ -526,12 +526,12 @@ impl<'r, 'h> Iterator for SplitN<'r, 'h> {
         let len = self.splits.target.len();
         if self.splits.next_start > len {
             // No more substrings available.
-            return None;
+            None
         } else {
             // Return the remaining part of the target
             let start = self.splits.next_start;
             self.splits.next_start = len + 1;
-            return Some(Ok(&self.splits.target[start..len]));
+            Some(Ok(&self.splits.target[start..len]))
         }
     }
 
@@ -570,9 +570,8 @@ impl RegexOptions {
         let unicode = Self::get_flag_value(self.syntaxc.get_unicode(), FLAG_UNICODE);
         let oniguruma_mode = Self::get_flag_value(self.oniguruma_mode, FLAG_ONIGURUMA_MODE);
 
-        let all_flags =
-            insensitive | multiline | whitespace | dotnl | unicode | unicode | oniguruma_mode;
-        all_flags
+        
+        insensitive | multiline | whitespace | dotnl | unicode | unicode | oniguruma_mode
     }
 }
 
@@ -865,7 +864,7 @@ impl Regex {
     /// ```
     pub fn find_iter<'r, 't>(&'r self, text: &'t str) -> Matches<'r, 't> {
         Matches {
-            re: &self,
+            re: self,
             text,
             last_end: 0,
             last_match: None,
@@ -1045,7 +1044,7 @@ impl Regex {
             } => {
                 let mut locations = inner.create_captures();
                 inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
-                Ok(locations.is_match().then(|| Captures {
+                Ok(locations.is_match().then_some(Captures {
                     inner: CapturesImpl::Wrap {
                         text,
                         locations,
@@ -1803,7 +1802,7 @@ impl Expr {
                 }
                 push_quoted(buf, val);
                 if casei {
-                    buf.push_str(")");
+                    buf.push(')');
                 }
             }
             Expr::Assertion(Assertion::StartText) => buf.push('^'),
@@ -1884,7 +1883,7 @@ impl Expr {
                 }
                 buf.push_str(inner);
                 if casei {
-                    buf.push_str(")");
+                    buf.push(')');
                 }
             }
             _ => panic!("attempting to format hard expr {:?}", self),

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -33,8 +33,8 @@ use core::mem;
 pub fn optimize(tree: &mut ExprTree) -> bool {
     // self recursion prevents us from moving the trailing lookahead out of group 0
     if !tree.self_recursive {
-        let requires_capture_group_fixup = optimize_trailing_lookahead(tree);
-        requires_capture_group_fixup
+        
+        optimize_trailing_lookahead(tree)
     } else {
         false
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -386,7 +386,7 @@ impl<'a> Parser<'a> {
         open: &str,
         close: &str,
         allow_relative: bool,
-    ) -> Result<NamedBackrefOrSubroutine> {
+    ) -> Result<NamedBackrefOrSubroutine<'_>> {
         if let Some(ParsedId {
             id,
             mut relative,
@@ -1248,7 +1248,7 @@ mod tests {
     #[test]
     fn parse_id_test() {
         use crate::parse::ParsedId;
-        fn create_id(id: &str, relative: Option<isize>, skip: usize) -> Option<ParsedId> {
+        fn create_id(id: &str, relative: Option<isize>, skip: usize) -> Option<ParsedId<'_>> {
             Some(ParsedId { id, relative, skip })
         }
         assert_eq!(parse_id("foo.", "", "", true), create_id("foo", None, 3));
@@ -2488,25 +2488,25 @@ mod tests {
     #[test]
     fn self_recursive_subroutine_call() {
         let tree = Expr::parse_tree(r"hello\g<0>?world").unwrap();
-        assert_eq!(tree.self_recursive, true);
+        assert!(tree.self_recursive);
 
         let tree = Expr::parse_tree(r"hello\g0?world").unwrap();
-        assert_eq!(tree.self_recursive, true);
+        assert!(tree.self_recursive);
 
         let tree = Expr::parse_tree(r"hello world").unwrap();
-        assert_eq!(tree.self_recursive, false);
+        assert!(!tree.self_recursive);
 
         let tree = Expr::parse_tree(r"hello\g1world").unwrap();
-        assert_eq!(tree.self_recursive, false);
+        assert!(!tree.self_recursive);
 
         let tree = Expr::parse_tree(r"hello\g<1>world").unwrap();
-        assert_eq!(tree.self_recursive, false);
+        assert!(!tree.self_recursive);
 
         let tree = Expr::parse_tree(r"(hello\g1?world)").unwrap();
-        assert_eq!(tree.self_recursive, false);
+        assert!(!tree.self_recursive);
 
         let tree = Expr::parse_tree(r"(?<a>hello\g<a>world)").unwrap();
-        assert_eq!(tree.self_recursive, false);
+        assert!(!tree.self_recursive);
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -357,7 +357,7 @@ impl<'a> Parser<'a> {
             group_name,
             recursion_level,
         } = self.parse_named_backref_or_subroutine(ix, open, close, allow_relative)?;
-        if let Some(_) = recursion_level {
+        if recursion_level.is_some() {
             return Err(Error::ParseError(ix, ParseError::InvalidGroupName));
         }
         if let Some(group) = group_ix {
@@ -463,7 +463,7 @@ impl<'a> Parser<'a> {
                 return Ok((end, group));
             }
         }
-        return Err(Error::ParseError(ix, ParseError::InvalidBackref));
+        Err(Error::ParseError(ix, ParseError::InvalidBackref))
     }
 
     // ix points to \ character
@@ -1120,7 +1120,7 @@ pub(crate) fn parse_id<'a>(
     }
     let relative_sign = s.as_bytes()[id_end];
     if relative_sign == b'+' || relative_sign == b'-' {
-        if let Some((end, relative_amount)) = parse_decimal(&s, id_end + 1) {
+        if let Some((end, relative_amount)) = parse_decimal(s, id_end + 1) {
             if s[end..].starts_with(close) {
                 if relative_amount == 0 && id_len == 0 {
                     return None;
@@ -1146,7 +1146,7 @@ fn is_id_char(c: char) -> bool {
 }
 
 fn is_digit(b: u8) -> bool {
-    b'0' <= b && b <= b'9'
+    (b'0'..=b'9').contains(&b)
 }
 
 fn is_hex_digit(b: u8) -> bool {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1146,7 +1146,7 @@ fn is_id_char(c: char) -> bool {
 }
 
 fn is_digit(b: u8) -> bool {
-    (b'0'..=b'9').contains(&b)
+    b.is_ascii_digit()
 }
 
 fn is_hex_digit(b: u8) -> bool {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -27,7 +27,6 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 
 use bit_set::BitSet;
-use core::usize;
 use regex_syntax::escape_into;
 
 use crate::parse_flags::*;
@@ -1071,7 +1070,7 @@ pub(crate) fn parse_decimal(s: &str, ix: usize) -> Option<(usize, usize)> {
     while end < s.len() && is_digit(s.as_bytes()[end]) {
         end += 1;
     }
-    usize::from_str_radix(&s[ix..end], 10)
+    s[ix..end].parse::<usize>()
         .ok()
         .map(|val| (end, val))
 }

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -26,7 +26,7 @@ pub trait Replacer {
     /// be beneficial to avoid finding sub-captures.
     ///
     /// In general, this is called once for every call to `replacen`.
-    fn no_expansion(&mut self) -> Option<Cow<str>> {
+    fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
         None
     }
 
@@ -51,7 +51,7 @@ pub trait Replacer {
     ///     dst.into_owned()
     /// }
     /// ```
-    fn by_ref(&mut self) -> ReplacerRef<Self> {
+    fn by_ref(&mut self) -> ReplacerRef<'_, Self> {
         ReplacerRef(self)
     }
 }

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -71,9 +71,9 @@ impl<'a, R: Replacer + ?Sized + 'a> Replacer for ReplacerRef<'a, R> {
     }
 }
 
-impl<'a> Replacer for &'a str {
+impl Replacer for &str {
     fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
-        caps.expand(*self, dst);
+        caps.expand(self, dst);
     }
 
     fn no_expansion(&mut self) -> Option<Cow<'_, str>> {
@@ -81,7 +81,7 @@ impl<'a> Replacer for &'a str {
     }
 }
 
-impl<'a> Replacer for &'a String {
+impl Replacer for &String {
     fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
         self.as_str().replace_append(caps, dst)
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -239,7 +239,7 @@ impl Prog {
     #[doc(hidden)]
     pub(crate) fn debug_print(&self, writer: &mut Formatter<'_>) -> core::fmt::Result {
         for (i, insn) in self.body.iter().enumerate() {
-            write!(writer, "{:3}: {:?}\n", i, insn)?;
+            writeln!(writer, "{:3}: {:?}", i, insn)?;
         }
         Ok(())
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -73,7 +73,6 @@ use alloc::collections::BTreeSet;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::usize;
 use regex_automata::meta::Regex;
 use regex_automata::util::look::LookMatcher;
 use regex_automata::util::primitives::NonMaxUsize;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -982,8 +982,8 @@ mod tests {
             // Remember state of saves for checking later
             expected.push(saves.clone());
             let mut actual_saves = vec![usize::MAX; slots];
-            for i in 0..slots {
-                actual_saves[i] = state.get(i);
+            for (i, item) in actual_saves.iter_mut().enumerate().take(slots) {
+                *item = state.get(i);
             }
             actual.push(actual_saves);
         }


### PR DESCRIPTION
I had the idea that it might be a good idea to fix clippy lints before making the next release.

I also did a [`cargo semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) and it confirmed that the next release can be minor, even after these changes.

Indeed after fixing these, we get some new lint warnings but I think we can leave them for a future release as they will be breaking:
```
warning: the `Err`-variant returned from this function is very large
   --> src/vm.rs:496:57
    |
496 | ...&str, pos: usize) -> Result<Option<Vec<usize>>> {
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/error.rs:17:5
    |
17  |     CompileError(CompileError),
    |     -------------------------- the largest variant contains at least 136 bytes
    |
    = help: try reducing the size of `error::Error`, for example by boxing large elements or replacing it with `Box<error::Error>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
```