### PR TITLE
Fix iterating over capture matches when the pattern contains \G

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -771,6 +771,7 @@ pub fn can_compile_as_anchored(root_expr: &Expr) -> bool {
     match root_expr {
         Expr::Concat(children) => match children[0] {
             Expr::Assertion(assertion) => assertion == Assertion::StartText,
+            Expr::ContinueFromPreviousMatchEnd => true,
             _ => false,
         },
         Expr::Assertion(assertion) => *assertion == Assertion::StartText,
@@ -1068,6 +1069,12 @@ mod tests {
         assert_eq!(can_compile_as_anchored(&tree.expr), true);
 
         let tree = Expr::parse_tree(r"^").unwrap();
+        assert_eq!(can_compile_as_anchored(&tree.expr), true);
+    }
+
+    #[test]
+    fn anchored_for_continue_from_prev_match_assertions() {
+        let tree = Expr::parse_tree(r"\G(\w+)\1").unwrap();
         assert_eq!(can_compile_as_anchored(&tree.expr), true);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,14 +139,14 @@ impl<'r, 't> Matches<'r, 't> {
     pub fn regex(&self) -> &'r Regex {
         self.re
     }
-}
 
-impl<'r, 't> Iterator for Matches<'r, 't> {
-    type Item = Result<Match<'t>>;
-
-    /// Adapted from the `regex` crate. Calls `find_from_pos` repeatedly.
+    /// Adapted from the `regex` crate. Calls `find_from_pos`/`captures_from_pos` repeatedly.
     /// Ignores empty matches immediately after a match.
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Also passes a flag when skipping an empty match, so that \G wouldn't match at the new start position.
+    fn next_with<F, R>(&mut self, mut search: F) -> Option<Result<R>>
+    where
+        F: FnMut(&Regex, usize, u32) -> Result<Option<(R, Match<'t>)>>,
+    {
         if self.last_end > self.text.len() {
             return None;
         }
@@ -160,20 +160,17 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
         } else {
             0
         };
-        let mat =
-            match self
-                .re
-                .find_from_pos_with_option_flags(self.text, self.last_end, option_flags)
-            {
-                Err(error) => {
-                    // Stop on first error: If an error is encountered, return it, and set the "last match position"
-                    // to the string length, so that the next next() call will return None, to prevent an infinite loop.
-                    self.last_end = self.text.len() + 1;
-                    return Some(Err(error));
-                }
-                Ok(None) => return None,
-                Ok(Some(mat)) => mat,
-            };
+
+        let (result, mat) = match search(self.re, self.last_end, option_flags) {
+            Err(error) => {
+                // Stop on first error: If an error is encountered, return it, and set the "last match position"
+                // to the string length, so that the next next() call will return None, to prevent an infinite loop.
+                self.last_end = self.text.len() + 1;
+                return Some(Err(error));
+            }
+            Ok(None) => return None,
+            Ok(Some(pair)) => pair,
+        };
 
         if mat.start == mat.end {
             // This is an empty match. To ensure we make progress, start
@@ -183,7 +180,7 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
             // Don't accept empty matches immediately following a match.
             // Just move on to the next match.
             if Some(mat.end) == self.last_match {
-                return self.next();
+                return self.next_with(search);
             }
         } else {
             self.last_end = mat.end;
@@ -191,7 +188,19 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
 
         self.last_match = Some(mat.end);
 
-        Some(Ok(mat))
+        Some(Ok(result))
+    }
+}
+
+impl<'r, 't> Iterator for Matches<'r, 't> {
+    type Item = Result<Match<'t>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let text = self.text;
+        self.next_with(move |re, pos, flags| {
+            re.find_from_pos_with_option_flags(text, pos, flags)
+                .map(|opt| opt.map(|m| (m, m)))
+        })
     }
 }
 
@@ -220,53 +229,17 @@ impl<'r, 't> CaptureMatches<'r, 't> {
 impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
     type Item = Result<Captures<'t>>;
 
-    /// Adapted from the `regex` crate. Calls `captures_from_pos` repeatedly.
-    /// Ignores empty matches immediately after a match.
     fn next(&mut self) -> Option<Self::Item> {
-        if self.0.last_end > self.0.text.len() {
-            return None;
-        }
-
-        let option_flags = if let Some(last_match) = self.0.last_match {
-            if self.0.last_end > last_match {
-                OPTION_SKIPPED_EMPTY_MATCH
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-
-        let captures = match self.0.re.captures_from_pos_with_option_flags(
-            self.0.text,
-            self.0.last_end,
-            option_flags,
-        ) {
-            Err(error) => {
-                // Stop on first error: If an error is encountered, return it, and set the "last match position"
-                // to the string length, so that the next next() call will return None, to prevent an infinite loop.
-                self.0.last_end = self.0.text.len() + 1;
-                return Some(Err(error));
-            }
-            Ok(None) => return None,
-            Ok(Some(captures)) => captures,
-        };
-
-        let mat = captures
-            .get(0)
-            .expect("`Captures` is expected to have entire match at 0th position");
-        if mat.start == mat.end {
-            self.0.last_end = next_utf8(self.0.text, mat.end);
-            if Some(mat.end) == self.0.last_match {
-                return self.next();
-            }
-        } else {
-            self.0.last_end = mat.end;
-        }
-
-        self.0.last_match = Some(mat.end);
-
-        Some(Ok(captures))
+        let text = self.0.text;
+        self.0.next_with(move |re, pos, flags| {
+            let captures = re.captures_from_pos_with_option_flags(text, pos, flags)?;
+            Ok(captures.map(|c| {
+                let mat = c
+                    .get(0)
+                    .expect("`Captures` is expected to have entire match at 0th position");
+                (c, mat)
+            }))
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,21 @@ impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
             return None;
         }
 
-        let captures = match self.0.re.captures_from_pos(self.0.text, self.0.last_end) {
+        let option_flags = if let Some(last_match) = self.0.last_match {
+            if self.0.last_end > last_match {
+                OPTION_SKIPPED_EMPTY_MATCH
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        let captures = match self.0.re.captures_from_pos_with_option_flags(
+            self.0.text,
+            self.0.last_end,
+            option_flags,
+        ) {
             Err(error) => {
                 // Stop on first error: If an error is encountered, return it, and set the "last match position"
                 // to the string length, so that the next next() call will return None, to prevent an infinite loop.
@@ -898,6 +912,15 @@ impl Regex {
     /// of the string slice.
     ///
     pub fn captures_from_pos<'t>(&self, text: &'t str, pos: usize) -> Result<Option<Captures<'t>>> {
+        self.captures_from_pos_with_option_flags(text, pos, 0)
+    }
+
+    fn captures_from_pos_with_option_flags<'t>(
+        &self,
+        text: &'t str,
+        pos: usize,
+        option_flags: u32,
+    ) -> Result<Option<Captures<'t>>> {
         let named_groups = self.named_groups.clone();
         match &self.inner {
             RegexImpl::Wrap {
@@ -926,7 +949,7 @@ impl Regex {
                 options,
                 ..
             } => {
-                let result = vm::run(prog, text, pos, 0, options)?;
+                let result = vm::run(prog, text, pos, option_flags, options)?;
                 Ok(result.map(|mut saves| {
                     saves.truncate(n_groups * 2);
                     Captures {

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -183,6 +183,67 @@ fn captures_iter_attributes() {
 }
 
 #[test]
+fn captures_iter_continue_from_previous_match_end() {
+    let text = "1122 33";
+
+    for (i, caps) in common::regex(r"\G(\d)\d").captures_iter(text).enumerate() {
+        let caps = caps.unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(caps.get(0).unwrap().start(), 0);
+                assert_eq!(caps.get(0).unwrap().end(), 2);
+                assert_eq!(caps.get(1).unwrap().start(), 0);
+                assert_eq!(caps.get(1).unwrap().end(), 1);
+            }
+            1 => {
+                assert_eq!(caps.get(0).unwrap().start(), 2);
+                assert_eq!(caps.get(0).unwrap().end(), 4);
+                assert_eq!(caps.get(1).unwrap().start(), 2);
+                assert_eq!(caps.get(1).unwrap().end(), 3);
+            }
+            i => panic!("Expected 2 results, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn captures_iter_continue_from_previous_match_end_with_zero_width_match() {
+    let text = "1122 33";
+
+    for (i, caps) in common::regex(r"\G\d*").captures_iter(text).enumerate() {
+        let caps = caps.unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(caps.get(0).unwrap().start(), 0);
+                assert_eq!(caps.get(0).unwrap().end(), 4);
+            }
+            i => panic!("Expected 1 result, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn captures_iter_continue_from_previous_match_end_single_match() {
+    let text = "123 456 789";
+
+    for (i, caps) in common::regex(r"\G(\d+)").captures_iter(text).enumerate() {
+        let caps = caps.unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(caps.get(0).unwrap().start(), 0);
+                assert_eq!(caps.get(0).unwrap().end(), 3);
+                assert_eq!(caps.get(1).unwrap().start(), 0);
+                assert_eq!(caps.get(1).unwrap().end(), 3);
+            }
+            i => panic!("Expected 1 result, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
 fn captures_from_pos() {
     let text = "11 21 33";
 


### PR DESCRIPTION
- fix iterating over capture matches when the pattern contains `\G` - this unifies the two iterators to share the logic of when to pass in the `OPTION_SKIPPED_EMPTY_MATCH` flag etc.
- also anchor expressions starting with `\G` to remove unnecessary VM instructions
