### PR TITLE
Refactor regex options to make it easier to build multiple patterns using the same options

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -826,17 +826,9 @@ impl<'a> Compiler<'a> {
 static PATTERN_MAPPING: RwLock<BTreeMap<String, String>> = RwLock::new(BTreeMap::new());
 
 pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<RaRegex> {
-    let mut config = RaConfig::new();
-    if let Some(size_limit) = options.delegate_size_limit {
-        config = config.nfa_size_limit(Some(size_limit));
-    }
-    if let Some(dfa_size_limit) = options.delegate_dfa_size_limit {
-        config = config.dfa_size_limit(Some(dfa_size_limit));
-    }
+    let builder = options_to_rabuilder(options);
 
-    let re = RaBuilder::new()
-        .configure(config)
-        .syntax(options.syntaxc)
+    let re = builder
         .build(inner_re)
         .map_err(CompileError::InnerError)
         .map_err(|e| Error::CompileError(Box::new(e)))?;
@@ -848,6 +840,21 @@ pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<Ra
         .insert(format!("{:?}", re), inner_re.to_owned());
 
     Ok(re)
+}
+
+pub(crate) fn options_to_rabuilder(options: &RegexOptions) -> RaBuilder {
+    let mut config = RaConfig::new();
+    if let Some(limit) = options.delegate_size_limit {
+        config = config.nfa_size_limit(Some(limit));
+    }
+    if let Some(limit) = options.delegate_dfa_size_limit {
+        config = config.dfa_size_limit(Some(limit));
+    }
+
+    let mut builder = RaBuilder::new();
+    builder.configure(config);
+    builder.syntax(options.syntaxc);
+    builder
 }
 
 /// Recursively populate the group_info_map with all capture groups in the Info tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,12 @@ const MAX_RECURSION: usize = 64;
 #[derive(Debug)]
 pub struct RegexBuilder {
     pattern: String,
+    options: RegexOptionsBuilder,
+}
+
+/// A builder for a `Regex` to allow configuring options.
+#[derive(Debug)]
+pub struct RegexOptionsBuilder {
     options: RegexOptions,
 }
 
@@ -99,8 +105,8 @@ enum RegexImpl {
         pattern: String,
         /// Some optimizations avoid the VM, but need to use an extra capture group to represent the match boundaries
         explicit_capture_group_0: bool,
-        /// The actual pattern passed to regex-automata
-        debug_pattern: String,
+        /// The actual pattern passed to regex-automata for delegation
+        delegated_pattern: String,
     },
     Fancy {
         prog: Arc<Prog>,
@@ -388,7 +394,7 @@ impl<'r, 'h> Iterator for SplitN<'r, 'h> {
 
 impl<'r, 'h> core::iter::FusedIterator for SplitN<'r, 'h> {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct RegexOptions {
     syntaxc: SyntaxConfig,
     delegate_size_limit: Option<usize>,
@@ -420,19 +426,7 @@ impl RegexOptions {
         let unicode = Self::get_flag_value(self.syntaxc.get_unicode(), FLAG_UNICODE);
         let oniguruma_mode = Self::get_flag_value(self.oniguruma_mode, FLAG_ONIGURUMA_MODE);
 
-        insensitive | multiline | whitespace | dotnl | unicode | unicode | oniguruma_mode
-    }
-}
-
-impl Default for RegexOptions {
-    fn default() -> Self {
-        RegexOptions {
-            syntaxc: SyntaxConfig::default(),
-            delegate_size_limit: None,
-            delegate_dfa_size_limit: None,
-            oniguruma_mode: false,
-            hard_regex_runtime_options: HardRegexRuntimeOptions::default(),
-        }
+        insensitive | multiline | whitespace | dotnl | unicode | oniguruma_mode
     }
 }
 
@@ -444,22 +438,25 @@ impl Default for HardRegexRuntimeOptions {
     }
 }
 
-impl RegexBuilder {
-    /// Create a new regex builder with a regex pattern.
-    ///
-    /// If the pattern is invalid, the call to `build` will fail later.
-    pub fn new(pattern: &str) -> Self {
-        RegexBuilder {
-            pattern: pattern.to_string(),
+impl Default for RegexOptionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RegexOptionsBuilder {
+    /// Create a new regex options builder.
+    pub fn new() -> Self {
+        RegexOptionsBuilder {
             options: RegexOptions::default(),
         }
     }
 
-    /// Build the `Regex`.
+    /// Build a `Regex` from the given pattern.
     ///
     /// Returns an [`Error`](enum.Error.html) if the pattern could not be parsed.
-    pub fn build(&self) -> Result<Regex> {
-        Regex::new_options(self.pattern.clone(), &self.options)
+    pub fn build(&self, pattern: String) -> Result<Regex> {
+        Regex::new_options(pattern, &self.options)
     }
 
     fn set_config(&mut self, func: impl Fn(SyntaxConfig) -> SyntaxConfig) -> &mut Self {
@@ -467,15 +464,9 @@ impl RegexBuilder {
         self
     }
 
-    /// Change the pattern to build
-    pub fn pattern(&mut self, pattern: String) -> &mut Self {
-        self.pattern = pattern;
-        self
-    }
-
     /// Override default case insensitive
     /// this is to enable/disable casing via builder instead of a flag within
-    /// the raw string provided to the regex builder
+    /// the raw string pattern which will be parsed
     ///
     /// Default is false
     pub fn case_insensitive(&mut self, yes: bool) -> &mut Self {
@@ -599,6 +590,90 @@ impl RegexBuilder {
     }
 }
 
+impl RegexBuilder {
+    /// Create a new regex builder.
+    pub fn new(pattern: &str) -> Self {
+        RegexBuilder {
+            pattern: pattern.to_string(),
+            options: RegexOptionsBuilder::new(),
+        }
+    }
+
+    /// Build a `Regex` from the given pattern.
+    ///
+    /// Returns an [`Error`](enum.Error.html) if the pattern could not be parsed.
+    pub fn build(&self) -> Result<Regex> {
+        self.options.build(self.pattern.clone())
+    }
+
+    /// Change the pattern to build. Useful when building multiple regexes from
+    /// many patterns.
+    pub fn pattern(&mut self, pattern: String) -> &mut Self {
+        self.pattern = pattern;
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::case_insensitive`]
+    pub fn case_insensitive(&mut self, yes: bool) -> &mut Self {
+        self.options.case_insensitive(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::multi_line`]
+    pub fn multi_line(&mut self, yes: bool) -> &mut Self {
+        self.options.multi_line(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::ignore_whitespace`]
+    pub fn ignore_whitespace(&mut self, yes: bool) -> &mut Self {
+        self.options.ignore_whitespace(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::dot_matches_new_line`]
+    pub fn dot_matches_new_line(&mut self, yes: bool) -> &mut Self {
+        self.options.dot_matches_new_line(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::verbose_mode`]
+    pub fn verbose_mode(&mut self, yes: bool) -> &mut Self {
+        self.options.ignore_whitespace(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::unicode_mode`]
+    pub fn unicode_mode(&mut self, yes: bool) -> &mut Self {
+        self.options.unicode_mode(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::backtrack_limit`]
+    pub fn backtrack_limit(&mut self, limit: usize) -> &mut Self {
+        self.options.backtrack_limit(limit);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::delegate_size_limit`]
+    pub fn delegate_size_limit(&mut self, limit: usize) -> &mut Self {
+        self.options.delegate_size_limit(limit);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::delegate_dfa_size_limit`]
+    pub fn delegate_dfa_size_limit(&mut self, limit: usize) -> &mut Self {
+        self.options.delegate_dfa_size_limit(limit);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::oniguruma_mode`]
+    pub fn oniguruma_mode(&mut self, yes: bool) -> &mut Self {
+        self.options.oniguruma_mode(yes);
+        self
+    }
+}
+
 impl fmt::Debug for Regex {
     /// Shows the original regular expression.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -644,13 +719,13 @@ impl Regex {
             // NOTE: there is a good opportunity here to use Hir to avoid regex-automata re-parsing it
             let mut re_cooked = String::new();
             tree.expr.to_str(&mut re_cooked, 0);
-            let inner = compile::compile_inner(&re_cooked, &options)?;
+            let inner = compile::compile_inner(&re_cooked, options)?;
             return Ok(Regex {
                 inner: RegexImpl::Wrap {
                     inner,
                     pattern,
                     explicit_capture_group_0: requires_capture_group_fixup,
-                    debug_pattern: re_cooked,
+                    delegated_pattern: re_cooked,
                 },
                 named_groups: Arc::new(tree.named_groups),
             });
@@ -970,14 +1045,14 @@ impl Regex {
     pub fn debug_print(&self, writer: &mut Formatter<'_>) -> fmt::Result {
         match &self.inner {
             RegexImpl::Wrap {
-                debug_pattern,
+                delegated_pattern,
                 explicit_capture_group_0,
                 ..
             } => {
                 write!(
                     writer,
                     "wrapped Regex {:?}, explicit_capture_group_0: {:}",
-                    debug_pattern, *explicit_capture_group_0
+                    delegated_pattern, *explicit_capture_group_0
                 )
             }
             RegexImpl::Fancy { prog, .. } => prog.debug_print(writer),
@@ -2006,7 +2081,7 @@ fn codepoint_len(b: u8) -> usize {
 /// Returns the smallest possible index of the next valid UTF-8 sequence
 /// starting after `i`.
 /// Adapted from a function with the same name in the `regex` crate.
-fn next_utf8(text: &str, i: usize) -> usize {
+pub(crate) fn next_utf8(text: &str, i: usize) -> usize {
     let b = match text.as_bytes().get(i) {
         None => return i + 1,
         Some(&b) => b,

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -111,10 +111,10 @@ fn atomic_group() {
 
 #[test]
 fn backtrack_limit() {
-    let re = RegexBuilder::new("(?i)(a|b|ab)*(?>c)")
+    let re = RegexBuilder::new(r"(?i)(a|b|ab)*(?>c)")
         .backtrack_limit(100_000)
         .build()
-        .unwrap();
+        .expect("regex to compile successfully");
     let s = "abababababababababababababababababababababababababababab";
     let result = re.is_match(s);
     assert!(result.is_err());

--- a/tests/regex_options.rs
+++ b/tests/regex_options.rs
@@ -1,7 +1,7 @@
 use fancy_regex::Regex;
 use fancy_regex::RegexBuilder;
 
-pub fn build_regex(builder: &RegexBuilder) -> Regex {
+fn build_regex(builder: &RegexBuilder) -> Regex {
     let result = builder.build();
     assert!(
         result.is_ok(),


### PR DESCRIPTION
Refactor regex options to make it easier to build multiple patterns using the same options
And make it clearer what options are actually used by the VM

This will be especially useful when we add a RegexSet feature.

This allows us to maintain a regex crate adjacent API while also improving ergonomics. I kept the documentation in one place and linked to it from the other to aid maintainance.