### PR TITLE
Add CRLF flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ with the exception that 0.x versions can break between minor versions.
 - Add support for more `\p{...}` and `\P{...}` aliases, for Oniguruma compatibility (#207)
 - Add support for word boundaries and zero-length fancy patterns inside variable lookbehinds (at top level) (#216)
 - Add support for `\R` to mean general newline, matching all common line break characters, treating `\r\n` atomically (#220)
+- Add support for the regex crate's `(?R)` CRLF mode flag (#238)
 - Add support for subroutine calls (including recursion up to 20 levels deep, matching Oniguruma behavior) `\g<1>` (#230)
 - Add support for Oniguruma's absent repeater `(?~abc)` (#233)
 ### Changed

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -1,7 +1,7 @@
 use fancy_regex::internal::{
     FLAG_CASEI, FLAG_DOTNL, FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE, FLAG_UNICODE,
 };
-use fancy_regex::{Absent, Expr, LookAround, Regex, RegexBuilder};
+use fancy_regex::{Absent, Assertion, Expr, LookAround, Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -279,7 +279,30 @@ fn info_to_tree_node<'a>(
                 ("Any".to_string(), Some("(no newline)".to_string()), None)
             }
         }
-        Expr::Assertion(_) => ("Assertion".to_string(), None, None),
+        Expr::Assertion(assertion) => {
+            use Assertion::*;
+            let (name, summary): (&str, Option<String>) = match assertion {
+                StartText => ("StartText", None),
+                EndText => ("EndText", None),
+                EndTextIgnoreTrailingNewlines { crlf: true } => {
+                    ("EndTextIgnoreTrailingNewlines", Some("(crlf)".to_string()))
+                }
+                EndTextIgnoreTrailingNewlines { crlf: false } => {
+                    ("EndTextIgnoreTrailingNewlines", None)
+                }
+                StartLine { crlf: true } => ("StartLine", Some("(crlf)".to_string())),
+                StartLine { crlf: false } => ("StartLine", None),
+                EndLine { crlf: true } => ("EndLine", Some("(crlf)".to_string())),
+                EndLine { crlf: false } => ("EndLine", None),
+                LeftWordBoundary => ("LeftWordBoundary", None),
+                LeftWordHalfBoundary => ("LeftWordHalfBoundary", None),
+                RightWordBoundary => ("RightWordBoundary", None),
+                RightWordHalfBoundary => ("RightWordHalfBoundary", None),
+                WordBoundary => ("WordBoundary", None),
+                NotWordBoundary => ("NotWordBoundary", None),
+            };
+            (name.to_string(), summary, None)
+        }
         Expr::GeneralNewline { .. } => {
             ("GeneralNewline".to_string(), Some("\\R".to_string()), None)
         }
@@ -708,5 +731,36 @@ mod tests {
         let node = parse_and_analyze(r"(?s).");
         assert_eq!(node.kind, "Any");
         assert_eq!(node.summary.as_deref(), None);
+    }
+
+    #[test]
+    fn test_info_to_tree_node_assertion() {
+        let test_cases: Vec<(&str, &str, Option<&str>)> = vec![
+            ("^", "StartText", None),
+            ("$", "EndText", None),
+            (r"\Z", "EndTextIgnoreTrailingNewlines", None),
+            (r"(?R)\Z", "EndTextIgnoreTrailingNewlines", Some("(crlf)")),
+            (r"(?m:^)", "StartLine", None),
+            (r"(?mR:^)", "StartLine", Some("(crlf)")),
+            (r"(?m:$)", "EndLine", None),
+            (r"(?mR:$)", "EndLine", Some("(crlf)")),
+            (r"\b{start}", "LeftWordBoundary", None),
+            (r"\b{start-half}", "LeftWordHalfBoundary", None),
+            (r"\b{end}", "RightWordBoundary", None),
+            (r"\b{end-half}", "RightWordHalfBoundary", None),
+            (r"\b", "WordBoundary", None),
+            (r"\B", "NotWordBoundary", None),
+        ];
+
+        for (pattern, expected_kind, expected_summary) in test_cases {
+            let node = parse_and_analyze(pattern);
+            assert_eq!(node.kind, expected_kind, "Pattern: {}", pattern);
+            assert_eq!(
+                node.summary.as_deref(),
+                expected_summary,
+                "Pattern: {}",
+                pattern
+            );
+        }
     }
 }

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -266,9 +266,15 @@ fn info_to_tree_node<'a>(
 ) -> AnalysisTreeNode {
     let (kind, summary, group_info) = match info.expr {
         Expr::Empty => ("Empty".to_string(), None, None),
-        Expr::Any { newline } => {
+        Expr::Any { newline, crlf } => {
             if *newline {
                 ("Any".to_string(), None, None)
+            } else if *crlf {
+                (
+                    "Any".to_string(),
+                    Some("(no newline or carriage return)".to_string()),
+                    None,
+                )
             } else {
                 ("Any".to_string(), Some("(no newline)".to_string()), None)
             }
@@ -439,6 +445,15 @@ pub fn main() {
 mod tests {
     use super::*;
 
+    /// Parse a pattern, analyze it, and convert to an AnalysisTreeNode.
+    /// Builds a group names lookup from the parse tree's named_groups (for patterns with named captures).
+    fn parse_and_analyze(pattern: &str) -> AnalysisTreeNode {
+        let tree = fancy_regex::Expr::parse_tree(pattern).unwrap();
+        let group_names = build_group_names_lookup(&tree.named_groups);
+        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        info_to_tree_node(&info, &group_names)
+    }
+
     #[test]
     fn test_escape_delegate_basic() {
         assert_eq!(escape_delegate("abc"), "abc");
@@ -463,11 +478,7 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_literal_newline() {
-        let tree = fancy_regex::Expr::parse_tree("test\n").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze("test\n");
 
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.children.len(), 5); // "test\n" as separate literals
@@ -478,11 +489,7 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_literal_slash_n() {
-        let tree = fancy_regex::Expr::parse_tree(r"test\n").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"test\n");
 
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.children.len(), 5); // "test\n" as separate literals
@@ -493,14 +500,10 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_literal_slash() {
-        let tree = fancy_regex::Expr::parse_tree("test\\\\").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze("test\\\\");
 
         assert_eq!(node.kind, "Concat");
-        assert_eq!(node.children.len(), 5); // "test\n" as separate literals
+        assert_eq!(node.children.len(), 5); // "test\\" as separate literals
         assert_eq!(node.children[0].kind, "Literal");
         assert_eq!(node.children[0].summary.as_deref(), Some("\"t\""));
         assert_eq!(node.children[4].summary.as_deref(), Some("\"\\\\\""));
@@ -509,11 +512,7 @@ mod tests {
     #[test]
     fn test_info_to_tree_node_delegate() {
         // Test that Delegate shows the pattern
-        let tree = fancy_regex::Expr::parse_tree(r"\w").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"\w");
 
         // The root should be a Delegate node
         assert_eq!(node.kind, "Delegate");
@@ -529,14 +528,8 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_group_named() {
-        // Test named capture group
-        let tree = fancy_regex::Expr::parse_tree(r"(?<word>\w+)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = build_group_names_lookup(&tree.named_groups);
+        let node = parse_and_analyze(r"(?<word>\w+)");
 
-        let node = info_to_tree_node(&info, &group_names);
-
-        // Find the Group node (should be a child of root)
         assert_eq!(node.kind, "Group");
         assert!(
             node.summary.as_deref().unwrap_or("").contains("word"),
@@ -547,12 +540,7 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_group_unnamed() {
-        // Test unnamed capture group
-        let tree = fancy_regex::Expr::parse_tree(r"(\w+)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"(\w+)");
 
         assert_eq!(node.kind, "Group");
         assert_eq!(node.group.as_ref().unwrap().index, 1);
@@ -561,15 +549,8 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_backref_named() {
-        // Test named backref
-        let tree = fancy_regex::Expr::parse_tree(r"(?<word>\w+)\s+\k<word>").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        // Build reverse lookup map from named_groups
-        let group_names = build_group_names_lookup(&tree.named_groups);
+        let node = parse_and_analyze(r"(?<word>\w+)\s+\k<word>");
 
-        let node = info_to_tree_node(&info, &group_names);
-
-        // Navigate to find Backref node (it's in Concat children)
         assert_eq!(node.kind, "Concat");
         let backref_node = node
             .children
@@ -589,14 +570,8 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_backref_numeric() {
-        // Test numeric backref
-        let tree = fancy_regex::Expr::parse_tree(r"(\w+)\s+\1").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
+        let node = parse_and_analyze(r"(\w+)\s+\1");
 
-        let node = info_to_tree_node(&info, &group_names);
-
-        // Navigate to find Backref node
         let backref_node = node
             .children
             .iter()
@@ -623,11 +598,7 @@ mod tests {
         ];
 
         for (pattern, expected_summary, expected_suffix) in test_cases {
-            let tree = fancy_regex::Expr::parse_tree(pattern).unwrap();
-            let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-            let group_names = std::collections::HashMap::new();
-
-            let node = info_to_tree_node(&info, &group_names);
+            let node = parse_and_analyze(pattern);
 
             let expected_kind = if expected_suffix.is_empty() {
                 "Repeat".to_string()
@@ -646,23 +617,11 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_concat_alt() {
-        // Test Concat and Alt count
-        let tree = fancy_regex::Expr::parse_tree(r"abc").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"abc");
         assert_eq!(node.kind, "Concat");
         assert_eq!(node.summary.as_deref(), Some("(3)"));
 
-        // Test Alt
-        let tree = fancy_regex::Expr::parse_tree(r"a|b|c").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"a|b|c");
         assert_eq!(node.kind, "Alt");
         assert_eq!(node.summary.as_deref(), Some("(3)"));
     }
@@ -677,11 +636,7 @@ mod tests {
         ];
 
         for (pattern, expected_kind, expected_summary) in test_cases {
-            let tree = fancy_regex::Expr::parse_tree(pattern).unwrap();
-            let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-            let group_names = std::collections::HashMap::new();
-
-            let node = info_to_tree_node(&info, &group_names);
+            let node = parse_and_analyze(pattern);
 
             assert_eq!(node.kind, expected_kind, "Pattern: {}", pattern);
             assert_eq!(
@@ -697,31 +652,17 @@ mod tests {
     fn test_info_to_tree_node_hard_easy() {
         // Test that hard flag is correctly set
         // Backref should be hard
-        let tree = fancy_regex::Expr::parse_tree(r"(\w+)\1").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"(\w+)\1");
         assert!(node.hard, "Pattern with backref should be hard");
 
         // Simple literal should be easy
-        let tree = fancy_regex::Expr::parse_tree(r"abc").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"abc");
         assert!(!node.hard, "Simple literal pattern should be easy");
     }
 
     #[test]
     fn test_info_to_tree_node_absent_repeater() {
-        let tree = fancy_regex::Expr::parse_tree(r"(?~abc)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"(?~abc)");
 
         assert_eq!(node.kind, "AbsentRepeater");
         // Should have 1 children: concat
@@ -732,11 +673,7 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_absent_expression() {
-        let tree = fancy_regex::Expr::parse_tree(r"(?~|abc|\d+)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"(?~|abc|\d+)");
 
         assert_eq!(node.kind, "AbsentExpression");
         // Should have 2 children: absent and exp
@@ -745,23 +682,31 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_absent_stopper() {
-        let tree = fancy_regex::Expr::parse_tree(r"(?~|abc)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"(?~|abc)");
         assert_eq!(node.kind, "AbsentStopper");
     }
 
     #[test]
     fn test_info_to_tree_node_absent_clear() {
-        let tree = fancy_regex::Expr::parse_tree(r"(?~|)").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
-
+        let node = parse_and_analyze(r"(?~|)");
         assert_eq!(node.kind, "AbsentClear");
+    }
+
+    #[test]
+    fn test_info_to_tree_node_any() {
+        let node = parse_and_analyze(r"(?R).");
+        assert_eq!(node.kind, "Any");
+        assert_eq!(
+            node.summary.as_deref(),
+            Some("(no newline or carriage return)")
+        );
+
+        let node = parse_and_analyze(r"(?-R).");
+        assert_eq!(node.kind, "Any");
+        assert_eq!(node.summary.as_deref(), Some("(no newline)"));
+
+        let node = parse_and_analyze(r"(?s).");
+        assert_eq!(node.kind, "Any");
+        assert_eq!(node.summary.as_deref(), None);
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -150,10 +150,19 @@ impl<'a> Compiler<'a> {
                     self.compile_delegate(info)?;
                 }
             }
-            Expr::Any { newline: true } => {
+            Expr::Any { newline: true, .. } => {
                 self.b.add(Insn::Any);
             }
-            Expr::Any { newline: false } => {
+            Expr::Any {
+                newline: false,
+                crlf: true,
+            } => {
+                self.b.add(Insn::AnyNoCRLF);
+            }
+            Expr::Any {
+                newline: false,
+                crlf: false,
+            } => {
                 self.b.add(Insn::AnyNoNL);
             }
             Expr::GeneralNewline { unicode } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1763,7 +1763,11 @@ pub enum Assertion {
     /// End of input text
     EndText,
     /// End of input text, or before any trailing newlines at the end (Oniguruma's `\Z`)
-    EndTextIgnoreTrailingNewlines,
+    EndTextIgnoreTrailingNewlines {
+        /// Whether CRLF mode is enabled.
+        /// If `true`, trailing `\r\n` pairs (in addition to bare `\n`) are also ignored.
+        crlf: bool,
+    },
     /// Start of a line
     StartLine {
         /// CRLF mode.
@@ -1804,7 +1808,7 @@ impl Assertion {
                 | RightWordHalfBoundary
                 | WordBoundary
                 | NotWordBoundary
-                | EndTextIgnoreTrailingNewlines
+                | EndTextIgnoreTrailingNewlines { .. }
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1536,7 +1536,8 @@ pub enum Expr {
     Any {
         /// Whether it also matches newlines or not
         newline: bool,
-        /// Whether CRLF mode is enabled (dot excludes both `\r` and `\n`)
+        /// Whether CRLF mode is enabled (`\r` also counts as a newline, so dot
+        /// excludes both `\r` and `\n`)
         crlf: bool,
     },
     /// An assertion
@@ -1765,12 +1766,16 @@ pub enum Assertion {
     EndTextIgnoreTrailingNewlines,
     /// Start of a line
     StartLine {
-        /// CRLF mode
+        /// CRLF mode.
+        /// If true, this assertion matches at the starting position of the input text, or at the position immediately
+        /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
     },
     /// End of a line
     EndLine {
         /// CRLF mode
+        /// If true, this assertion matches at the ending position of the input text, or at the position immediately
+        /// preceding either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
     },
     /// Left word boundary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,8 +425,9 @@ impl RegexOptions {
         let dotnl = Self::get_flag_value(self.syntaxc.get_dot_matches_new_line(), FLAG_DOTNL);
         let unicode = Self::get_flag_value(self.syntaxc.get_unicode(), FLAG_UNICODE);
         let oniguruma_mode = Self::get_flag_value(self.oniguruma_mode, FLAG_ONIGURUMA_MODE);
+        let crlf = Self::get_flag_value(self.syntaxc.get_crlf(), FLAG_CRLF);
 
-        insensitive | multiline | whitespace | dotnl | unicode | oniguruma_mode
+        insensitive | multiline | whitespace | dotnl | unicode | oniguruma_mode | crlf
     }
 }
 
@@ -488,6 +489,18 @@ impl RegexOptionsBuilder {
     /// except for a new line character.
     pub fn dot_matches_new_line(&mut self, yes: bool) -> &mut Self {
         self.set_config(|x| x.dot_matches_new_line(yes))
+    }
+
+    /// Enable or disable the CRLF mode flag (`R`).
+    ///
+    /// When enabled, `\r\n` is treated as a single line ending for the purposes of
+    /// `^` and `$` in multi-line mode, instead of treating `\r` and `\n` as separate
+    /// line endings.
+    ///
+    /// By default, this is disabled. It may be selectively enabled in the regular
+    /// expression by using the `R` flag, e.g. `(?mR)` or `(?Rm)`.
+    pub fn crlf(&mut self, yes: bool) -> &mut Self {
+        self.set_config(|x| x.crlf(yes))
     }
 
     /// Enable verbose mode in the regular expression.
@@ -670,6 +683,12 @@ impl RegexBuilder {
     /// See [`RegexOptionsBuilder::oniguruma_mode`]
     pub fn oniguruma_mode(&mut self, yes: bool) -> &mut Self {
         self.options.oniguruma_mode(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::crlf`]
+    pub fn crlf(&mut self, yes: bool) -> &mut Self {
+        self.options.crlf(yes);
         self
     }
 }
@@ -1517,6 +1536,8 @@ pub enum Expr {
     Any {
         /// Whether it also matches newlines or not
         newline: bool,
+        /// Whether CRLF mode is enabled (dot excludes both `\r` and `\n`)
+        crlf: bool,
     },
     /// An assertion
     Assertion(Assertion),
@@ -1958,7 +1979,11 @@ impl Expr {
     pub fn to_str(&self, buf: &mut String, precedence: u8) {
         match *self {
             Expr::Empty => (),
-            Expr::Any { newline } => buf.push_str(if newline { "(?s:.)" } else { "." }),
+            Expr::Any { newline, crlf } => buf.push_str(match (newline, crlf) {
+                (true, _) => "(?s:.)",
+                (false, true) => "(?R-s:.)",
+                (false, false) => ".",
+            }),
             Expr::Literal { ref val, casei } => {
                 if casei {
                     buf.push_str("(?i:");
@@ -2128,7 +2153,8 @@ pub mod internal {
     pub use crate::compile::compile;
     pub use crate::optimize::optimize;
     pub use crate::parse_flags::{
-        FLAG_CASEI, FLAG_DOTNL, FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE, FLAG_UNICODE,
+        FLAG_CASEI, FLAG_CRLF, FLAG_DOTNL, FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE,
+        FLAG_UNICODE,
     };
     pub use crate::vm::{run_default, run_trace, Insn, Prog};
 }
@@ -2297,8 +2323,16 @@ mod tests {
     fn test_is_leaf_node_leaf_nodes() {
         // Test all leaf node variants
         assert!(Expr::Empty.is_leaf_node());
-        assert!(Expr::Any { newline: false }.is_leaf_node());
-        assert!(Expr::Any { newline: true }.is_leaf_node());
+        assert!(Expr::Any {
+            newline: false,
+            crlf: false
+        }
+        .is_leaf_node());
+        assert!(Expr::Any {
+            newline: true,
+            crlf: false
+        }
+        .is_leaf_node());
         assert!(Expr::Assertion(crate::Assertion::StartText).is_leaf_node());
         assert!(Expr::Literal {
             val: "test".to_string(),
@@ -2364,7 +2398,10 @@ mod tests {
         assert!(!Expr::Absent(Absent::Expression {
             absent: Box::new(make_literal("/*")),
             exp: Box::new(Expr::Repeat {
-                child: Box::new(Expr::Any { newline: true }),
+                child: Box::new(Expr::Any {
+                    newline: true,
+                    crlf: false
+                }),
                 lo: 0,
                 hi: usize::MAX,
                 greedy: true
@@ -2432,7 +2469,10 @@ mod tests {
         let expr = Expr::Absent(Absent::Expression {
             absent: Box::new(make_literal("/*")),
             exp: Box::new(Expr::Repeat {
-                child: Box::new(Expr::Any { newline: true }),
+                child: Box::new(Expr::Any {
+                    newline: true,
+                    crlf: false,
+                }),
                 lo: 0,
                 hi: usize::MAX,
                 greedy: true,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -502,7 +502,9 @@ impl<'a> Parser<'a> {
             // \Z matches at the end of the string, or before any number of newlines at the end
             (
                 end,
-                Expr::Assertion(Assertion::EndTextIgnoreTrailingNewlines),
+                Expr::Assertion(Assertion::EndTextIgnoreTrailingNewlines {
+                    crlf: self.flag(FLAG_CRLF),
+                }),
             )
         } else if (b == b'b' || b == b'B') && !in_class {
             let check_pos = self.optional_whitespace(end)?;
@@ -1562,7 +1564,7 @@ mod tests {
     fn end_text_before_empty_lines() {
         assert_eq!(
             p("\\Z"),
-            Expr::Assertion(Assertion::EndTextIgnoreTrailingNewlines)
+            Expr::Assertion(Assertion::EndTextIgnoreTrailingNewlines { crlf: false })
         );
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -266,13 +266,15 @@ impl<'a> Parser<'a> {
                 ix + 1,
                 Expr::Any {
                     newline: self.flag(FLAG_DOTNL),
+                    crlf: self.flag(FLAG_CRLF),
                 },
             )),
             b'^' => Ok((
                 ix + 1,
                 if self.flag(FLAG_MULTI) {
-                    // TODO: support crlf flag
-                    Expr::Assertion(Assertion::StartLine { crlf: false })
+                    Expr::Assertion(Assertion::StartLine {
+                        crlf: self.flag(FLAG_CRLF),
+                    })
                 } else {
                     Expr::Assertion(Assertion::StartText)
                 },
@@ -280,8 +282,9 @@ impl<'a> Parser<'a> {
             b'$' => Ok((
                 ix + 1,
                 if self.flag(FLAG_MULTI) {
-                    // TODO: support crlf flag
-                    Expr::Assertion(Assertion::EndLine { crlf: false })
+                    Expr::Assertion(Assertion::EndLine {
+                        crlf: self.flag(FLAG_CRLF),
+                    })
                 } else {
                     Expr::Assertion(Assertion::EndText)
                 },
@@ -603,9 +606,23 @@ impl<'a> Parser<'a> {
                 },
             )
         } else if b == b'O' && !in_class {
-            (end, Expr::Any { newline: true })
+            (
+                end,
+                Expr::Any {
+                    newline: true,
+                    crlf: true,
+                },
+            )
         } else if b == b'N' && !in_class {
-            (end, Expr::Any { newline: false })
+            // \N always means "not a newline" regardless of dot mode flags
+            // - just like \n is a literal, this is the inverse
+            (
+                end,
+                Expr::Any {
+                    newline: false,
+                    crlf: false,
+                },
+            )
         } else if b == b'g' && !in_class {
             if end == self.re.len() {
                 return Err(Error::ParseError(
@@ -999,6 +1016,7 @@ impl<'a> Parser<'a> {
             match b {
                 b'i' => self.update_flag(FLAG_CASEI, neg),
                 b'm' => self.update_flag(FLAG_MULTI, neg),
+                b'R' => self.update_flag(FLAG_CRLF, neg),
                 b's' => self.update_flag(FLAG_DOTNL, neg),
                 b'U' => self.update_flag(FLAG_SWAP_GREED, neg),
                 b'x' => self.update_flag(FLAG_IGNORE_SPACE, neg),
@@ -1514,8 +1532,20 @@ mod tests {
 
     #[test]
     fn any() {
-        assert_eq!(p("."), Expr::Any { newline: false });
-        assert_eq!(p("(?s:.)"), Expr::Any { newline: true });
+        assert_eq!(
+            p("."),
+            Expr::Any {
+                newline: false,
+                crlf: false
+            }
+        );
+        assert_eq!(
+            p("(?s:.)"),
+            Expr::Any {
+                newline: true,
+                crlf: false
+            }
+        );
     }
 
     #[test]
@@ -2016,7 +2046,10 @@ mod tests {
         assert_eq!(
             tree.expr,
             Expr::Concat(vec![
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
                 Expr::Backref {
                     group: 1,
                     casei: false,
@@ -2032,7 +2065,10 @@ mod tests {
         assert_eq!(
             tree.expr,
             Expr::Concat(vec![
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
                 Expr::Backref {
                     group: 1,
                     casei: false,
@@ -2049,7 +2085,10 @@ mod tests {
             tree.expr,
             Expr::Concat(vec![
                 make_group(make_literal("a")),
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
                 Expr::Backref {
                     group: 2,
                     casei: false,
@@ -2068,7 +2107,10 @@ mod tests {
                     group: 2,
                     casei: false,
                 },
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
             ])
         );
         // this doesn't count as a numeric reference
@@ -2139,9 +2181,15 @@ mod tests {
                 Expr::Assertion(Assertion::StartText),
                 make_group(Expr::Alt(vec![
                     Expr::Empty,
-                    Expr::Any { newline: false },
+                    Expr::Any {
+                        newline: false,
+                        crlf: false
+                    },
                     Expr::Concat(vec![
-                        make_group(Expr::Any { newline: false }),
+                        make_group(Expr::Any {
+                            newline: false,
+                            crlf: false
+                        }),
                         Expr::SubroutineCall(1),
                         Expr::BackrefWithRelativeRecursionLevel {
                             group: 2,
@@ -2161,7 +2209,10 @@ mod tests {
             p(r"(a)(.)\g<-1>"),
             Expr::Concat(vec![
                 make_group(make_literal("a")),
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
                 Expr::SubroutineCall(2),
             ])
         );
@@ -2171,7 +2222,10 @@ mod tests {
             Expr::Concat(vec![
                 make_group(make_literal("a")),
                 Expr::SubroutineCall(2),
-                make_group(Expr::Any { newline: false }),
+                make_group(Expr::Any {
+                    newline: false,
+                    crlf: false
+                }),
             ])
         );
 
@@ -2215,20 +2269,44 @@ mod tests {
 
     #[test]
     fn flag_state() {
-        assert_eq!(p("(?s)."), Expr::Any { newline: true });
-        assert_eq!(p("(?s:(?-s:.))"), Expr::Any { newline: false });
+        assert_eq!(
+            p("(?s)."),
+            Expr::Any {
+                newline: true,
+                crlf: false
+            }
+        );
+        assert_eq!(
+            p("(?s:(?-s:.))"),
+            Expr::Any {
+                newline: false,
+                crlf: false
+            }
+        );
         assert_eq!(
             p("(?s:.)."),
             Expr::Concat(vec![
-                Expr::Any { newline: true },
-                Expr::Any { newline: false },
+                Expr::Any {
+                    newline: true,
+                    crlf: false
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
         assert_eq!(
             p("(?:(?s).)."),
             Expr::Concat(vec![
-                Expr::Any { newline: true },
-                Expr::Any { newline: false },
+                Expr::Any {
+                    newline: true,
+                    crlf: false
+                },
+                Expr::Any {
+                    newline: false,
+                    crlf: false
+                },
             ])
         );
     }
@@ -2244,6 +2322,27 @@ mod tests {
         assert_eq!(
             p("(?m:$)"),
             Expr::Assertion(Assertion::EndLine { crlf: false })
+        );
+    }
+
+    #[test]
+    fn flag_crlf() {
+        assert_eq!(
+            p("(?mR:^)"),
+            Expr::Assertion(Assertion::StartLine { crlf: true })
+        );
+        assert_eq!(
+            p("(?Rm:^)"),
+            Expr::Assertion(Assertion::StartLine { crlf: true })
+        );
+        assert_eq!(
+            p("(?mR:$)"),
+            Expr::Assertion(Assertion::EndLine { crlf: true })
+        );
+        // Negating R reverts to LF-only
+        assert_eq!(
+            p("(?mR)(?-R:^)"),
+            Expr::Assertion(Assertion::StartLine { crlf: false })
         );
     }
 
@@ -2889,9 +2988,15 @@ mod tests {
                 Expr::Assertion(Assertion::StartText,),
                 make_group(Expr::Alt(vec![
                     Expr::Empty,
-                    Expr::Any { newline: false },
+                    Expr::Any {
+                        newline: false,
+                        crlf: false
+                    },
                     Expr::Concat(vec![
-                        make_group(Expr::Any { newline: false },),
+                        make_group(Expr::Any {
+                            newline: false,
+                            crlf: false
+                        },),
                         Expr::SubroutineCall(1,),
                         Expr::Backref {
                             group: 2,
@@ -3112,7 +3217,10 @@ mod tests {
         assert_eq!(
             expr,
             make_group(Expr::Repeat {
-                child: Box::new(Expr::Any { newline: true }),
+                child: Box::new(Expr::Any {
+                    newline: true,
+                    crlf: false
+                }),
                 lo: 0,
                 hi: usize::MAX,
                 greedy: true
@@ -3130,7 +3238,10 @@ mod tests {
         assert_eq!(
             expr,
             make_group(Expr::Repeat {
-                child: Box::new(Expr::Any { newline: true }),
+                child: Box::new(Expr::Any {
+                    newline: true,
+                    crlf: false
+                }),
                 lo: 0,
                 hi: usize::MAX,
                 greedy: true
@@ -3149,7 +3260,10 @@ mod tests {
             expr,
             Expr::Concat(vec![
                 make_group(Expr::Repeat {
-                    child: Box::new(Expr::Any { newline: true }),
+                    child: Box::new(Expr::Any {
+                        newline: true,
+                        crlf: false
+                    }),
                     lo: 0,
                     hi: usize::MAX,
                     greedy: true

--- a/src/parse_flags.rs
+++ b/src/parse_flags.rs
@@ -12,3 +12,5 @@ pub const FLAG_IGNORE_SPACE: u32 = 1 << 4;
 pub const FLAG_UNICODE: u32 = 1 << 5;
 /// Flag bit for parsing in Oniguruma compatibility mode
 pub const FLAG_ONIGURUMA_MODE: u32 = 1 << 6;
+/// Flag bit for CRLF mode (treat `\r\n` as a single line ending)
+pub const FLAG_CRLF: u32 = 1 << 7;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -224,6 +224,8 @@ pub enum Insn {
     Any,
     /// Match any character (not including newline)
     AnyNoNL,
+    /// Match any character (not including `\r` or `\n`, for CRLF mode)
+    AnyNoCRLF,
     /// Assertions
     Assertion(Assertion),
     /// Match the literal string at the current index
@@ -685,6 +687,13 @@ pub(crate) fn run(
                 }
                 Insn::AnyNoNL => {
                     if ix < s.len() && s.as_bytes()[ix] != b'\n' {
+                        ix += codepoint_len_at(s, ix);
+                    } else {
+                        break 'fail;
+                    }
+                }
+                Insn::AnyNoCRLF => {
+                    if ix < s.len() && s.as_bytes()[ix] != b'\r' && s.as_bytes()[ix] != b'\n' {
                         ix += codepoint_len_at(s, ix);
                     } else {
                         break 'fail;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -710,11 +710,14 @@ pub(crate) fn run(
                     if !match assertion {
                         Assertion::StartText => look_matcher.is_start(s.as_bytes(), ix),
                         Assertion::EndText => look_matcher.is_end(s.as_bytes(), ix),
-                        Assertion::EndTextIgnoreTrailingNewlines => {
+                        Assertion::EndTextIgnoreTrailingNewlines { crlf } => {
                             let bytes = s.as_bytes();
                             if ix == bytes.len() {
                                 // At the end of string
                                 true
+                            } else if crlf {
+                                // In CRLF mode, trailing \r\n pairs and bare \n are ignored
+                                bytes[ix..].iter().all(|&b| b == b'\n' || b == b'\r')
                             } else {
                                 // Check if all remaining bytes are newlines
                                 bytes[ix..].iter().all(|&b| b == b'\n')

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -222,9 +222,9 @@ pub enum Insn {
     End,
     /// Match any character (including newline)
     Any,
-    /// Match any character (not including newline)
+    /// Match any character except for the line feed character (`\n`)
     AnyNoNL,
-    /// Match any character (not including `\r` or `\n`, for CRLF mode)
+    /// Match any character except for a carriage return or line feed character (`\r` or `\n`)
     AnyNoCRLF,
     /// Assertions
     Assertion(Assertion),

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -1,6 +1,7 @@
 use fancy_regex::{Captures, CompileError, Error, Expander, Match, Result};
 use std::borrow::Cow;
 use std::ops::Index;
+use std::ops::Range;
 
 mod common;
 
@@ -138,6 +139,127 @@ fn captures_with_conditional() {
     assert_match(captures.get(0), "abc", 0, 3);
     assert_match(captures.get(1), "ab", 0, 2);
     assert!(captures.get(2).is_none());
+}
+
+#[test]
+fn capture_with_crlf_flag() {
+    // The following test cases are adopted from the test cases of the `regex-automata` crate:
+    // https://github.com/rust-lang/regex/blob/c79c40a39ebc4ffdc9b886e34806b9085583b769/testdata/crlf.toml
+    assert_capture_with_crlf_flag(
+        r"(?mR)^[a-z]+$",
+        "abc\r\ndef\r\nxyz",
+        vec!["abc", "def", "xyz"],
+        vec![(0..3), (5..8), (10..13)],
+    );
+    assert_capture_with_crlf_flag(r"(?mR)^$", "abc\r\ndef\r\nxyz", vec![], vec![]);
+    assert_capture_with_crlf_flag(r"(?mR)^$", "", vec![""], vec![(0..0)]);
+    assert_capture_with_crlf_flag(r"(?mR)^$", "\r\n", vec!["", ""], vec![(0..0), (2..2)]);
+    assert_capture_with_crlf_flag(
+        r"(?mR)^",
+        "abc\r\ndef\r\nxyz",
+        vec!["", "", ""],
+        vec![(0..0), (5..5), (10..10)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)^",
+        "\r\n\r\n\r\n",
+        vec!["", "", "", ""],
+        vec![(0..0), (2..2), (4..4), (6..6)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)^",
+        "\r\r\r",
+        vec!["", "", "", ""],
+        vec![(0..0), (1..1), (2..2), (3..3)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)^",
+        "\n\n\n",
+        vec!["", "", "", ""],
+        vec![(0..0), (1..1), (2..2), (3..3)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)$",
+        "abc\r\ndef\r\nxyz",
+        vec!["", "", ""],
+        vec![(3..3), (8..8), (13..13)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)$",
+        "\r\n\r\n\r\n",
+        vec!["", "", "", ""],
+        vec![(0..0), (2..2), (4..4), (6..6)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)$",
+        "\r\r\r",
+        vec!["", "", "", ""],
+        vec![(0..0), (1..1), (2..2), (3..3)],
+    );
+    assert_capture_with_crlf_flag(
+        r"(?mR)$",
+        "\n\n\n",
+        vec!["", "", "", ""],
+        vec![(0..0), (1..1), (2..2), (3..3)],
+    );
+    // In CRLF mode, `.` should not match `\r` or `\n`
+    assert_capture_with_crlf_flag(r"(?R).", "\r\n\r\n\r\n", vec![], vec![]);
+}
+
+#[cfg_attr(feature = "track_caller", track_caller)]
+fn assert_capture_with_crlf_flag(
+    regex_src: &str,
+    text: &str,
+    expected_texts: Vec<&str>,
+    expected_spans: Vec<Range<usize>>,
+) {
+    fn assert_capture_matches(
+        regex_src: &str,
+        text: &str,
+        expected_texts: &[&str],
+        expected_spans: &[Range<usize>],
+    ) {
+        let regex = common::regex(regex_src);
+        let capture_matches: Vec<_> = regex.captures_iter(text).map(|c| c.unwrap()).collect();
+        assert_eq!(
+            capture_matches.len(),
+            expected_texts.len(),
+            "Pattern '{}' on '{}': expected {} matches, got {}",
+            regex_src,
+            text.escape_default(),
+            expected_texts.len(),
+            capture_matches.len(),
+        );
+        for (captures, (&expected_text, expected_span)) in capture_matches
+            .iter()
+            .zip(expected_texts.iter().zip(expected_spans.iter()))
+        {
+            assert_match(
+                captures.get(0),
+                expected_text,
+                expected_span.start,
+                expected_span.end,
+            );
+        }
+    }
+
+    fn make_harder(regex_src: &str) -> String {
+        // Wrap the original regex source in an atomic group to make it `hard` so that the execution of the regex is
+        // handled by the backtracking VM engine implemented in `fancy-regex` rather than delegated to the engine of
+        // `regex-automata`.
+        format!(r"(?>{})", regex_src)
+    }
+
+    // Verify that the regex-automata's engine is able to handle the CRLF flag.
+    assert_capture_matches(regex_src, text, &expected_texts, &expected_spans);
+
+    // Verify that the fancy-regex's backtracking VM engine is able to handle the CRLF flag.
+    assert_capture_matches(
+        make_harder(regex_src).as_str(),
+        text,
+        &expected_texts,
+        &expected_spans,
+    );
 }
 
 #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use fancy_regex::Match;
+use fancy_regex::{Match, RegexBuilder};
 use std::ops::Range;
 
 #[test]
@@ -535,7 +535,6 @@ fn find_iter_empty_repeat_anchored_non_greedy_issue70() {
 #[test]
 fn find_iter_collect_when_backtrack_limit_hit() {
     use fancy_regex::Error;
-    use fancy_regex::RegexBuilder;
     use fancy_regex::RuntimeError;
 
     let r = RegexBuilder::new("(x+x+)+(?>y)")
@@ -561,6 +560,54 @@ fn find_conditional() {
 #[test]
 fn find_endtext_before_newlines() {
     assert_eq!(find(r"\Z", "hello\nworld\n\n\n"), Some((11, 11)));
+}
+
+#[test]
+fn find_endtext_ignore_trailing_newlines_non_crlf() {
+    // \Z without CRLF mode: only bare \n chars are skipped at the end.
+    // "abc\n\n" — \Z matches at position 3 (before the trailing newlines)
+    assert_eq!(find(r"\Z", "abc\n\n"), Some((3, 3)));
+    // No trailing newlines: \Z matches at the very end
+    assert_eq!(find(r"\Z", "abc"), Some((3, 3)));
+    // \r\n at the end: in non-CRLF mode the \r is NOT treated as a newline for \Z,
+    // so \Z matches just before the trailing \n, not before the \r\n pair.
+    assert_eq!(find(r"\Z", "abc\r\n"), Some((4, 4)));
+}
+
+#[test]
+fn find_endtext_ignore_trailing_newlines_crlf() {
+    // (?R) enables CRLF mode; \Z should then treat \r as part of trailing newlines too.
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .build()
+            .unwrap()
+            .find("abc\r\n")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .build()
+            .unwrap()
+            .find("abc\r\r")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
+    // bare \n still works in CRLF mode
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .build()
+            .unwrap()
+            .find("abc\n")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
 }
 
 #[test]

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -333,6 +333,59 @@ fn general_newline_not_in_character_class() {
     assert_no_match(r"[\R]", "\r\n");
 }
 
+#[test]
+fn crlf_flag_multiline() {
+    // (?mR) treats \r\n as a single line ending for ^ and $
+    let pattern = r"(?mR)^test$";
+    assert_match(pattern, "test");
+    assert_match(pattern, "\r\ntest\r\n");
+    assert_match(pattern, "test\r\n");
+    assert_match(pattern, "\r\ntest");
+    // In CRLF mode bare \r is also treated as a line ending
+    assert_match(pattern, "\rtest\r");
+    // ^ should not match between \r and \n (they form a single unit)
+    assert_no_match(r"(?mR)^\ntest$", "\r\ntest");
+    // In non-CRLF multiline mode, \r is not a line ending
+    assert_no_match(r"(?m)^test$", "\rtest\r");
+    // Works with a lookahead (hard/fancy regex)
+    assert_match(r"(?mR)(?=^test$)^\w+$", "\r\ntest\r\n");
+}
+
+#[test]
+fn crlf_flag_dot() {
+    // In CRLF mode, `.` does not match `\r` or `\n`
+    assert_no_match(r"(?R).", "\r");
+    assert_no_match(r"(?R).", "\n");
+    assert_no_match(r"(?R).", "\r\n");
+    // But it still matches other characters
+    assert_match(r"(?R).", "a");
+    assert_match(r"(?R).", " ");
+    // Same via the backtracking VM (hard/fancy path)
+    assert_no_match(r"(?R)(?=).", "\r");
+    assert_no_match(r"(?R)(?=).", "\n");
+    // Without CRLF mode, `.` matches `\r` but not `\n`
+    assert_match(r".", "\r");
+    assert_no_match(r".", "\n");
+}
+
+#[test]
+fn crlf_flag_oniguruma_any_char() {
+    // Regardless of mode, \O always matches any character
+    // including newline and carriage return
+    let test_pattern = |pattern: &str| {
+        assert_match(pattern, "\r");
+        assert_match(pattern, "\n");
+        assert_match(pattern, "\t");
+        assert_match(pattern, "╔");
+        assert_match(pattern, "a");
+        assert_match(pattern, "š");
+        assert_no_match(pattern, "");
+    };
+
+    test_pattern(r"(?R)\O");
+    test_pattern(r"\O");
+}
+
 #[cfg_attr(feature = "track_caller", track_caller)]
 fn assert_match(re: &str, text: &str) {
     let result = match_text(re, text);

--- a/tests/regex_options.rs
+++ b/tests/regex_options.rs
@@ -136,6 +136,26 @@ fn check_oniguruma_mode_changes_wordbounds() {
 }
 
 #[test]
+fn check_crlf_option() {
+    // With CRLF mode and multi-line enabled, ^ and $ should treat \r\n as a single line ending
+    let regex = build_regex(RegexBuilder::new(r"^test$").multi_line(true).crlf(true));
+    assert!(regex.is_match("test").unwrap_or_default());
+    assert!(regex.is_match("\r\ntest\r\n").unwrap_or_default());
+    assert!(regex.is_match("test\r\n").unwrap_or_default());
+    assert!(regex.is_match("\r\ntest").unwrap_or_default());
+}
+
+#[test]
+fn check_crlf_flag_in_pattern() {
+    // The (?mR) flag combination in the pattern itself should enable CRLF mode
+    let regex = build_regex(&RegexBuilder::new(r"(?mR)^test$"));
+    assert!(regex.is_match("test").unwrap_or_default());
+    assert!(regex.is_match("\r\ntest\r\n").unwrap_or_default());
+    assert!(regex.is_match("test\r\n").unwrap_or_default());
+    assert!(regex.is_match("\r\ntest").unwrap_or_default());
+}
+
+#[test]
 fn can_build_multiple_regexes_with_same_options() {
     let mut builder = RegexBuilder::new(r"^[a-z@.]+$");
     builder.case_insensitive(true);


### PR DESCRIPTION
Supersedes #131, but borrows many test cases from the original PR and thus credits @mmizutani as a co-author. Fixes #135 

I also used the opportunity to clean up the playground analysis info node test cases, removing boilerplate by creating a helper function.