### PR TITLE
Add support for Oniguruma's absent repeater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ with the exception that 0.x versions can break between minor versions.
 - Add support for more `\p{...}` and `\P{...}` aliases, for Oniguruma compatibility (#207)
 - Add support for word boundaries and zero-length fancy patterns inside variable lookbehinds (at top level) (#216)
 - Add support for `\R` to mean general newline, matching all common line break characters, treating `\r\n` atomically (#220)
+- Add support for Oniguruma's absent repeater `(?~abc)` (#233)
 ### Changed
 - `RegexBuilder` can now build multiple patterns with the same options (#213)
 ### Fixed

--- a/docs/absent.md
+++ b/docs/absent.md
@@ -1,0 +1,81 @@
+# Absent Operators
+
+The absent operators are worth talking about because they are quite uncommon.
+
+## Absent Repeater
+
+An absent repeater node is defined by the syntax `(?~inner_pattern)`, and it will match any text where the inner pattern does not match (i.e. is absent), including across newlines.
+This does not add any new abilities to the engine, it just allows to clarify intent and to be more easily optimized under the hood. fancy-regex mainly implements this for Oniguruma compatibility.
+
+It works best or is at least easiest to understand when the inner pattern is a literal.
+
+### Example
+
+Let's imagine you have some Markdown, containing some code fences.
+
+It might look something like this:
+
+````md
+# Some Heading
+
+Given a todo list like this:
+
+**Input:**
+```json
+{
+  "todos": [
+    {
+      "content": "Create `some_helper_func` helper in some_file.rs that takes a closure to check the error",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "content": "Update error-asserting tests in some_file.rs to use `some_helper_func`",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "content": "Run `cargo fmt` and `cargo test`",
+      "status": "pending",
+      "priority": "medium"
+    }
+  ]
+}
+```
+
+You might expect this output:
+
+**Output:**
+```text
+High priority tasks have now been completed.
+```
+
+Some more text.
+````
+
+Let's say you want to match all input and output codeblocks.
+
+Typically you *could* do it like:
+
+```regexp
+[*]{2}(?:In|Out)put:[*]{2}\n```(?:[^`]+|`(?!``))+```
+```
+
+This would match everything inside the codeblock which is not a backtick, or backticks which are not followed by another 2 backticks, until it reaches the 3 backticks marking the end of the codeblock.
+Generally this type of construct can be quite hard to follow and reason about, to be sure it won't suffer from catastrophic backtracking.
+
+With the absent repeater, the intention becomes a lot easier to understand - match anything that isn't 3 backticks, followed by 3 backticks.
+```regexp
+[*]{2}(?:In|Out)put:[*]{2}\n```(?~```)```
+```
+
+It also allows the engine to optimize it accordingly.
+
+### Other ways of looking at it
+
+The absent repeater can be considered shorthand for this:
+```regexp
+(?((?!absent))\O|)*
+```
+
+Essentially a conditional, which says when the absent expression doesn't match, match a single character including newlines. When the absent expression does match, match nothing. Repeat greedily.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -84,3 +84,8 @@ Backtracking control verbs:
 
 `(*FAIL)`
 : fail the current backtracking branch
+
+Absent repeater:
+
+`(?~abc)`
+: match anything until `abc` would match or until the end of the haystack if no match

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -212,7 +212,7 @@ pub fn is_match(pattern: &str, text: &str, flags: JsValue) -> Result<bool, Strin
 #[derive(Serialize, Deserialize)]
 pub struct AnalysisTreeNode {
     pub kind: String,
-    pub summary: String,
+    pub summary: Option<String>,
     pub hard: bool,
     pub min_size: usize,
     pub const_size: bool,
@@ -265,26 +265,28 @@ fn info_to_tree_node<'a>(
     group_names: &std::collections::HashMap<usize, String>,
 ) -> AnalysisTreeNode {
     let (kind, summary, group_info) = match info.expr {
-        Expr::Empty => ("Empty".to_string(), "".to_string(), None),
+        Expr::Empty => ("Empty".to_string(), None, None),
         Expr::Any { newline } => {
             if *newline {
-                ("Any".to_string(), "".to_string(), None)
+                ("Any".to_string(), None, None)
             } else {
-                ("Any".to_string(), "(no newline)".to_string(), None)
+                ("Any".to_string(), Some("(no newline)".to_string()), None)
             }
         }
-        Expr::Assertion(_) => ("Assertion".to_string(), "".to_string(), None),
-        Expr::GeneralNewline { .. } => ("GeneralNewline".to_string(), "\\R".to_string(), None),
-        Expr::Literal { val, .. } => ("Literal".to_string(), format!("{:?}", val), None),
-        Expr::Concat(v) => ("Concat".to_string(), format!("({})", v.len()), None),
-        Expr::Alt(v) => ("Alt".to_string(), format!("({})", v.len()), None),
+        Expr::Assertion(_) => ("Assertion".to_string(), None, None),
+        Expr::GeneralNewline { .. } => {
+            ("GeneralNewline".to_string(), Some("\\R".to_string()), None)
+        }
+        Expr::Literal { val, .. } => ("Literal".to_string(), Some(format!("{:?}", val)), None),
+        Expr::Concat(v) => ("Concat".to_string(), Some(format!("({})", v.len())), None),
+        Expr::Alt(v) => ("Alt".to_string(), Some(format!("({})", v.len())), None),
         Expr::Group(_) => {
             let group_index = info.start_group();
             let group_name = group_names.get(&group_index).cloned();
             let summary = if let Some(ref name) = group_name {
-                format!("{} ({})", group_index, name)
+                Some(format!("{} ({})", group_index, name))
             } else {
-                format!("{}", group_index)
+                Some(format!("{}", group_index))
             };
             (
                 "Group".to_string(),
@@ -302,7 +304,7 @@ fn info_to_tree_node<'a>(
                 LookAround::LookBehind => ("LookBehind", "positive"),
                 LookAround::LookBehindNeg => ("LookBehind", "negative"),
             };
-            (kind_str.to_string(), format!("({})", polarity), None)
+            (kind_str.to_string(), Some(format!("({})", polarity)), None)
         }
         Expr::Repeat { lo, hi, .. } => {
             let hi_str = if *hi == usize::MAX {
@@ -312,19 +314,23 @@ fn info_to_tree_node<'a>(
             };
             (
                 "Repeat".to_string(),
-                format!("{{{}..{}}}", lo, hi_str),
+                Some(format!("{{{}..{}}}", lo, hi_str)),
                 None,
             )
         }
         Expr::Delegate { inner, .. } => {
             let escaped = escape_delegate(inner);
-            ("Delegate".to_string(), format!("\"{}\"", escaped), None)
+            (
+                "Delegate".to_string(),
+                Some(format!("\"{}\"", escaped)),
+                None,
+            )
         }
         Expr::Backref { group, .. } => {
             let summary = if let Some(name) = group_names.get(group) {
-                format!("({})", name)
+                Some(format!("({})", name))
             } else {
-                format!("{}", group)
+                Some(format!("{}", group))
             };
             ("Backref".to_string(), summary, None)
         }
@@ -334,41 +340,41 @@ fn info_to_tree_node<'a>(
             ..
         } => {
             let summary = if let Some(name) = group_names.get(group) {
-                format!("({}) level={}", name, relative_level)
+                Some(format!("({}) level={}", name, relative_level))
             } else {
-                format!("{} level={}", group, relative_level)
+                Some(format!("{} level={}", group, relative_level))
             };
             ("Backref".to_string(), summary, None)
         }
-        Expr::AtomicGroup(_) => ("AtomicGroup".to_string(), "".to_string(), None),
-        Expr::KeepOut => ("KeepOut".to_string(), "".to_string(), None),
-        Expr::ContinueFromPreviousMatchEnd => (
-            "ContinueFromPreviousMatchEnd".to_string(),
-            "".to_string(),
-            None,
-        ),
+        Expr::AtomicGroup(_) => ("AtomicGroup".to_string(), None, None),
+        Expr::KeepOut => ("KeepOut".to_string(), None, None),
+        Expr::ContinueFromPreviousMatchEnd => {
+            ("ContinueFromPreviousMatchEnd".to_string(), None, None)
+        }
         Expr::BackrefExistsCondition(group) => (
             "BackrefExistsCondition".to_string(),
-            format!("{}", group),
+            Some(format!("{}", group)),
             None,
         ),
-        Expr::Conditional { .. } => ("Conditional".to_string(), "".to_string(), None),
-        Expr::SubroutineCall(group) => ("SubroutineCall".to_string(), format!("{}", group), None),
+        Expr::Conditional { .. } => ("Conditional".to_string(), None, None),
+        Expr::SubroutineCall(group) => (
+            "SubroutineCall".to_string(),
+            Some(format!("{}", group)),
+            None,
+        ),
         Expr::UnresolvedNamedSubroutineCall { name, .. } => (
             "UnresolvedNamedSubroutineCall".to_string(),
-            format!("({})", name),
+            Some(format!("({})", name)),
             None,
         ),
-        Expr::BacktrackingControlVerb(_) => {
-            ("BacktrackingControlVerb".to_string(), "".to_string(), None)
-        }
+        Expr::BacktrackingControlVerb(_) => ("BacktrackingControlVerb".to_string(), None, None),
         Expr::Absent(ref absent) => {
             use crate::Absent::*;
             match absent {
-                Repeater(_) => ("AbsentRepeater".to_string(), "".to_string(), None),
-                Expression { .. } => ("AbsentExpression".to_string(), "".to_string(), None),
-                Stopper(_) => ("AbsentStopper".to_string(), "".to_string(), None),
-                Clear => ("AbsentClear".to_string(), "".to_string(), None),
+                Repeater(_) => ("AbsentRepeater".to_string(), None, None),
+                Expression { .. } => ("AbsentExpression".to_string(), None, None),
+                Stopper(_) => ("AbsentStopper".to_string(), None, None),
+                Clear => ("AbsentClear".to_string(), None, None),
             }
         }
     };
@@ -459,8 +465,8 @@ mod tests {
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.children.len(), 5); // "test\n" as separate literals
         assert_eq!(node.children[0].kind, "Literal");
-        assert_eq!(node.children[0].summary, "\"t\"");
-        assert_eq!(node.children[4].summary, "\"\\n\"");
+        assert_eq!(node.children[0].summary.as_deref(), Some("\"t\""));
+        assert_eq!(node.children[4].summary.as_deref(), Some("\"\\n\""));
     }
 
     #[test]
@@ -474,8 +480,8 @@ mod tests {
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.children.len(), 5); // "test\n" as separate literals
         assert_eq!(node.children[0].kind, "Literal");
-        assert_eq!(node.children[0].summary, "\"t\"");
-        assert_eq!(node.children[4].summary, "\"\\n\"");
+        assert_eq!(node.children[0].summary.as_deref(), Some("\"t\""));
+        assert_eq!(node.children[4].summary.as_deref(), Some("\"\\n\""));
     }
 
     #[test]
@@ -489,8 +495,8 @@ mod tests {
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.children.len(), 5); // "test\n" as separate literals
         assert_eq!(node.children[0].kind, "Literal");
-        assert_eq!(node.children[0].summary, "\"t\"");
-        assert_eq!(node.children[4].summary, "\"\\\\\"");
+        assert_eq!(node.children[0].summary.as_deref(), Some("\"t\""));
+        assert_eq!(node.children[4].summary.as_deref(), Some("\"\\\\\""));
     }
 
     #[test]
@@ -505,11 +511,11 @@ mod tests {
         // The root should be a Delegate node
         assert_eq!(node.kind, "Delegate");
         assert!(
-            node.summary.contains(r"\w"),
+            node.summary.as_deref().unwrap_or("").contains(r"\w"),
             "Delegate summary should contain the pattern"
         );
         assert!(
-            !node.summary.contains(r"\\w"),
+            !node.summary.as_deref().unwrap_or("").contains(r"\\w"),
             "Delegate summary should not contain extra slashes"
         );
     }
@@ -526,7 +532,7 @@ mod tests {
         // Find the Group node (should be a child of root)
         assert_eq!(node.kind, "Group");
         assert!(
-            node.summary.contains("word"),
+            node.summary.as_deref().unwrap_or("").contains("word"),
             "Group summary should contain the name"
         );
         assert_eq!(node.group.as_ref().unwrap().name, Some("word".to_string()));
@@ -565,7 +571,11 @@ mod tests {
             .expect("Should find Backref node");
 
         assert!(
-            backref_node.summary.contains("word"),
+            backref_node
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .contains("word"),
             "Backref summary should contain the name"
         );
     }
@@ -586,7 +596,7 @@ mod tests {
             .find(|n| n.kind == "Backref")
             .expect("Should find Backref node");
 
-        assert_eq!(backref_node.summary, "1");
+        assert_eq!(backref_node.summary.as_deref(), Some("1"));
     }
 
     #[test]
@@ -608,7 +618,12 @@ mod tests {
             let node = info_to_tree_node(&info, &group_names);
 
             assert_eq!(node.kind, "Repeat", "Pattern: {}", pattern);
-            assert_eq!(node.summary, expected_summary, "Pattern: {}", pattern);
+            assert_eq!(
+                node.summary.as_deref(),
+                Some(expected_summary),
+                "Pattern: {}",
+                pattern
+            );
         }
     }
 
@@ -622,7 +637,7 @@ mod tests {
         let node = info_to_tree_node(&info, &group_names);
 
         assert_eq!(node.kind, "Concat");
-        assert_eq!(node.summary, "(3)");
+        assert_eq!(node.summary.as_deref(), Some("(3)"));
 
         // Test Alt
         let tree = fancy_regex::Expr::parse_tree(r"a|b|c").unwrap();
@@ -632,7 +647,7 @@ mod tests {
         let node = info_to_tree_node(&info, &group_names);
 
         assert_eq!(node.kind, "Alt");
-        assert_eq!(node.summary, "(3)");
+        assert_eq!(node.summary.as_deref(), Some("(3)"));
     }
 
     #[test]
@@ -652,7 +667,12 @@ mod tests {
             let node = info_to_tree_node(&info, &group_names);
 
             assert_eq!(node.kind, expected_kind, "Pattern: {}", pattern);
-            assert_eq!(node.summary, expected_summary, "Pattern: {}", pattern);
+            assert_eq!(
+                node.summary.as_deref(),
+                Some(expected_summary),
+                "Pattern: {}",
+                pattern
+            );
         }
     }
 

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -1,7 +1,7 @@
 use fancy_regex::internal::{
     FLAG_CASEI, FLAG_DOTNL, FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE, FLAG_UNICODE,
 };
-use fancy_regex::{Expr, LookAround, Regex, RegexBuilder};
+use fancy_regex::{Absent, Expr, LookAround, Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -362,7 +362,15 @@ fn info_to_tree_node<'a>(
         Expr::BacktrackingControlVerb(_) => {
             ("BacktrackingControlVerb".to_string(), "".to_string(), None)
         }
-        Expr::Absent(_) => ("Absent".to_string(), "".to_string(), None),
+        Expr::Absent(ref absent) => {
+            use crate::Absent::*;
+            match absent {
+                Repeater(_) => ("AbsentRepeater".to_string(), "".to_string(), None),
+                Expression { .. } => ("AbsentExpression".to_string(), "".to_string(), None),
+                Stopper(_) => ("AbsentStopper".to_string(), "".to_string(), None),
+                Clear => ("AbsentClear".to_string(), "".to_string(), None),
+            }
+        }
     };
 
     let children = info
@@ -668,5 +676,51 @@ mod tests {
         let node = info_to_tree_node(&info, &group_names);
 
         assert!(!node.hard, "Simple literal pattern should be easy");
+    }
+
+    #[test]
+    fn test_info_to_tree_node_absent_repeater() {
+        let tree = fancy_regex::Expr::parse_tree(r"(?~abc)").unwrap();
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let group_names = std::collections::HashMap::new();
+
+        let node = info_to_tree_node(&info, &group_names);
+
+        assert_eq!(node.kind, "AbsentRepeater");
+    }
+
+    #[test]
+    fn test_info_to_tree_node_absent_expression() {
+        let tree = fancy_regex::Expr::parse_tree(r"(?~|abc|\d+)").unwrap();
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let group_names = std::collections::HashMap::new();
+
+        let node = info_to_tree_node(&info, &group_names);
+
+        assert_eq!(node.kind, "AbsentExpression");
+        // Should have 2 children: absent and exp
+        assert_eq!(node.children.len(), 2);
+    }
+
+    #[test]
+    fn test_info_to_tree_node_absent_stopper() {
+        let tree = fancy_regex::Expr::parse_tree(r"(?~|abc)").unwrap();
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let group_names = std::collections::HashMap::new();
+
+        let node = info_to_tree_node(&info, &group_names);
+
+        assert_eq!(node.kind, "AbsentStopper");
+    }
+
+    #[test]
+    fn test_info_to_tree_node_absent_clear() {
+        let tree = fancy_regex::Expr::parse_tree(r"(?~|)").unwrap();
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let group_names = std::collections::HashMap::new();
+
+        let node = info_to_tree_node(&info, &group_names);
+
+        assert_eq!(node.kind, "AbsentClear");
     }
 }

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -707,6 +707,10 @@ mod tests {
         let node = info_to_tree_node(&info, &group_names);
 
         assert_eq!(node.kind, "AbsentRepeater");
+        // Should have 1 children: concat
+        assert_eq!(node.children.len(), 1);
+        // concat should have a b and c literals as children
+        assert_eq!(node.children[0].children.len(), 3);
     }
 
     #[test]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -219,7 +219,9 @@ impl Compiler {
                     )));
                 }
                 // Compile the child expression as a delegate
-                let delegate = self.compile_absent_delegate(child_info)?;
+                let delegate = DelegateBuilder::new()
+                    .push(child_info)
+                    .build_delegate(&self.options)?;
 
                 // Add the Absent instruction
                 self.b.add(Insn::Absent { delegate });
@@ -650,23 +652,6 @@ impl Compiler {
         Ok(())
     }
 
-    fn compile_absent_delegate(&mut self, info: &Info) -> Result<Delegate> {
-        let mut builder = DelegateBuilder::new();
-        builder.push(info);
-
-        let capture_groups = builder
-            .capture_groups
-            .expect("Expected at least one expression");
-
-        let compiled = compile_inner(&builder.re, &self.options)?;
-
-        Ok(Delegate {
-            inner: compiled,
-            pattern: builder.re.clone(),
-            capture_groups: capture_groups.to_option_if_non_empty(),
-        })
-    }
-
     fn compile_delegates(&mut self, infos: &[Info<'_>]) -> Result<()> {
         if infos.is_empty() {
             return Ok(());
@@ -857,17 +842,21 @@ impl DelegateBuilder {
     }
 
     fn build(&self, options: &RegexOptions) -> Result<Insn> {
+        Ok(Insn::Delegate(self.build_delegate(options)?))
+    }
+
+    fn build_delegate(&self, options: &RegexOptions) -> Result<Delegate> {
         let capture_groups = self
             .capture_groups
             .expect("Expected at least one expression");
 
         let compiled = compile_inner(&self.re, options)?;
 
-        Ok(Insn::Delegate(Delegate {
+        Ok(Delegate {
             inner: compiled,
             pattern: self.re.clone(),
             capture_groups: capture_groups.to_option_if_non_empty(),
-        }))
+        })
     }
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -39,7 +39,9 @@ use crate::analyze::Info;
 use crate::vm::{CachePoolFn, ReverseBackwardsDelegate};
 use crate::vm::{CaptureGroupRange, Delegate, Insn, Prog};
 use crate::LookAround::*;
-use crate::{Absent, BacktrackingControlVerb, CompileError, Error, Expr, LookAround, RegexOptions, Result};
+use crate::{
+    Absent, BacktrackingControlVerb, CompileError, Error, Expr, LookAround, RegexOptions, Result,
+};
 
 // I'm thinking it probably doesn't make a lot of sense having this split
 // out from Compiler.
@@ -211,19 +213,21 @@ impl Compiler {
                 let child_info = &info.children[0];
                 if child_info.hard {
                     return Err(Error::CompileError(Box::new(
-                        CompileError::FeatureNotYetSupported("Absent repeater containing hard patterns".to_string()),
+                        CompileError::FeatureNotYetSupported(
+                            "Absent repeater containing hard patterns".to_string(),
+                        ),
                     )));
                 }
                 // Compile the child expression as a delegate
                 let delegate = self.compile_absent_delegate(child_info)?;
-                
+
                 // Add the Absent instruction with a placeholder for next
                 let absent_pc = self.b.pc();
                 self.b.add(Insn::Absent {
                     delegate,
                     next: 0, // Will be set below
                 });
-                
+
                 // Set the next pointer to the instruction after the Absent
                 let next_pc = self.b.pc();
                 match self.b.prog[absent_pc] {
@@ -660,13 +664,13 @@ impl Compiler {
     fn compile_absent_delegate(&mut self, info: &Info) -> Result<Delegate> {
         let mut builder = DelegateBuilder::new();
         builder.push(info);
-        
+
         let capture_groups = builder
             .capture_groups
             .expect("Expected at least one expression");
-        
+
         let compiled = compile_inner(&builder.re, &self.options)?;
-        
+
         Ok(Delegate {
             inner: compiled,
             pattern: builder.re.clone(),
@@ -938,7 +942,7 @@ mod tests {
 
         assert_eq!(prog.len(), 5, "prog: {:?}", prog);
         assert_matches!(prog[0], Save(0));
-        assert_delegate(&prog[1], "ab*", None);
+        assert_delegate_insn(&prog[1], "ab*", None);
         assert_matches!(prog[2], Restore(0));
         assert_matches!(prog[3], Lit(ref l) if l == "c");
         assert_matches!(prog[4], End);
@@ -953,7 +957,7 @@ mod tests {
         assert_matches!(prog[0], Split(1, 3));
         assert_matches!(prog[1], Lit(ref l) if l == "x");
         assert_matches!(prog[2], FailNegativeLookAround);
-        assert_delegate(&prog[3], "(?:a|ab)x*", None);
+        assert_delegate_insn(&prog[3], "(?:a|ab)x*", None);
         assert_matches!(prog[4], End);
     }
 
@@ -966,8 +970,8 @@ mod tests {
         assert_matches!(prog[0], Split(1, 3));
         assert_matches!(prog[1], Lit(ref l) if l == "x");
         assert_matches!(prog[2], FailNegativeLookAround);
-        assert_delegate(&prog[3], "(?:a|b)c", None);
-        assert_delegate(&prog[4], "x*", None);
+        assert_delegate_insn(&prog[3], "(?:a|b)c", None);
+        assert_delegate_insn(&prog[4], "x*", None);
         assert_matches!(prog[5], End);
     }
 
@@ -984,7 +988,7 @@ mod tests {
         assert_matches!(prog[4], Lit(ref l) if l == "a");
         assert_matches!(prog[5], Jmp(7));
         assert_matches!(prog[6], Lit(ref l) if l == "ab");
-        assert_delegate(&prog[7], "x*", None);
+        assert_delegate_insn(&prog[7], "x*", None);
         assert_matches!(prog[8], End);
     }
 
@@ -1188,17 +1192,16 @@ mod tests {
         );
     }
 
-    /*TODO
-    // Test that absent repeater returns feature not supported
-        let tree = Expr::parse_tree(r"(?~abc)").unwrap();
-        let info = analyze(&tree, true).unwrap();
-        let result = compile(&info, true);
-        assert!(result.is_err());
-        assert_matches!(
-            result.err().unwrap(),
-            Error::CompileError(box_err) if matches!(*box_err, CompileError::FeatureNotYetSupported(_))
-        );
-*/
+    #[test]
+    fn absent_repeater_with_easy_inner_compiles() {
+        let prog = compile_prog(r"((?~abc))");
+
+        assert_eq!(prog.len(), 4, "prog: {:?}", prog);
+        assert_matches!(prog[0], Save(0));
+        assert_absent_insn(&prog[1], "abc", None);
+        assert_matches!(prog[2], Save(1));
+        assert_matches!(prog[3], End);
+    }
 
     #[test]
     fn absent_operators_error() {
@@ -1238,7 +1241,7 @@ mod tests {
         let prog = compile_prog(r"(.(b)([^a]+))c");
 
         assert_eq!(prog.len(), 2, "prog: {:?}", prog);
-        assert_delegate(&prog[0], "(.(b)([^a]+))c", Some(CaptureGroupRange(0, 3)));
+        assert_delegate_insn(&prog[0], "(.(b)([^a]+))c", Some(CaptureGroupRange(0, 3)));
         assert_matches!(prog[1], End);
     }
 
@@ -1249,15 +1252,15 @@ mod tests {
         assert_eq!(prog.len(), 12, "prog: {:?}", prog);
 
         assert_matches!(prog[0], Save(0));
-        assert_delegate(&prog[1], ".(b)", Some(CaptureGroupRange(1, 2)));
+        assert_delegate_insn(&prog[1], ".(b)", Some(CaptureGroupRange(1, 2)));
         assert_matches!(prog[2], Save(4));
-        assert_delegate(&prog[3], "[^a]", None);
+        assert_delegate_insn(&prog[3], "[^a]", None);
         assert_matches!(prog[4], Split(3, 5));
         assert_matches!(prog[5], Save(5));
         assert_matches!(prog[6], Split(7, 9));
         assert_matches!(prog[7], Lit(ref l) if l == "c");
         assert_matches!(prog[8], FailNegativeLookAround);
-        assert_delegate(&prog[9], r"(\w)", Some(CaptureGroupRange(3, 4)));
+        assert_delegate_insn(&prog[9], r"(\w)", Some(CaptureGroupRange(3, 4)));
         assert_matches!(prog[10], Save(1));
         assert_matches!(prog[11], End);
     }
@@ -1270,29 +1273,40 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
-    fn assert_delegate(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
-        use crate::vm::Delegate;
-
+    fn assert_delegate_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
         match insn {
-            Insn::Delegate(Delegate {
-                inner,
-                capture_groups,
-                ..
-            }) => {
-                assert_eq!(
-                    PATTERN_MAPPING
-                        .read()
-                        .unwrap()
-                        .get(&alloc::format!("{:?}", inner))
-                        .unwrap(),
-                    re
-                );
-                assert_eq!(captures, *capture_groups);
-            }
+            Insn::Delegate(delegate) => assert_delegate(delegate, re, captures),
             _ => {
                 panic!("Expected Insn::Delegate but was {:#?}", insn);
             }
         }
+    }
+
+    #[cfg(feature = "std")]
+    fn assert_absent_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
+        match insn {
+            Insn::Absent { delegate, .. } => assert_delegate(delegate, re, captures),
+            _ => {
+                panic!("Expected Insn::Absent but was {:#?}", insn);
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    fn assert_delegate(
+        delegate: &crate::vm::Delegate,
+        re: &str,
+        captures: Option<CaptureGroupRange>,
+    ) {
+        assert_eq!(
+            PATTERN_MAPPING
+                .read()
+                .unwrap()
+                .get(&alloc::format!("{:?}", delegate.inner))
+                .unwrap(),
+            re
+        );
+        assert_eq!(captures, delegate.capture_groups);
     }
 
     #[cfg(not(feature = "std"))]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1250,7 +1250,6 @@ mod tests {
         prog.body
     }
 
-    #[cfg(feature = "std")]
     fn assert_delegate_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
         match insn {
             Insn::Delegate(delegate) => assert_delegate(delegate, re, captures),
@@ -1260,7 +1259,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
     fn assert_absent_repeater_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
         match insn {
             Insn::AbsentRepeater(delegate) => assert_delegate(delegate, re, captures),
@@ -1288,5 +1286,5 @@ mod tests {
     }
 
     #[cfg(not(feature = "std"))]
-    fn assert_delegate(_: &Insn, _: &str, _: Option<CaptureGroupRange>) {}
+    fn assert_delegate(_: &crate::vm::Delegate, _: &str, _: Option<CaptureGroupRange>) {}
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -39,7 +39,7 @@ use crate::analyze::Info;
 use crate::vm::{CachePoolFn, ReverseBackwardsDelegate};
 use crate::vm::{CaptureGroupRange, Delegate, Insn, Prog};
 use crate::LookAround::*;
-use crate::{BacktrackingControlVerb, CompileError, Error, Expr, LookAround, RegexOptions, Result};
+use crate::{Absent, BacktrackingControlVerb, CompileError, Error, Expr, LookAround, RegexOptions, Result};
 
 // I'm thinking it probably doesn't make a lot of sense having this split
 // out from Compiler.
@@ -206,6 +206,30 @@ impl Compiler {
             }
             Expr::Conditional { .. } => {
                 self.compile_conditional(|compiler, i| compiler.visit(&info.children[i], hard))?;
+            }
+            Expr::Absent(Absent::Repeater(_)) => {
+                let child_info = &info.children[0];
+                if child_info.hard {
+                    return Err(Error::CompileError(Box::new(
+                        CompileError::FeatureNotYetSupported("Absent repeater containing hard patterns".to_string()),
+                    )));
+                }
+                // Compile the child expression as a delegate
+                let delegate = self.compile_absent_delegate(child_info)?;
+                
+                // Add the Absent instruction with a placeholder for next
+                let absent_pc = self.b.pc();
+                self.b.add(Insn::Absent {
+                    delegate,
+                    next: 0, // Will be set below
+                });
+                
+                // Set the next pointer to the instruction after the Absent
+                let next_pc = self.b.pc();
+                match self.b.prog[absent_pc] {
+                    Insn::Absent { ref mut next, .. } => *next = next_pc,
+                    _ => unreachable!(),
+                }
             }
             Expr::SubroutineCall(_) => {
                 return Err(Error::CompileError(Box::new(
@@ -631,6 +655,23 @@ impl Compiler {
                 capture_groups: capture_groups.to_option_if_non_empty(),
             }));
         Ok(())
+    }
+
+    fn compile_absent_delegate(&mut self, info: &Info) -> Result<Delegate> {
+        let mut builder = DelegateBuilder::new();
+        builder.push(info);
+        
+        let capture_groups = builder
+            .capture_groups
+            .expect("Expected at least one expression");
+        
+        let compiled = compile_inner(&builder.re, &self.options)?;
+        
+        Ok(Delegate {
+            inner: compiled,
+            pattern: builder.re.clone(),
+            capture_groups: capture_groups.to_option_if_non_empty(),
+        })
     }
 
     fn compile_delegates(&mut self, infos: &[Info<'_>]) -> Result<()> {
@@ -1147,9 +1188,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn absent_operators_error() {
-        // Test that absent repeater returns feature not supported
+    /*TODO
+    // Test that absent repeater returns feature not supported
         let tree = Expr::parse_tree(r"(?~abc)").unwrap();
         let info = analyze(&tree, true).unwrap();
         let result = compile(&info, true);
@@ -1158,7 +1198,10 @@ mod tests {
             result.err().unwrap(),
             Error::CompileError(box_err) if matches!(*box_err, CompileError::FeatureNotYetSupported(_))
         );
+*/
 
+    #[test]
+    fn absent_operators_error() {
         // Test that absent expression returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc|\d*)").unwrap();
         let info = analyze(&tree, true).unwrap();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -221,19 +221,8 @@ impl Compiler {
                 // Compile the child expression as a delegate
                 let delegate = self.compile_absent_delegate(child_info)?;
 
-                // Add the Absent instruction with a placeholder for next
-                let absent_pc = self.b.pc();
-                self.b.add(Insn::Absent {
-                    delegate,
-                    next: 0, // Will be set below
-                });
-
-                // Set the next pointer to the instruction after the Absent
-                let next_pc = self.b.pc();
-                match self.b.prog[absent_pc] {
-                    Insn::Absent { ref mut next, .. } => *next = next_pc,
-                    _ => unreachable!(),
-                }
+                // Add the Absent instruction
+                self.b.add(Insn::Absent { delegate });
             }
             Expr::SubroutineCall(_) => {
                 return Err(Error::CompileError(Box::new(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -224,7 +224,7 @@ impl Compiler {
                     .build_delegate(&self.options)?;
 
                 // Add the Absent instruction
-                self.b.add(Insn::Absent { delegate });
+                self.b.add(Insn::AbsentRepeater(delegate));
             }
             Expr::SubroutineCall(_) => {
                 return Err(Error::CompileError(Box::new(
@@ -1176,7 +1176,7 @@ mod tests {
 
         assert_eq!(prog.len(), 4, "prog: {:?}", prog);
         assert_matches!(prog[0], Save(0));
-        assert_absent_insn(&prog[1], "abc", None);
+        assert_absent_repeater_insn(&prog[1], "abc", None);
         assert_matches!(prog[2], Save(1));
         assert_matches!(prog[3], End);
     }
@@ -1261,11 +1261,11 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
-    fn assert_absent_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
+    fn assert_absent_repeater_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {
         match insn {
-            Insn::Absent { delegate, .. } => assert_delegate(delegate, re, captures),
+            Insn::AbsentRepeater(delegate) => assert_delegate(delegate, re, captures),
             _ => {
-                panic!("Expected Insn::Absent but was {:#?}", insn);
+                panic!("Expected Insn::AbsentRepeater but was {:#?}", insn);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 #![doc = include_str!("../docs/subroutines/2_flags.md")]
 #![doc = include_str!("../docs/subroutines/3_left_recursion.md")]
 #![doc = include_str!("../docs/subroutines/4_recursion.md")]
+#![doc = include_str!("../docs/absent.md")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -313,11 +313,8 @@ pub enum Insn {
     #[cfg(feature = "variable-lookbehinds")]
     /// Reverse lookbehind using regex-automata for variable-sized patterns
     BackwardsDelegate(ReverseBackwardsDelegate),
-    /// Absent operator - matches if delegate does not match from current position
-    Absent {
-        /// The delegate pattern to check
-        delegate: Delegate,
-    },
+    /// Absent repeater operator - matches if delegate does not match from current position
+    AbsentRepeater(Delegate),
 }
 
 /// Sequence of instructions for the VM to execute.
@@ -956,7 +953,7 @@ pub(crate) fn run(
                         }
                     }
                 }
-                Insn::Absent { ref delegate } => {
+                Insn::AbsentRepeater(ref delegate) => {
                     // The absent operator matches the shortest string not containing the delegate pattern
                     // We advance one character at a time, checking if delegate matches at each position
                     // If delegate matches, we've found the boundary and continue to next instruction

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -313,6 +313,13 @@ pub enum Insn {
     #[cfg(feature = "variable-lookbehinds")]
     /// Reverse lookbehind using regex-automata for variable-sized patterns
     BackwardsDelegate(ReverseBackwardsDelegate),
+    /// Absent operator - matches if delegate does not match from current position
+    Absent {
+        /// The delegate pattern to check
+        delegate: Delegate,
+        /// Program counter for continuing after absent check
+        next: usize,
+    },
 }
 
 /// Sequence of instructions for the VM to execute.
@@ -949,6 +956,42 @@ pub(crate) fn run(
                             Some(m) => ix = m.offset(),
                             _ => break 'fail,
                         }
+                    }
+                }
+                Insn::Absent { ref delegate, next } => {
+                    // The absent operator matches the shortest string not containing the delegate pattern
+                    // We advance one character at a time, checking if delegate matches at each position
+                    // If delegate matches, we've found the boundary and continue to next instruction
+                    // If we reach end of string without delegate matching, we also continue
+                    
+                    // Check if delegate matches at current position
+                    let input = Input::new(s).span(ix..s.len()).anchored(Anchored::Yes);
+                    let delegate_matches_here = if delegate.capture_groups.is_some() {
+                        let range = delegate.capture_groups.unwrap();
+                        inner_slots.resize((range.end() - range.start() + 1) * 2, None);
+                        delegate.inner.search_slots(&input, &mut inner_slots).is_some()
+                    } else {
+                        delegate.inner.search_half(&input).is_some()
+                    };
+                    
+                    if delegate_matches_here {
+                        // Delegate matches at current position - we've reached the boundary
+                        // Continue to next instruction without consuming any characters
+                        pc = next;
+                        continue;
+                    }
+                    
+                    // Delegate doesn't match here
+                    if ix < s.len() {
+                        // Try advancing one character and checking again
+                        state.push(next, ix)?; // If advancing fails, continue to next instruction
+                        ix += codepoint_len_at(s, ix);
+                        // Stay at same pc to check delegate match at new position
+                        continue;
+                    } else {
+                        // Reached end of string - delegate never matched, so we succeed
+                        pc = next;
+                        continue;
                     }
                 }
                 Insn::ContinueFromPreviousMatchEnd { at_start } => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -963,24 +963,27 @@ pub(crate) fn run(
                     // We advance one character at a time, checking if delegate matches at each position
                     // If delegate matches, we've found the boundary and continue to next instruction
                     // If we reach end of string without delegate matching, we also continue
-                    
+
                     // Check if delegate matches at current position
                     let input = Input::new(s).span(ix..s.len()).anchored(Anchored::Yes);
                     let delegate_matches_here = if delegate.capture_groups.is_some() {
                         let range = delegate.capture_groups.unwrap();
                         inner_slots.resize((range.end() - range.start() + 1) * 2, None);
-                        delegate.inner.search_slots(&input, &mut inner_slots).is_some()
+                        delegate
+                            .inner
+                            .search_slots(&input, &mut inner_slots)
+                            .is_some()
                     } else {
                         delegate.inner.search_half(&input).is_some()
                     };
-                    
+
                     if delegate_matches_here {
                         // Delegate matches at current position - we've reached the boundary
                         // Continue to next instruction without consuming any characters
                         pc = next;
                         continue;
                     }
-                    
+
                     // Delegate doesn't match here
                     if ix < s.len() {
                         // Try advancing one character and checking again

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -964,16 +964,8 @@ pub(crate) fn run(
 
                     // Check if delegate matches at current position
                     let input = Input::new(s).span(ix..s.len()).anchored(Anchored::Yes);
-                    let delegate_matches_here = if delegate.capture_groups.is_some() {
-                        let range = delegate.capture_groups.unwrap();
-                        inner_slots.resize((range.end() - range.start() + 1) * 2, None);
-                        delegate
-                            .inner
-                            .search_slots(&input, &mut inner_slots)
-                            .is_some()
-                    } else {
-                        delegate.inner.search_half(&input).is_some()
-                    };
+                    // capture groups in the delegate are always ignored, so we can use the quicker search_half method
+                    let delegate_matches_here = delegate.inner.search_half(&input).is_some();
 
                     if delegate_matches_here {
                         // Delegate matches at current position - we've reached the boundary

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -317,8 +317,6 @@ pub enum Insn {
     Absent {
         /// The delegate pattern to check
         delegate: Delegate,
-        /// Program counter for continuing after absent check
-        next: usize,
     },
 }
 
@@ -958,7 +956,7 @@ pub(crate) fn run(
                         }
                     }
                 }
-                Insn::Absent { ref delegate, next } => {
+                Insn::Absent { ref delegate } => {
                     // The absent operator matches the shortest string not containing the delegate pattern
                     // We advance one character at a time, checking if delegate matches at each position
                     // If delegate matches, we've found the boundary and continue to next instruction
@@ -980,21 +978,16 @@ pub(crate) fn run(
                     if delegate_matches_here {
                         // Delegate matches at current position - we've reached the boundary
                         // Continue to next instruction without consuming any characters
-                        pc = next;
-                        continue;
-                    }
-
-                    // Delegate doesn't match here
-                    if ix < s.len() {
+                        // Fall through via pc += 1 below
+                    } else if ix < s.len() {
                         // Try advancing one character and checking again
-                        state.push(next, ix)?; // If advancing fails, continue to next instruction
+                        state.push(pc + 1, ix)?;
                         ix += codepoint_len_at(s, ix);
                         // Stay at same pc to check delegate match at new position
                         continue;
                     } else {
                         // Reached end of string - delegate never matched, so we succeed
-                        pc = next;
-                        continue;
+                        // Fall through via pc += 1 below
                     }
                 }
                 Insn::ContinueFromPreviousMatchEnd { at_start } => {

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -208,56 +208,8 @@
   // Compile failed: ParseError(1, InvalidEscape("\\o"))
   x2("[\\o{101}]", "A", 0, 1);
 
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~)", "", 0, 0);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~)", "A", 0, 0);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("aaaaa(?~)", "aaaaaaaaaa", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~(?:|aaa))", "aaa", 0, 0);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~aaa|)", "aaa", 0, 0);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
+  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater containing hard patterns"))
   x2("a(?~(?~)).", "abcdefghijklmnopqrstuvwxyz", 0, 26);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("/\\*(?~\\*/)\\*/", "/* */ */", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~\\w+)zzzzz", "zzzzz", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~\\w*)zzzzz", "zzzzz", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~A.C|B)", "ABC", 0, 0);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~XYZ|ABC)a", "ABCa", 1, 4);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~XYZ|ABC)a", "aABCa", 0, 1);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("<[^>]*>(?~[<>])</[^>]*>", "<a>vvv</a>   <b>  </b>", 0, 10);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~ab)", "ccc\ndab", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?m:(?~ab))", "ccc\ndab", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?-m:(?~ab))", "ccc\ndab", 0, 5);
-
-  // Compile failed: CompileError(FeatureNotYetSupported("Absent repeater"))
-  x2("(?~abc)xyz", "xyz012345678901234567890123456789abc", 0, 3);
 
   // Compile failed: CompileError(FeatureNotYetSupported("Absent expression"))
   x2("(?~|78|\\d*)", "123456789", 0, 6);


### PR DESCRIPTION
Add support for Oniguruma's absent repeater, with documentation.

I also updated the playground's `info_to_tree_node` method to show more details about `Absent` `Expr`s and while I was there, made the `summary` on `AnalysisTreeNode` optional.