### PR TITLE
Wrap Prog in Arc and remove Clone from Insn and Prog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ enum RegexImpl {
         debug_pattern: String,
     },
     Fancy {
-        prog: Prog,
+        prog: Arc<Prog>,
         n_groups: usize,
         options: RegexOptions,
     },
@@ -819,7 +819,7 @@ impl Regex {
         let prog = compile(&info, can_compile_as_anchored(&tree.expr))?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
-                prog,
+                prog: Arc::new(prog),
                 n_groups: info.end_group(),
                 options,
             },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -215,7 +215,7 @@ impl core::fmt::Debug for ReverseBackwardsDelegate {
 }
 
 /// Instruction of the VM.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Insn {
     /// Successful end of program
     End,
@@ -309,7 +309,7 @@ pub enum Insn {
 }
 
 /// Sequence of instructions for the VM to execute.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Prog {
     /// Instructions of the program
     pub body: Vec<Insn>,


### PR DESCRIPTION
This change significantly improves `Regex` cloning performance. Instead of cloning all instructions when cloning a `Regex`, we now use `Arc<Prog>` to share the program between clones. As a result we can remove the `Clone` trait from `Insn` and `Prog`.