### PR TITLE
Add support for defining subroutines inside (conditional-style) DEFINE blocks

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -82,7 +82,9 @@ Conditionals - if/then/else:
 `(?(1)true_branch|false_branch)`
 : if the first capture group matched then execute the true_branch regex expression, else execute false_branch ([docs](https://www.regular-expressions.info/conditional.html)) \
 `(?(condition)true_branch|false_branch)`
-: if the condition matches then execute the true_branch regex expression, else execute false_branch from the point just before the condition was evaluated
+: if the condition matches then execute the true_branch regex expression, else execute false_branch from the point just before the condition was evaluated \
+`(?(DEFINE)(capture group)(?<named_group>another)`
+: define capture groups for later use in subroutine calls
 
 Backtracking control verbs:
 

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -377,6 +377,7 @@ fn info_to_tree_node<'a>(
                 Clear => ("AbsentClear".to_string(), None, None),
             }
         }
+        Expr::DefineGroup { .. } => ("DefineGroup".to_string(), None, None),
     };
 
     let children = info
@@ -746,5 +747,16 @@ mod tests {
         let node = info_to_tree_node(&info, &group_names);
 
         assert_eq!(node.kind, "AbsentClear");
+    }
+
+    #[test]
+    fn test_info_to_tree_node_define_group() {
+        let tree = fancy_regex::Expr::parse_tree(r"(?(DEFINE)(a)(b))").unwrap();
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let group_names = std::collections::HashMap::new();
+
+        let node = info_to_tree_node(&info, &group_names);
+
+        assert_eq!(node.kind, "DefineGroup");
     }
 }

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -469,6 +469,16 @@ impl<'a> Analyzer<'a> {
                     }
                 }
             }
+            Expr::DefineGroup { ref definitions } => {
+                // DEFINE groups don't match anything themselves, but we still need to
+                // visit the definitions to assign group numbers and analyze any nested content.
+                // The DEFINE block itself is not hard - it matches nothing, so it can be
+                // delegated (as an empty string) to the underlying engine.
+                let def_info = self.visit(definitions, 0, inside_zero_rep, enclosing_group)?;
+                min_size = 0;
+                const_size = true;
+                children.push(def_info);
+            }
         };
 
         Ok(Info {
@@ -611,6 +621,9 @@ impl<'a> Analyzer<'a> {
             }
             Expr::UnresolvedNamedSubroutineCall { .. }
             | Expr::BackrefWithRelativeRecursionLevel { .. } => true,
+            Expr::DefineGroup { definitions } => {
+                self.expr_can_terminate(definitions, root_expr, recursion_stack, memo)
+            }
             _ => true,
         }
     }
@@ -1672,5 +1685,40 @@ mod tests {
         assert!(matches!(info.children[4].expr, Expr::LookAround(_, _)));
         assert_eq!(info.children[4].start_group(), 6);
         assert_eq!(info.children[4].end_group(), 6);
+    }
+
+    #[test]
+    fn define_group_is_easy_zero_size() {
+        // A DEFINE block should be analyzed as: min_size=0, const_size=true, hard=false
+        // It matches nothing itself, so it doesn't need backtracking.
+        let tree = Expr::parse_tree(r"(?(DEFINE)(?<word>\w+))").unwrap();
+        let info = analyze(&tree, false).unwrap();
+
+        assert!(matches!(info.expr, Expr::DefineGroup { .. }));
+        assert_eq!(info.min_size, 0);
+        assert!(info.const_size);
+        assert!(!info.hard);
+    }
+
+    #[test]
+    fn define_group_assigns_group_numbers() {
+        // Groups inside a DEFINE block should still be assigned group numbers,
+        // so that subroutine calls can reference them.
+        let tree = Expr::parse_tree(r"(?(DEFINE)(?<first>a)(?<second>b))").unwrap();
+        let info = analyze(&tree, false).unwrap();
+
+        // The definitions child: a Concat of two groups (groups 1 and 2)
+        assert_eq!(info.children[0].start_group(), 1);
+        assert_eq!(info.children[0].end_group(), 3);
+
+        // Group numbers are assigned in the usual order
+        let tree = Expr::parse_tree(r"(abc)(?(DEFINE)(?<second>a)ignored: no group(?<third>b(?<fourth>c)))(?<fifth>d)").unwrap();
+        let info = analyze(&tree, false).unwrap();
+
+        assert_eq!(info.start_group(), 1);
+        assert_eq!(info.end_group(), 6);
+        assert_eq!(info.children[0].start_group(), 1);
+        assert_eq!(info.children[1].children[0].start_group(), 2);
+        assert_eq!(info.children[2].start_group(), 5);
     }
 }

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1712,7 +1712,10 @@ mod tests {
         assert_eq!(info.children[0].end_group(), 3);
 
         // Group numbers are assigned in the usual order
-        let tree = Expr::parse_tree(r"(abc)(?(DEFINE)(?<second>a)ignored: no group(?<third>b(?<fourth>c)))(?<fifth>d)").unwrap();
+        let tree = Expr::parse_tree(
+            r"(abc)(?(DEFINE)(?<second>a)ignored: no group(?<third>b(?<fourth>c)))(?<fifth>d)",
+        )
+        .unwrap();
         let info = analyze(&tree, false).unwrap();
 
         assert_eq!(info.start_group(), 1);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -319,6 +319,13 @@ impl<'a> Compiler<'a> {
                     CompileError::FeatureNotYetSupported(error_msg.to_string()),
                 )));
             }
+            Expr::DefineGroup { .. } => {
+                // DEFINE groups don't generate any VM instructions themselves.
+                // The groups defined inside are available for subroutine calls,
+                // but the DEFINE block itself doesn't match anything.
+                // Group numbers were already assigned during analysis, and the
+                // subroutine calls will inline the appropriate code when invoked.
+            }
         }
         Ok(())
     }
@@ -1380,6 +1387,16 @@ mod tests {
         assert_delegate_insn(&prog[4], "(.)", Some(CaptureGroupRange(1, 2)));
         assert_matches!(prog[5], Save(1));
         assert_matches!(prog[6], End);
+    }
+
+    #[test]
+    fn define_group_is_delegated_as_empty() {
+        // A standalone DEFINE block is not hard, so it gets delegated as an empty regex
+        let prog = compile_prog(r"(?(DEFINE)(?<word>\w+))");
+
+        assert_eq!(prog.len(), 2, "prog: {:?}", prog);
+        assert_delegate_insn(&prog[0], "", Some(CaptureGroupRange(0, 1)));
+        assert_matches!(prog[1], End);
     }
 
     fn compile_prog(re: &str) -> Vec<Insn> {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -758,21 +758,28 @@ impl<'a> Compiler<'a> {
         for info in infos {
             delegate_builder.push(info);
         }
-        let delegate = delegate_builder.build(&self.options)?;
-
-        self.b.add(delegate);
+        // Skip emitting a delegate for an empty regex (e.g. a batch of
+        // only DefineGroups), as it would just match the empty string.
+        if !delegate_builder.is_empty() {
+            self.b.add(delegate_builder.build(&self.options)?);
+        }
         Ok(())
     }
 
     fn compile_delegate(&mut self, info: &Info) -> Result<()> {
-        let insn = if info.is_literal() {
+        if info.is_literal() {
             let mut val = String::new();
             info.push_literal(&mut val);
-            Insn::Lit(val)
+            self.b.add(Insn::Lit(val));
         } else {
-            DelegateBuilder::new().push(info).build(&self.options)?
-        };
-        self.b.add(insn);
+            let mut builder = DelegateBuilder::new();
+            builder.push(info);
+            // Skip emitting a delegate for an empty regex (e.g. DefineGroup),
+            // as it would just match the empty string and is a no-op.
+            if !builder.is_empty() {
+                self.b.add(builder.build(&self.options)?);
+            }
+        }
         Ok(())
     }
 
@@ -926,6 +933,11 @@ impl DelegateBuilder {
             const_size: true,
             capture_groups: None,
         }
+    }
+
+    /// Returns true if the regex string built so far is empty.
+    fn is_empty(&self) -> bool {
+        self.re.is_empty()
     }
 
     fn push(&mut self, info: &Info<'_>) -> &mut DelegateBuilder {
@@ -1390,13 +1402,13 @@ mod tests {
     }
 
     #[test]
-    fn define_group_is_delegated_as_empty() {
-        // A standalone DEFINE block is not hard, so it gets delegated as an empty regex
+    fn define_group_is_a_no_op() {
+        // A DEFINE block is not hard but produces an empty delegate regex,
+        // so compilation skips it entirely — only the End instruction remains.
         let prog = compile_prog(r"(?(DEFINE)(?<word>\w+))");
 
-        assert_eq!(prog.len(), 2, "prog: {:?}", prog);
-        assert_delegate_insn(&prog[0], "", Some(CaptureGroupRange(0, 1)));
-        assert_matches!(prog[1], End);
+        assert_eq!(prog.len(), 1, "prog: {:?}", prog);
+        assert_matches!(prog[0], End);
     }
 
     fn compile_prog(re: &str) -> Vec<Insn> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1543,6 +1543,13 @@ pub enum Expr {
     BacktrackingControlVerb(BacktrackingControlVerb),
     /// Match while the given expression is absent from the haystack
     Absent(Absent),
+    /// DEFINE group - defines capture groups for subroutines without matching anything
+    /// The expressions inside are parsed and assigned group numbers, but no VM instructions
+    /// are generated for the DEFINE block itself.
+    DefineGroup {
+        /// The expressions/groups being defined
+        definitions: Box<Expr>,
+    },
 }
 
 /// Type of look-around assertion as used for a look-around expression.
@@ -1816,6 +1823,7 @@ macro_rules! children_iter_match {
                 second: Some(exp.$single_method()),
                 third: None,
             },
+            Expr::DefineGroup { definitions } => $iter::Single(Some(definitions.$single_method())),
             _ if $self.is_leaf_node() => $iter::Empty,
             _ => unimplemented!(),
         }
@@ -1975,6 +1983,9 @@ impl Expr {
                 if casei {
                     buf.push(')');
                 }
+            }
+            Expr::DefineGroup { .. } => {
+                // DEFINE groups match nothing - output empty string for delegation
             }
             _ => panic!("attempting to format hard expr {:?}", self),
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1050,6 +1050,20 @@ impl<'a> Parser<'a> {
         let bytes = self.re.as_bytes();
         // get the character after the open paren
         let b = bytes[ix];
+
+        // Check for DEFINE condition first - (?(DEFINE)...)
+        if self.re[ix..].starts_with("DEFINE)") {
+            let end = ix + "DEFINE)".len();
+            let (end, definitions) = self.parse_re(end, depth)?;
+            let after = self.check_for_close_paren(end)?;
+            return Ok((
+                after,
+                Expr::DefineGroup {
+                    definitions: Box::new(definitions),
+                },
+            ));
+        }
+
         let (next, condition) = if b == b'\'' {
             self.parse_named_backref(ix, "'", "')", true)?
         } else if b == b'<' {
@@ -3661,5 +3675,44 @@ mod tests {
     #[test]
     fn parse_absent_range_clear() {
         assert_eq!(p(r"(?~|)"), Expr::Absent(Absent::Clear));
+    }
+
+    #[test]
+    fn define_group() {
+        assert_eq!(
+            p(r"(?(DEFINE)(?<word>\w+))"),
+            Expr::DefineGroup {
+                definitions: Box::new(make_group(Expr::Repeat {
+                    child: Box::new(Expr::Delegate {
+                        inner: "\\w".to_string(),
+                        casei: false,
+                    }),
+                    lo: 1,
+                    hi: usize::MAX,
+                    greedy: true,
+                })),
+            }
+        );
+    }
+
+    #[test]
+    fn define_group_with_subroutine_call() {
+        assert_eq!(
+            p(r"(?(DEFINE)(?<word>\w+))\g<word>"),
+            Expr::Concat(vec![
+                Expr::DefineGroup {
+                    definitions: Box::new(make_group(Expr::Repeat {
+                        child: Box::new(Expr::Delegate {
+                            inner: "\\w".to_string(),
+                            casei: false,
+                        }),
+                        lo: 1,
+                        hi: usize::MAX,
+                        greedy: true,
+                    })),
+                },
+                Expr::SubroutineCall(1),
+            ])
+        );
     }
 }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -742,3 +742,33 @@ fn test_forward_refrence_subroutine_zero_repetition_capture_group() {
     // This has a forward reference to group n, which is defined as . with {0} repetition
     assert_match(r"\g<n>(?<n>.){0}", "X");
 }
+
+#[test]
+fn test_define_group_subroutine_call() {
+    // Basic DEFINE block: the definition does not match, the subroutine call does
+    assert_match(r"(?(DEFINE)(?<word>\w+))\g<word>", "hello");
+    assert_no_match(r"^(?(DEFINE)(?<word>\w+))\g<word>$", "hello world");
+}
+
+#[test]
+fn test_define_group_multiple_definitions() {
+    // DEFINE block with multiple named groups used as subroutines
+    let pattern = r"^(?(DEFINE)(?<year>\d{4})(?<month>\d{2})(?<day>\d{2}))\g<year>-\g<month>-\g<day>$";
+    assert_match(
+        pattern,
+        "2024-03-17",
+    );
+    assert_no_match(
+        pattern,
+        "1-2-3",
+    );
+}
+
+#[test]
+fn test_define_group_does_not_consume_input() {
+    // The DEFINE block itself must not consume any input; only the subroutine call does
+    let pattern = r"^(?(DEFINE)(?<digit>\d)ignored_literal)X\g<digit>Y$";
+    assert_match(pattern, "X5Y");
+    assert_no_match(pattern, "X Y");
+    assert_no_match(pattern, "X8ignored_literalY");
+}

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -753,15 +753,10 @@ fn test_define_group_subroutine_call() {
 #[test]
 fn test_define_group_multiple_definitions() {
     // DEFINE block with multiple named groups used as subroutines
-    let pattern = r"^(?(DEFINE)(?<year>\d{4})(?<month>\d{2})(?<day>\d{2}))\g<year>-\g<month>-\g<day>$";
-    assert_match(
-        pattern,
-        "2024-03-17",
-    );
-    assert_no_match(
-        pattern,
-        "1-2-3",
-    );
+    let pattern =
+        r"^(?(DEFINE)(?<year>\d{4})(?<month>\d{2})(?<day>\d{2}))\g<year>-\g<month>-\g<day>$";
+    assert_match(pattern, "2024-03-17");
+    assert_no_match(pattern, "1-2-3");
 }
 
 #[test]


### PR DESCRIPTION
It can make it easier to read the pattern as opposed to using the `{0}` zero-repetition syntax when defining a capture group but not wanting to match it immediately.

The implementation is so simple that we essentially get it for free.

https://www.regular-expressions.info/subroutine.html#define