### PR TITLE
Implement `find_not_empty` option to reject zero-length matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ with the exception that 0.x versions can break between minor versions.
 - Add support for the regex crate's `(?R)` CRLF mode flag (#238)
 - Add support for subroutine calls (including recursion up to 20 levels deep, matching Oniguruma behavior) `\g<1>` (#230)
 - Add support for Oniguruma's absent repeater `(?~abc)` (#233)
+- Add support for ignoring empty matches (#240)
 ### Changed
 - `RegexBuilder` can now build multiple patterns with the same options (#213)
 ### Fixed

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -24,7 +24,7 @@ extern crate criterion;
 use criterion::Criterion;
 use std::time::Duration;
 
-use fancy_regex::internal::{analyze, compile, run_default};
+use fancy_regex::internal::{analyze, compile, run_default, CompileOptions};
 use fancy_regex::Expr;
 use regex::Regex;
 
@@ -63,7 +63,15 @@ fn analyze_literal_re(c: &mut Criterion) {
 fn run_backtrack(c: &mut Criterion) {
     let tree = Expr::parse_tree("^.*?(([ab]+)\\1b)").unwrap();
     let a = analyze(&tree, true).unwrap();
-    let p = compile(&a, true, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            anchored: true,
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     c.bench_function("run_backtrack", |b| {
         b.iter(|| {
             let result = run_default(&p, "babab", 0).unwrap();
@@ -78,7 +86,14 @@ fn run_backtrack(c: &mut Criterion) {
 fn run_tricky(c: &mut Criterion) {
     let tree = Expr::parse_tree("(a|b|ab)*bc").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let mut s = String::new();
     for _ in 0..28 {
         s.push_str("ab");
@@ -90,7 +105,14 @@ fn run_tricky(c: &mut Criterion) {
 fn run_backtrack_limit(c: &mut Criterion) {
     let tree = Expr::parse_tree("(?i)(a|b|ab)*(?>c)").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let s = "abababababababababababababababababababababababababababab";
     c.bench_function("run_backtrack_limit", |b| {
         b.iter(|| run_default(&p, &s, 0).unwrap_err())
@@ -102,7 +124,14 @@ fn const_size_lookbehind(c: &mut Criterion) {
     // Benchmark const-size lookbehind (should use simple GoBack)
     let tree = Expr::parse_tree(r"(?<=ab)x").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let input = "abx";
     c.bench_function("const_size_lookbehind", |b| {
         b.iter(|| run_default(&p, input, 0).unwrap())
@@ -114,7 +143,14 @@ fn variable_size_lookbehind(c: &mut Criterion) {
     // Benchmark variable-size lookbehind (uses reverse DFA)
     let tree = Expr::parse_tree(r"(?<=a+b+)x").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let input = "aaabbbbx";
     c.bench_function("variable_size_lookbehind", |b| {
         b.iter(|| run_default(&p, input, 0).unwrap())
@@ -126,7 +162,14 @@ fn variable_size_alt_lookbehind(c: &mut Criterion) {
     // Benchmark variable-size lookbehind with alternation
     let tree = Expr::parse_tree(r"(?<=a|bc)x").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let input = "bcx";
     c.bench_function("variable_size_alt_lookbehind", |b| {
         b.iter(|| run_default(&p, input, 0).unwrap())
@@ -163,7 +206,14 @@ fn continue_from_end_of_prev_match_short_haystack(c: &mut Criterion) {
     // Benchmark \G with a short haystack that doesn't match
     let tree = Expr::parse_tree(r"\Gfoo").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let input = "bar"; // 3 bytes, doesn't match
     c.bench_function("continue_from_end_of_prev_match_short_haystack", |b| {
         b.iter(|| run_default(&p, input, 0).unwrap())
@@ -174,7 +224,14 @@ fn continue_from_end_of_prev_match_long_haystack(c: &mut Criterion) {
     // Benchmark \G with a long haystack that doesn't match
     let tree = Expr::parse_tree(r"\Gfoo").unwrap();
     let a = analyze(&tree, false).unwrap();
-    let p = compile(&a, false, tree.contains_subroutines).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
     let mut input = String::new();
     for _ in 0..10000 {
         input.push('x');

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -24,7 +24,7 @@ extern crate criterion;
 use criterion::Criterion;
 use std::time::Duration;
 
-use fancy_regex::internal::{analyze, compile, run_default, CompileOptions};
+use fancy_regex::internal::{analyze, compile, run_default, AnalyzeContext, CompileOptions};
 use fancy_regex::Expr;
 use regex::Regex;
 
@@ -56,13 +56,20 @@ fn analyze_literal_re(c: &mut Criterion) {
     let re = "^\\\\([!-/:-@\\[-`\\{-~aftnrv]|[0-7]{1,3}|x[0-9a-fA-F]{2}|x\\{[0-9a-fA-F]{1,6}\\})";
     let tree = Expr::parse_tree(re).unwrap();
     c.bench_function("analyze_literal_re", |b| {
-        b.iter(|| analyze(&tree, false).unwrap())
+        b.iter(|| analyze(&tree, AnalyzeContext::default()).unwrap())
     });
 }
 
 fn run_backtrack(c: &mut Criterion) {
     let tree = Expr::parse_tree("^.*?(([ab]+)\\1b)").unwrap();
-    let a = analyze(&tree, true).unwrap();
+    let a = analyze(
+        &tree,
+        AnalyzeContext {
+            explicit_capture_group_0: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -85,7 +92,7 @@ fn run_backtrack(c: &mut Criterion) {
 // implementations, see README.md:
 fn run_tricky(c: &mut Criterion) {
     let tree = Expr::parse_tree("(a|b|ab)*bc").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -104,7 +111,7 @@ fn run_tricky(c: &mut Criterion) {
 
 fn run_backtrack_limit(c: &mut Criterion) {
     let tree = Expr::parse_tree("(?i)(a|b|ab)*(?>c)").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -123,7 +130,7 @@ fn run_backtrack_limit(c: &mut Criterion) {
 fn const_size_lookbehind(c: &mut Criterion) {
     // Benchmark const-size lookbehind (should use simple GoBack)
     let tree = Expr::parse_tree(r"(?<=ab)x").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -142,7 +149,7 @@ fn const_size_lookbehind(c: &mut Criterion) {
 fn variable_size_lookbehind(c: &mut Criterion) {
     // Benchmark variable-size lookbehind (uses reverse DFA)
     let tree = Expr::parse_tree(r"(?<=a+b+)x").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -161,7 +168,7 @@ fn variable_size_lookbehind(c: &mut Criterion) {
 fn variable_size_alt_lookbehind(c: &mut Criterion) {
     // Benchmark variable-size lookbehind with alternation
     let tree = Expr::parse_tree(r"(?<=a|bc)x").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -205,7 +212,7 @@ criterion_group!(
 fn continue_from_end_of_prev_match_short_haystack(c: &mut Criterion) {
     // Benchmark \G with a short haystack that doesn't match
     let tree = Expr::parse_tree(r"\Gfoo").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {
@@ -223,7 +230,7 @@ fn continue_from_end_of_prev_match_short_haystack(c: &mut Criterion) {
 fn continue_from_end_of_prev_match_long_haystack(c: &mut Criterion) {
     // Benchmark \G with a long haystack that doesn't match
     let tree = Expr::parse_tree(r"\Gfoo").unwrap();
-    let a = analyze(&tree, false).unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
     let p = compile(
         &a,
         CompileOptions {

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -89,13 +89,12 @@ fn main() {
             let re = args.next().expect("expected regexp argument");
             let tree = Expr::parse_tree(&re).unwrap();
             let text = args.next().expect("expected text argument");
-            let a = analyze(&tree, false).unwrap();
+            let a = analyze(&tree, false, false).unwrap();
             let p = compile(
                 &a,
                 CompileOptions {
                     anchored: true,
                     contains_subroutines: tree.contains_subroutines,
-                    hard_context: false,
                 },
             )
             .unwrap();
@@ -138,7 +137,7 @@ fn graph(re: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
 fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let mut tree = Expr::parse_tree(&re).unwrap();
     let requires_capture_group_fixup = optimize(&mut tree);
-    let a = analyze(&tree, requires_capture_group_fixup);
+    let a = analyze(&tree, requires_capture_group_fixup, false);
     writeln!(writer, "{:#?}", a)
 }
 
@@ -153,13 +152,13 @@ fn prog(re: &str) -> Prog {
     // which means that "toy" behaves differently to tests etc.
     let mut tree = Expr::parse_tree(re).expect("Expected parsing regex to work");
     let requires_capture_group_fixup = optimize(&mut tree);
-    let result = analyze(&tree, requires_capture_group_fixup).expect("Expected analyze to succeed");
+    let result =
+        analyze(&tree, requires_capture_group_fixup, false).expect("Expected analyze to succeed");
     compile(
         &result,
         CompileOptions {
             anchored: can_compile_as_anchored(&tree.expr),
             contains_subroutines: tree.contains_subroutines,
-            hard_context: false,
         },
     )
     .expect("Expected compile to succeed")

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -21,7 +21,7 @@
 //! A simple test app for exercising and debugging the regex engine.
 
 use fancy_regex::internal::{
-    analyze, can_compile_as_anchored, compile, optimize, run_trace, Insn, Prog,
+    analyze, can_compile_as_anchored, compile, optimize, run_trace, CompileOptions, Insn, Prog,
 };
 use fancy_regex::*;
 use std::env;
@@ -90,7 +90,15 @@ fn main() {
             let tree = Expr::parse_tree(&re).unwrap();
             let text = args.next().expect("expected text argument");
             let a = analyze(&tree, false).unwrap();
-            let p = compile(&a, true, tree.contains_subroutines, false).unwrap();
+            let p = compile(
+                &a,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    hard_context: false,
+                },
+            )
+            .unwrap();
             run_trace(&p, &text, 0).unwrap();
         } else if cmd == "graph" {
             let re = args.next().expect("expected regexp argument");
@@ -148,9 +156,11 @@ fn prog(re: &str) -> Prog {
     let result = analyze(&tree, requires_capture_group_fixup).expect("Expected analyze to succeed");
     compile(
         &result,
-        can_compile_as_anchored(&tree.expr),
-        tree.contains_subroutines,
-        false,
+        CompileOptions {
+            anchored: can_compile_as_anchored(&tree.expr),
+            contains_subroutines: tree.contains_subroutines,
+            hard_context: false,
+        },
     )
     .expect("Expected compile to succeed")
 }

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -21,7 +21,8 @@
 //! A simple test app for exercising and debugging the regex engine.
 
 use fancy_regex::internal::{
-    analyze, can_compile_as_anchored, compile, optimize, run_trace, CompileOptions, Insn, Prog,
+    analyze, can_compile_as_anchored, compile, optimize, run_trace, AnalyzeContext, CompileOptions,
+    Insn, Prog,
 };
 use fancy_regex::*;
 use std::env;
@@ -89,7 +90,7 @@ fn main() {
             let re = args.next().expect("expected regexp argument");
             let tree = Expr::parse_tree(&re).unwrap();
             let text = args.next().expect("expected text argument");
-            let a = analyze(&tree, false, false).unwrap();
+            let a = analyze(&tree, AnalyzeContext::default()).unwrap();
             let p = compile(
                 &a,
                 CompileOptions {
@@ -137,7 +138,13 @@ fn graph(re: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
 fn show_analysis(re: &str, writer: &mut Formatter<'_>) -> Result {
     let mut tree = Expr::parse_tree(&re).unwrap();
     let requires_capture_group_fixup = optimize(&mut tree);
-    let a = analyze(&tree, requires_capture_group_fixup, false);
+    let a = analyze(
+        &tree,
+        AnalyzeContext {
+            explicit_capture_group_0: requires_capture_group_fixup,
+            ..Default::default()
+        },
+    );
     writeln!(writer, "{:#?}", a)
 }
 
@@ -152,8 +159,14 @@ fn prog(re: &str) -> Prog {
     // which means that "toy" behaves differently to tests etc.
     let mut tree = Expr::parse_tree(re).expect("Expected parsing regex to work");
     let requires_capture_group_fixup = optimize(&mut tree);
-    let result =
-        analyze(&tree, requires_capture_group_fixup, false).expect("Expected analyze to succeed");
+    let result = analyze(
+        &tree,
+        AnalyzeContext {
+            explicit_capture_group_0: requires_capture_group_fixup,
+            ..Default::default()
+        },
+    )
+    .expect("Expected analyze to succeed");
     compile(
         &result,
         CompileOptions {

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -90,7 +90,7 @@ fn main() {
             let tree = Expr::parse_tree(&re).unwrap();
             let text = args.next().expect("expected text argument");
             let a = analyze(&tree, false).unwrap();
-            let p = compile(&a, true, tree.contains_subroutines).unwrap();
+            let p = compile(&a, true, tree.contains_subroutines, false).unwrap();
             run_trace(&p, &text, 0).unwrap();
         } else if cmd == "graph" {
             let re = args.next().expect("expected regexp argument");
@@ -110,7 +110,7 @@ fn graph(re: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
             .replace(r#"""#, r#"\""#);
         write!(writer, r#"{:3} [label="{}: {}"];{}"#, i, i, label, "\n")?;
         match *insn {
-            Insn::Split(a, b) => {
+            Insn::Split(a, b) | Insn::SplitUnanchored(a, b) => {
                 write!(writer, "{:3} -> {};\n", i, a)?;
                 write!(writer, "{:3} -> {};\n", i, b)?;
             }
@@ -150,6 +150,7 @@ fn prog(re: &str) -> Prog {
         &result,
         can_compile_as_anchored(&tree.expr),
         tree.contains_subroutines,
+        false,
     )
     .expect("Expected compile to succeed")
 }
@@ -202,7 +203,7 @@ digraph G {
             r"a+(?<b>b*)(?=c)\k<b>",
             "\
 digraph G {
-  0 [label=\"0: Split(3, 1)\"];
+  0 [label=\"0: SplitUnanchored(3, 1)\"];
   0 -> 3;
   0 -> 1;
   1 [label=\"1: Any\"];
@@ -257,7 +258,7 @@ digraph G {
     fn test_compilation_fancy_debug_output() {
         let expected = "  ".to_owned()
             + "\
-  0: Split(3, 1)
+  0: SplitUnanchored(3, 1)
   1: Any
   2: Jmp(0)
   3: Save(0)
@@ -284,7 +285,7 @@ digraph G {
     fn test_compilation_variable_lookbehind_debug_output() {
         let expected = "  ".to_owned()
             + "\
-  0: Split(3, 1)
+  0: SplitUnanchored(3, 1)
   1: Any
   2: Jmp(0)
   3: Save(0)

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -186,12 +186,18 @@ pub fn analyze_regex(pattern: &str, flags: JsValue) -> Result<String, String> {
     let flags = get_flags(flags)?;
     let regex_flags = compute_regex_flags(&flags);
 
-    use fancy_regex::internal::{analyze, optimize};
+    use fancy_regex::internal::{analyze, optimize, AnalyzeContext};
 
     match fancy_regex::Expr::parse_tree_with_flags(pattern, regex_flags) {
         Ok(mut tree) => {
             let requires_capture_group_fixup = optimize(&mut tree);
-            match analyze(&tree, requires_capture_group_fixup) {
+            match analyze(
+                &tree,
+                AnalyzeContext {
+                    explicit_capture_group_0: requires_capture_group_fixup,
+                    ..Default::default()
+                },
+            ) {
                 Ok(info) => Ok(format!("{:#?}", info)),
                 Err(e) => Err(format!("Analysis error: {}", e)),
             }
@@ -417,7 +423,7 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
     let flags = get_flags(flags)?;
     let regex_flags = compute_regex_flags(&flags);
 
-    use fancy_regex::internal::{analyze, optimize};
+    use fancy_regex::internal::{analyze, optimize, AnalyzeContext};
 
     match fancy_regex::Expr::parse_tree_with_flags(pattern, regex_flags) {
         Ok(mut tree) => {
@@ -425,7 +431,13 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
             // Build reverse lookup map from group index to name once
             let group_names = build_group_names_lookup(&named_groups);
             let requires_capture_group_fixup = optimize(&mut tree);
-            match analyze(&tree, requires_capture_group_fixup) {
+            match analyze(
+                &tree,
+                AnalyzeContext {
+                    explicit_capture_group_0: requires_capture_group_fixup,
+                    ..Default::default()
+                },
+            ) {
                 Ok(info) => {
                     let tree_node = info_to_tree_node(&info, &group_names);
                     serde_wasm_bindgen::to_value(&tree_node)
@@ -453,7 +465,9 @@ mod tests {
     fn parse_and_analyze(pattern: &str) -> AnalysisTreeNode {
         let tree = fancy_regex::Expr::parse_tree(pattern).unwrap();
         let group_names = build_group_names_lookup(&tree.named_groups);
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
+        let info =
+            fancy_regex::internal::analyze(&tree, fancy_regex::internal::AnalyzeContext::default())
+                .unwrap();
         info_to_tree_node(&info, &group_names)
     }
 

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -47,6 +47,7 @@ pub struct RegexFlags {
     pub ignore_whitespace: bool,
     pub unicode: bool,
     pub oniguruma_mode: bool,
+    pub find_not_empty: bool,
 }
 
 impl Default for RegexFlags {
@@ -58,6 +59,7 @@ impl Default for RegexFlags {
             ignore_whitespace: false,
             unicode: true,
             oniguruma_mode: true,
+            find_not_empty: false,
         }
     }
 }
@@ -81,6 +83,7 @@ fn build_regex(pattern: &str, flags: &RegexFlags) -> Result<Regex, String> {
     builder.ignore_whitespace(flags.ignore_whitespace);
     builder.unicode_mode(flags.unicode);
     builder.oniguruma_mode(flags.oniguruma_mode);
+    builder.find_not_empty(flags.find_not_empty);
 
     builder
         .build()

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -195,7 +195,7 @@ pub fn analyze_regex(pattern: &str, flags: JsValue) -> Result<String, String> {
                 &tree,
                 AnalyzeContext {
                     explicit_capture_group_0: requires_capture_group_fixup,
-                    ..Default::default()
+                    find_not_empty: flags.find_not_empty,
                 },
             ) {
                 Ok(info) => Ok(format!("{:#?}", info)),
@@ -435,7 +435,7 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
                 &tree,
                 AnalyzeContext {
                     explicit_capture_group_0: requires_capture_group_fixup,
-                    ..Default::default()
+                    find_not_empty: flags.find_not_empty,
                 },
             ) {
                 Ok(info) => {

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -784,11 +784,7 @@ mod tests {
 
     #[test]
     fn test_info_to_tree_node_define_group() {
-        let tree = fancy_regex::Expr::parse_tree(r"(?(DEFINE)(a)(b))").unwrap();
-        let info = fancy_regex::internal::analyze(&tree, false).unwrap();
-        let group_names = std::collections::HashMap::new();
-
-        let node = info_to_tree_node(&info, &group_names);
+        let node = parse_and_analyze(r"(?(DEFINE)(a)(b))");
 
         assert_eq!(node.kind, "DefineGroup");
     }

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -37,6 +37,7 @@ class FancyRegexPlayground {
                 dotMatchesNewline: document.getElementById('flag-dot-matches-newline'),
                 ignoreWhitespace: document.getElementById('flag-ignore-whitespace'),
                 onigurumaMode: document.getElementById('flag-oniguruma-mode'),
+                findNotEmpty: document.getElementById('flag-find-not-empty'),
             }
         };
 
@@ -73,6 +74,7 @@ class FancyRegexPlayground {
             ignore_whitespace: this.elements.flags.ignoreWhitespace.checked,
             unicode: true,
             oniguruma_mode: this.elements.flags.onigurumaMode.checked,
+            find_not_empty: this.elements.flags.findNotEmpty.checked,
         };
     }
 

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -46,6 +46,10 @@
                             <input type="checkbox" id="flag-oniguruma-mode" />
                             <label for="flag-oniguruma-mode">Oniguruma mode</label>
                         </div>
+                        <div class="flag-group">
+                            <input type="checkbox" id="flag-find-not-empty" />
+                            <label for="flag-find-not-empty">Find not empty</label>
+                        </div>
                     </div>
                 </div>
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -127,6 +127,9 @@ struct Analyzer<'a> {
     group_exprs: Map<usize, &'a Expr>,
     /// Track groups currently being analyzed to prevent infinite recursion
     analyzing_groups: BitSet,
+    /// When true, nodes that could produce empty matches (min size 0 and not const size)
+    /// are promoted to hard so the VM can backtrack past them to find a non-empty match.
+    find_not_empty: bool,
 }
 
 impl<'a> Analyzer<'a> {
@@ -471,6 +474,12 @@ impl<'a> Analyzer<'a> {
             }
         };
 
+        // When find_not_empty is active, any node that could produce an empty match
+        // must be handled by the VM so it can backtrack past it to find a non-empty match.
+        if self.find_not_empty && min_size == 0 && !const_size {
+            hard = true;
+        }
+
         Ok(Info {
             expr,
             children,
@@ -721,7 +730,11 @@ fn collect_groups<'a>(
 }
 
 /// Analyze the parsed expression to determine whether it requires fancy features.
-pub fn analyze<'a>(tree: &'a ExprTree, explicit_capture_group_0: bool) -> Result<Info<'a>> {
+pub fn analyze<'a>(
+    tree: &'a ExprTree,
+    explicit_capture_group_0: bool,
+    find_not_empty: bool,
+) -> Result<Info<'a>> {
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
     if tree.numeric_capture_group_references && !tree.named_groups.is_empty() {
         return Err(Error::CompileError(Box::new(
@@ -749,6 +762,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, explicit_capture_group_0: bool) -> Result
         root_groups: BitSet::new(),
         group_exprs,
         analyzing_groups: BitSet::new(),
+        find_not_empty,
     };
 
     let analyzed = analyzer.visit(&tree.expr, 0, false, 0)?;
@@ -826,7 +840,7 @@ mod tests {
     ) {
         let tree = Expr::parse_tree(pattern).unwrap();
         assert_compile_error(
-            analyze(&tree, explicit_capture_group_0),
+            analyze(&tree, explicit_capture_group_0, false),
             |e| matches!(e, CompileError::InvalidBackref(g) if *g == expected_group),
         );
     }
@@ -881,7 +895,7 @@ mod tests {
         // This would then cause a misleading "Invalid back reference" error instead of
         // the correct error.
         let tree = Expr::parse_tree(r"(?<a>a)(?<b>b)\g<no_exist>(?<c>c)\k<a>\k<c>").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
 
         // Should get the unresolved subroutine call error, not an invalid backref error
         assert_compile_error(
@@ -893,36 +907,46 @@ mod tests {
     #[test]
     fn allow_analysis_of_self_backref() {
         // even if it will never match, see issue 103
-        assert!(!analyze(&Expr::parse_tree(r"(.\1)").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"((.\1))").unwrap(), true).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(([ab]+)\1b)").unwrap(), false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.\1)").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"((.\1))").unwrap(), true, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(([ab]+)\1b)").unwrap(), false, false).is_err());
         // in the following scenario it can match
-        assert!(!analyze(&Expr::parse_tree(r"(([ab]+?)(?(1)\1| )c)+").unwrap(), false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(([ab]+?)(?(1)\1| )c)+").unwrap(),
+            false,
+            false
+        )
+        .is_err());
     }
 
     #[test]
     fn allow_backref_even_when_capture_group_occurs_after_backref() {
-        assert!(!analyze(&Expr::parse_tree(r"\1(.)").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(\1(.))").unwrap(), true).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"\1(.)").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(\1(.))").unwrap(), true, false).is_err());
     }
 
     #[test]
     fn valid_backref_occurs_after_capture_group() {
-        assert!(!analyze(&Expr::parse_tree(r"(.)\1").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"((.)\1)").unwrap(), true).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.)\1").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"((.)\1)").unwrap(), true, false).is_err());
 
-        assert!(!analyze(&Expr::parse_tree(r"((.)\2\2)\1").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)\1(.)\2").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)foo(.)\2").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\3\2\1").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\3\1").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\2\1").unwrap(), false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"((.)\2\2)\1").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.)\1(.)\2").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.)foo(.)\2").unwrap(), false, false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)(foo)(.)\3\2\1").unwrap(),
+            false,
+            false
+        )
+        .is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\3\1").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\2\1").unwrap(), false, false).is_err());
     }
 
     #[test]
     fn feature_not_yet_supported() {
         let tree = &Expr::parse_tree(r"(a)\k<1-0>").unwrap();
-        assert_compile_error(analyze(tree, false), |e| {
+        assert_compile_error(analyze(tree, false, false), |e| {
             matches!(e, CompileError::FeatureNotYetSupported(_))
         });
     }
@@ -930,7 +954,7 @@ mod tests {
     #[test]
     fn subroutine_call_undefined() {
         let tree = &Expr::parse_tree(r"\g<wrong_name>(?<different_name>a)").unwrap();
-        assert_compile_error(analyze(tree, false), |e| {
+        assert_compile_error(analyze(tree, false, false), |e| {
             matches!(e, CompileError::SubroutineCallTargetNotFound(_, _))
         });
     }
@@ -939,49 +963,49 @@ mod tests {
     fn numeric_capture_group_references_cannot_be_used_with_named_groups() {
         // Test case 1: Named group followed by numeric backref (no alternation)
         let tree = Expr::parse_tree(r"(?<name>a)\1").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 2: Numeric backref followed by named group
         let tree = Expr::parse_tree(r"(a)\1(?<name>b)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 3: Alternation with numeric backref and named group in first branch
         let tree = Expr::parse_tree(r"(?<name>a)\1|b").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 4: Alternation with named group in first branch, numeric backref in second
         let tree = Expr::parse_tree(r"(?<name>a)|\1").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 5: Numbered group containing named group, with numeric backref
         let tree = Expr::parse_tree(r"(a|(?<name>b))\1").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 6: Multiple branches with named groups and numeric backrefs
         let tree = Expr::parse_tree(r"(?<x>a)|(?<y>b)|\1").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 7: Numeric subroutine call with named group
         let tree = Expr::parse_tree(r"(?<foo>\w+)\g<1>").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 8: Named group with numeric subroutine call in alternation
         let tree = Expr::parse_tree(r"(?<foo>a)|\g<1>").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
@@ -989,28 +1013,28 @@ mod tests {
 
         // Only numeric backrefs and subroutine calls, no named groups
         let tree = Expr::parse_tree(r"(a)(b+)\1\g<2>").unwrap();
-        assert!(analyze(&tree, false).is_ok());
+        assert!(analyze(&tree, false, false).is_ok());
 
         // Only named groups and named backrefs and named subroutine calls
         let tree = Expr::parse_tree(r"(?<name>a)\k<name>\g<name>").unwrap();
-        assert!(analyze(&tree, false).is_ok());
+        assert!(analyze(&tree, false, false).is_ok());
 
         // Multiple named and numbered groups, no backrefs or subroutine calls
         let tree = Expr::parse_tree(r"(?<a>a)|(?<b>b)(c)(d+)").unwrap();
-        assert!(analyze(&tree, false).is_ok());
+        assert!(analyze(&tree, false, false).is_ok());
     }
 
     #[test]
     fn is_literal() {
         let tree = Expr::parse_tree("abc").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.is_literal(), true);
     }
 
     #[test]
     fn is_literal_with_repeat() {
         let tree = Expr::parse_tree("abc*").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.is_literal(), false);
     }
 
@@ -1033,14 +1057,14 @@ mod tests {
     fn backref_inherits_group_size_info() {
         // Test that backrefs properly inherit min_size and const_size from referenced groups
         let tree = Expr::parse_tree(r"(abc)\1").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // The concatenation should have min_size = 3 + 3 = 6 (group + backref)
         assert_eq!(info.min_size, 6);
         assert!(info.const_size);
 
         // Test with a variable-length group
         let tree = Expr::parse_tree(r"(a+)\1").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // The group has min_size = 1, but const_size = false due to the +
         // So the total should be min_size = 2, const_size = false
         assert_eq!(info.min_size, 2);
@@ -1048,7 +1072,7 @@ mod tests {
 
         // Test with optional group
         let tree = Expr::parse_tree(r"(a?)\1").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // Both group and backref can be empty, so min_size = 0
         assert_eq!(info.min_size, 0);
         assert!(!info.const_size);
@@ -1059,7 +1083,7 @@ mod tests {
         // Test forward references (backref before group definition)
         // These should use conservative defaults but still work
         let tree = Expr::parse_tree(r"\1(abc)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // Forward ref gets min_size=0, group gets min_size=3, total=3
         assert_eq!(info.min_size, 3);
         // Forward ref sets const_size=false, so overall is false
@@ -1068,30 +1092,35 @@ mod tests {
 
     #[test]
     fn backref_in_lookbehind() {
-        assert!(!analyze(&Expr::parse_tree(r"(hello)(?<=\b\1)").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(..)(?<=\1\1)").unwrap(), false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(abc)(?<=\1)def").unwrap(), false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(hello)(?<=\b\1)").unwrap(),
+            false,
+            false
+        )
+        .is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(..)(?<=\1\1)").unwrap(), false, false).is_err());
+        assert!(!analyze(&Expr::parse_tree(r"(abc)(?<=\1)def").unwrap(), false, false).is_err());
     }
 
     #[test]
     fn backref_inside_recursed_group_not_supported() {
         let tree = Expr::parse_tree(r"(?<foo>a|\(\g<foo>\)\k<foo>?)").unwrap();
         assert_compile_error(
-            analyze(&tree, false),
+            analyze(&tree, false, false),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
 
         // Test with numbered groups
         let tree = Expr::parse_tree(r"(\g<1>\1)").unwrap();
         assert_compile_error(
-            analyze(&tree, false),
+            analyze(&tree, false, false),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
 
         // Another example with alternation inside recursed group
         let tree = Expr::parse_tree(r"(a|\g<1>b\1)").unwrap();
         assert_compile_error(
-            analyze(&tree, false),
+            analyze(&tree, false, false),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
     }
@@ -1099,7 +1128,7 @@ mod tests {
     #[test]
     fn backref_outside_recursed_group_is_allowed() {
         let tree = Expr::parse_tree(r"(?<foo>a|\(\g<foo>\))\k<foo>").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(
             result.is_ok(),
             "Backref outside recursed group should pass analysis"
@@ -1115,13 +1144,13 @@ mod tests {
     #[test]
     fn min_pos_in_group_calculated_correctly_with_no_groups() {
         let tree = Expr::parse_tree(r"\G").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.min_size, 0);
         assert_eq!(info.min_pos_in_group, 0);
         assert!(info.const_size);
 
         let tree = Expr::parse_tree(r"\G(?=abc)\w+").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // the lookahead itself has min size 0
         assert_eq!(info.children[1].min_size, 0);
         assert!(info.children[1].const_size);
@@ -1135,7 +1164,7 @@ mod tests {
         assert!(!info.const_size);
 
         let tree = Expr::parse_tree(r"(?:ab*|cd){2}(?=bar)\w").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // the whole expression has min size 3 (a times 2 plus \w)
         assert_eq!(info.min_size, 3);
         // the min pos of the lookahead is 2
@@ -1149,7 +1178,7 @@ mod tests {
     #[test]
     fn backtracking_control_verb_is_hard_and_const_size() {
         let tree = Expr::parse_tree(r"(*FAIL)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.min_size, 0);
         assert_eq!(info.min_pos_in_group, 0);
         assert!(info.const_size);
@@ -1158,7 +1187,7 @@ mod tests {
     #[test]
     fn min_pos_in_group_calculated_correctly_with_capture_groups() {
         let tree = Expr::parse_tree(r"a(bc)d(e(f)g)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.min_pos_in_group, 0);
         // before the capture begins, the min pos in group 0 is 1
         assert_eq!(info.children[1].min_pos_in_group, 1);
@@ -1184,7 +1213,7 @@ mod tests {
     #[test]
     fn absent_repeater_is_hard_and_not_const_size() {
         let tree = Expr::parse_tree(r"(?~abc)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.min_size, 0);
         assert!(!info.const_size);
         assert!(info.hard);
@@ -1193,7 +1222,7 @@ mod tests {
     #[test]
     fn absent_expression_is_hard_and_not_const_size() {
         let tree = Expr::parse_tree(r"(?~|abc|\d+)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         // min_size comes from exp part (\d+ has min_size 1)
         assert_eq!(info.min_size, 1);
         assert!(!info.const_size);
@@ -1203,7 +1232,7 @@ mod tests {
     #[test]
     fn range_clear_is_hard_and_const_size() {
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_eq!(info.min_size, 0);
         assert!(info.const_size);
         assert!(info.hard);
@@ -1213,12 +1242,12 @@ mod tests {
     fn left_recursive_subroutine_direct() {
         // Direct left recursion: group 1 calls itself at position 0
         let tree = Expr::parse_tree(r"(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"abc(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1226,11 +1255,11 @@ mod tests {
     #[test]
     fn not_left_recursive_subroutine_after_group() {
         let tree = Expr::parse_tree(r"(a)\g<1>").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(result.is_ok());
 
         let tree = Expr::parse_tree(r"(?<test>a)\g<test>").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(result.is_ok());
     }
 
@@ -1238,12 +1267,12 @@ mod tests {
     fn left_recursive_subroutine_at_start() {
         // Left recursion at start of group: (\g<1>a)
         let tree = Expr::parse_tree(r"(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"(?<test>\g<test>a)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1252,12 +1281,12 @@ mod tests {
     fn left_recursive_subroutine_indirect() {
         // Indirect left recursion: non-nested subroutine calls to each other
         let tree = Expr::parse_tree(r"(\g<2>)(\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"(\g<2>)(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1266,7 +1295,7 @@ mod tests {
     fn left_recursive_subroutine_with_alternation() {
         // Left recursion through alternation, depending which branch is taken it could be left-recursive
         let tree = Expr::parse_tree(r"(a|\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1276,7 +1305,7 @@ mod tests {
         // Not left recursive because subroutine call is after a character was consumed,
         // but still never-ending because the recursive call is mandatory.
         let tree = Expr::parse_tree(r"(a\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1284,7 +1313,7 @@ mod tests {
     #[test]
     fn bounded_recursive_after_char_is_allowed() {
         let tree = Expr::parse_tree(r"(a\g<1>?)").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(result.is_ok());
     }
 
@@ -1292,7 +1321,7 @@ mod tests {
     fn not_left_recursive_zero_repetition() {
         // Not left recursive because subroutine call is unreachable
         let tree = Expr::parse_tree(r"(a?\g<1>){0}").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(result.is_ok());
     }
 
@@ -1300,7 +1329,7 @@ mod tests {
     fn left_recursive_with_both_positions() {
         // Left recursive because \g<1> appears at position 0 in the group even though also at end at position 1
         let tree = Expr::parse_tree(r"(\g<1>a\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1308,7 +1337,7 @@ mod tests {
     #[test]
     fn left_recursive_with_lookahead() {
         let tree = Expr::parse_tree(r"((?=a)\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1318,7 +1347,7 @@ mod tests {
         // Self-recursive on group 0 after a character
         let tree = Expr::parse_tree(r"a\g<0>").unwrap();
         // Group 0 calls itself at position 1 (after 'a'), so this is NOT left recursive
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1327,7 +1356,7 @@ mod tests {
     fn not_left_recursive_forward_call() {
         // Forward subroutine call - not left recursive: \g<1>(a)
         let tree = Expr::parse_tree(r"\g<1>(a)").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         // The call happens before the group is defined, but it's at position 0 of group 0 (implicit)
         // which calls group 1. Group 1 doesn't call anything, so no cycle.
         assert!(result.is_ok());
@@ -1337,7 +1366,7 @@ mod tests {
     fn not_left_recursive_group_zero_explicit() {
         // Self-recursive on explicit group 0: (a\g<0>)
         let tree = Expr::parse_tree(r"(a\g<0>)").unwrap();
-        assert_compile_error(analyze(&tree, true), |e| {
+        assert_compile_error(analyze(&tree, true, false), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1345,7 +1374,7 @@ mod tests {
     #[test]
     fn not_left_recursive_group_zero_subroutine_call_unreachable() {
         let tree = Expr::parse_tree(r"\g<0>{0}abc").unwrap();
-        let result = analyze(&tree, true);
+        let result = analyze(&tree, true, false);
         assert!(result.is_ok());
     }
 
@@ -1353,7 +1382,7 @@ mod tests {
     fn left_recursive_group_zero_at_start() {
         // Self-recursive on explicit group 0 at start: (\g<0>a)
         let tree = Expr::parse_tree(r"(\g<0>a)").unwrap();
-        let result = analyze(&tree, true);
+        let result = analyze(&tree, true, false);
         // With explicit group 0, \g<0> at position 0 is left-recursive
         assert!(result.is_err());
     }
@@ -1367,7 +1396,7 @@ mod tests {
         // Group 3 -> Group 1 (at pos 1, after 'a')
         // This forms a cycle, but the call from group 3 to group 1 is at position 1
         // So it's not left-recursive
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1376,7 +1405,7 @@ mod tests {
     fn three_way_left_recursive() {
         // Three-way left recursion
         let tree = Expr::parse_tree(r"(\g<2>)(\g<3>)(\g<1>)").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         // Group 1 -> Group 2 (at pos 0)
         // Group 2 -> Group 3 (at pos 0)
         // Group 3 -> Group 1 (at pos 0)
@@ -1384,7 +1413,7 @@ mod tests {
         assert!(result.is_err());
 
         let tree = Expr::parse_tree(r"(\g<2>a)(\g<3>b)(\g<1>c)").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
         assert!(result.is_err());
     }
 
@@ -1396,7 +1425,7 @@ mod tests {
         // Group 2 contains \g<1> - calls group 1 at position 0
         // This creates a cycle: Group 2 -> Group 1 (at pos 0) -> Group 2 (at pos 0)
         let tree = Expr::parse_tree(r"(a?\g<2>){0}(\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false), |e| {
+        assert_compile_error(analyze(&tree, false, false), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1406,7 +1435,7 @@ mod tests {
         // Group n (1): |\g<m>\g<n> - calls m then itself, but m has min_size > 0
         // Group m (2): a(b)\g<m> - calls itself after 'ab'
         let tree = Expr::parse_tree(r"(?<n>|\g<m>\g<n>)\z|\zEND (?<m>a(b)\g<m>)").unwrap();
-        let result = analyze(&tree, false);
+        let result = analyze(&tree, false, false);
 
         assert!(
             result.is_ok(),
@@ -1422,7 +1451,7 @@ mod tests {
     fn forward_subroutine_call_single_group() {
         // Forward reference: calls group 1 before it's defined
         let tree = Expr::parse_tree(r"\g<1>(.a.)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
 
         // The pattern should have 1 capture group
         assert_eq!(info.start_group(), 1);
@@ -1458,7 +1487,7 @@ mod tests {
     fn forward_subroutine_call_with_multiple_groups() {
         // Forward reference with multiple groups defined after the subroutine call
         let tree = Expr::parse_tree(r"\g<2>(a)(bc+)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
 
         // The pattern should have 2 capture groups
         assert_eq!(info.start_group(), 1);
@@ -1496,7 +1525,7 @@ mod tests {
     fn forward_subroutine_call_with_nested_groups() {
         // Forward reference with multiple nested groups defined after the subroutine call
         let tree = Expr::parse_tree(r"(foo)\g<4>(a(b)?)(c(d))(?!e)").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
 
         // The pattern should have 5 capture groups
         assert_eq!(info.start_group(), 1);

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1696,7 +1696,7 @@ mod tests {
         // A DEFINE block should be analyzed as: min_size=0, const_size=true, hard=false
         // It matches nothing itself, so it doesn't need backtracking.
         let tree = Expr::parse_tree(r"(?(DEFINE)(?<word>\w+))").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         assert!(matches!(info.expr, Expr::DefineGroup { .. }));
         assert_eq!(info.min_size, 0);
@@ -1709,7 +1709,7 @@ mod tests {
         // Groups inside a DEFINE block should still be assigned group numbers,
         // so that subroutine calls can reference them.
         let tree = Expr::parse_tree(r"(?(DEFINE)(?<first>a)(?<second>b))").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         // The definitions child: a Concat of two groups (groups 1 and 2)
         assert_eq!(info.children[0].start_group(), 1);
@@ -1720,7 +1720,7 @@ mod tests {
             r"(abc)(?(DEFINE)(?<second>a)ignored: no group(?<third>b(?<fourth>c)))(?<fifth>d)",
         )
         .unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         assert_eq!(info.start_group(), 1);
         assert_eq!(info.end_group(), 6);

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -729,12 +729,23 @@ fn collect_groups<'a>(
     }
 }
 
+/// Context options for [`analyze`].
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzeContext {
+    /// When `true`, capture group numbering starts at 0 rather than 1 (i.e. there is an explicit
+    /// outer capture group 0 in the pattern rather than an implicit one added by the compiler).
+    pub explicit_capture_group_0: bool,
+    /// When `true`, sub-expressions that could produce an empty match (`min_size == 0` and not
+    /// `const_size`) are promoted to `hard` so that the VM can backtrack past them to find a
+    /// non-empty match.
+    pub find_not_empty: bool,
+}
+
 /// Analyze the parsed expression to determine whether it requires fancy features.
-pub fn analyze<'a>(
-    tree: &'a ExprTree,
-    explicit_capture_group_0: bool,
-    find_not_empty: bool,
-) -> Result<Info<'a>> {
+pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> {
+    let explicit_capture_group_0 = ctx.explicit_capture_group_0;
+    let find_not_empty = ctx.find_not_empty;
+
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
     if tree.numeric_capture_group_references && !tree.named_groups.is_empty() {
         return Err(Error::CompileError(Box::new(
@@ -813,7 +824,7 @@ pub fn can_compile_as_anchored(root_expr: &Expr) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::analyze;
+    use super::{analyze, AnalyzeContext};
     // use super::literal_const_size;
     use crate::{can_compile_as_anchored, CompileError, Error, Expr};
     use matches::assert_matches;
@@ -840,7 +851,13 @@ mod tests {
     ) {
         let tree = Expr::parse_tree(pattern).unwrap();
         assert_compile_error(
-            analyze(&tree, explicit_capture_group_0, false),
+            analyze(
+                &tree,
+                AnalyzeContext {
+                    explicit_capture_group_0,
+                    ..Default::default()
+                },
+            ),
             |e| matches!(e, CompileError::InvalidBackref(g) if *g == expected_group),
         );
     }
@@ -895,7 +912,7 @@ mod tests {
         // This would then cause a misleading "Invalid back reference" error instead of
         // the correct error.
         let tree = Expr::parse_tree(r"(?<a>a)(?<b>b)\g<no_exist>(?<c>c)\k<a>\k<c>").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
 
         // Should get the unresolved subroutine call error, not an invalid backref error
         assert_compile_error(
@@ -907,46 +924,101 @@ mod tests {
     #[test]
     fn allow_analysis_of_self_backref() {
         // even if it will never match, see issue 103
-        assert!(!analyze(&Expr::parse_tree(r"(.\1)").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"((.\1))").unwrap(), true, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(([ab]+)\1b)").unwrap(), false, false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.\1)").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"((.\1))").unwrap(),
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            }
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(([ab]+)\1b)").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
         // in the following scenario it can match
         assert!(!analyze(
             &Expr::parse_tree(r"(([ab]+?)(?(1)\1| )c)+").unwrap(),
-            false,
-            false
+            AnalyzeContext::default(),
         )
         .is_err());
     }
 
     #[test]
     fn allow_backref_even_when_capture_group_occurs_after_backref() {
-        assert!(!analyze(&Expr::parse_tree(r"\1(.)").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(\1(.))").unwrap(), true, false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"\1(.)").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(\1(.))").unwrap(),
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            }
+        )
+        .is_err());
     }
 
     #[test]
     fn valid_backref_occurs_after_capture_group() {
-        assert!(!analyze(&Expr::parse_tree(r"(.)\1").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"((.)\1)").unwrap(), true, false).is_err());
-
-        assert!(!analyze(&Expr::parse_tree(r"((.)\2\2)\1").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)\1(.)\2").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)foo(.)\2").unwrap(), false, false).is_err());
         assert!(!analyze(
-            &Expr::parse_tree(r"(.)(foo)(.)\3\2\1").unwrap(),
-            false,
-            false
+            &Expr::parse_tree(r"(.)\1").unwrap(),
+            AnalyzeContext::default()
         )
         .is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\3\1").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(.)(foo)(.)\2\1").unwrap(), false, false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"((.)\1)").unwrap(),
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            }
+        )
+        .is_err());
+
+        assert!(!analyze(
+            &Expr::parse_tree(r"((.)\2\2)\1").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)\1(.)\2").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)foo(.)\2").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)(foo)(.)\3\2\1").unwrap(),
+            AnalyzeContext::default(),
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)(foo)(.)\3\1").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(.)(foo)(.)\2\1").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
     }
 
     #[test]
     fn feature_not_yet_supported() {
         let tree = &Expr::parse_tree(r"(a)\k<1-0>").unwrap();
-        assert_compile_error(analyze(tree, false, false), |e| {
+        assert_compile_error(analyze(tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::FeatureNotYetSupported(_))
         });
     }
@@ -954,7 +1026,7 @@ mod tests {
     #[test]
     fn subroutine_call_undefined() {
         let tree = &Expr::parse_tree(r"\g<wrong_name>(?<different_name>a)").unwrap();
-        assert_compile_error(analyze(tree, false, false), |e| {
+        assert_compile_error(analyze(tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::SubroutineCallTargetNotFound(_, _))
         });
     }
@@ -963,49 +1035,49 @@ mod tests {
     fn numeric_capture_group_references_cannot_be_used_with_named_groups() {
         // Test case 1: Named group followed by numeric backref (no alternation)
         let tree = Expr::parse_tree(r"(?<name>a)\1").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 2: Numeric backref followed by named group
         let tree = Expr::parse_tree(r"(a)\1(?<name>b)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 3: Alternation with numeric backref and named group in first branch
         let tree = Expr::parse_tree(r"(?<name>a)\1|b").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 4: Alternation with named group in first branch, numeric backref in second
         let tree = Expr::parse_tree(r"(?<name>a)|\1").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 5: Numbered group containing named group, with numeric backref
         let tree = Expr::parse_tree(r"(a|(?<name>b))\1").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 6: Multiple branches with named groups and numeric backrefs
         let tree = Expr::parse_tree(r"(?<x>a)|(?<y>b)|\1").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 7: Numeric subroutine call with named group
         let tree = Expr::parse_tree(r"(?<foo>\w+)\g<1>").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
         // Test case 8: Named group with numeric subroutine call in alternation
         let tree = Expr::parse_tree(r"(?<foo>a)|\g<1>").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NamedBackrefOnly)
         });
 
@@ -1013,28 +1085,28 @@ mod tests {
 
         // Only numeric backrefs and subroutine calls, no named groups
         let tree = Expr::parse_tree(r"(a)(b+)\1\g<2>").unwrap();
-        assert!(analyze(&tree, false, false).is_ok());
+        assert!(analyze(&tree, AnalyzeContext::default()).is_ok());
 
         // Only named groups and named backrefs and named subroutine calls
         let tree = Expr::parse_tree(r"(?<name>a)\k<name>\g<name>").unwrap();
-        assert!(analyze(&tree, false, false).is_ok());
+        assert!(analyze(&tree, AnalyzeContext::default()).is_ok());
 
         // Multiple named and numbered groups, no backrefs or subroutine calls
         let tree = Expr::parse_tree(r"(?<a>a)|(?<b>b)(c)(d+)").unwrap();
-        assert!(analyze(&tree, false, false).is_ok());
+        assert!(analyze(&tree, AnalyzeContext::default()).is_ok());
     }
 
     #[test]
     fn is_literal() {
         let tree = Expr::parse_tree("abc").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.is_literal(), true);
     }
 
     #[test]
     fn is_literal_with_repeat() {
         let tree = Expr::parse_tree("abc*").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.is_literal(), false);
     }
 
@@ -1057,14 +1129,14 @@ mod tests {
     fn backref_inherits_group_size_info() {
         // Test that backrefs properly inherit min_size and const_size from referenced groups
         let tree = Expr::parse_tree(r"(abc)\1").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // The concatenation should have min_size = 3 + 3 = 6 (group + backref)
         assert_eq!(info.min_size, 6);
         assert!(info.const_size);
 
         // Test with a variable-length group
         let tree = Expr::parse_tree(r"(a+)\1").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // The group has min_size = 1, but const_size = false due to the +
         // So the total should be min_size = 2, const_size = false
         assert_eq!(info.min_size, 2);
@@ -1072,7 +1144,7 @@ mod tests {
 
         // Test with optional group
         let tree = Expr::parse_tree(r"(a?)\1").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // Both group and backref can be empty, so min_size = 0
         assert_eq!(info.min_size, 0);
         assert!(!info.const_size);
@@ -1083,7 +1155,7 @@ mod tests {
         // Test forward references (backref before group definition)
         // These should use conservative defaults but still work
         let tree = Expr::parse_tree(r"\1(abc)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // Forward ref gets min_size=0, group gets min_size=3, total=3
         assert_eq!(info.min_size, 3);
         // Forward ref sets const_size=false, so overall is false
@@ -1094,33 +1166,40 @@ mod tests {
     fn backref_in_lookbehind() {
         assert!(!analyze(
             &Expr::parse_tree(r"(hello)(?<=\b\1)").unwrap(),
-            false,
-            false
+            AnalyzeContext::default(),
         )
         .is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(..)(?<=\1\1)").unwrap(), false, false).is_err());
-        assert!(!analyze(&Expr::parse_tree(r"(abc)(?<=\1)def").unwrap(), false, false).is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(..)(?<=\1\1)").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
+        assert!(!analyze(
+            &Expr::parse_tree(r"(abc)(?<=\1)def").unwrap(),
+            AnalyzeContext::default()
+        )
+        .is_err());
     }
 
     #[test]
     fn backref_inside_recursed_group_not_supported() {
         let tree = Expr::parse_tree(r"(?<foo>a|\(\g<foo>\)\k<foo>?)").unwrap();
         assert_compile_error(
-            analyze(&tree, false, false),
+            analyze(&tree, AnalyzeContext::default()),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
 
         // Test with numbered groups
         let tree = Expr::parse_tree(r"(\g<1>\1)").unwrap();
         assert_compile_error(
-            analyze(&tree, false, false),
+            analyze(&tree, AnalyzeContext::default()),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
 
         // Another example with alternation inside recursed group
         let tree = Expr::parse_tree(r"(a|\g<1>b\1)").unwrap();
         assert_compile_error(
-            analyze(&tree, false, false),
+            analyze(&tree, AnalyzeContext::default()),
             |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("Backreference") && s.contains("recursed")),
         );
     }
@@ -1128,7 +1207,7 @@ mod tests {
     #[test]
     fn backref_outside_recursed_group_is_allowed() {
         let tree = Expr::parse_tree(r"(?<foo>a|\(\g<foo>\))\k<foo>").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(
             result.is_ok(),
             "Backref outside recursed group should pass analysis"
@@ -1144,13 +1223,13 @@ mod tests {
     #[test]
     fn min_pos_in_group_calculated_correctly_with_no_groups() {
         let tree = Expr::parse_tree(r"\G").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.min_size, 0);
         assert_eq!(info.min_pos_in_group, 0);
         assert!(info.const_size);
 
         let tree = Expr::parse_tree(r"\G(?=abc)\w+").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // the lookahead itself has min size 0
         assert_eq!(info.children[1].min_size, 0);
         assert!(info.children[1].const_size);
@@ -1164,7 +1243,7 @@ mod tests {
         assert!(!info.const_size);
 
         let tree = Expr::parse_tree(r"(?:ab*|cd){2}(?=bar)\w").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // the whole expression has min size 3 (a times 2 plus \w)
         assert_eq!(info.min_size, 3);
         // the min pos of the lookahead is 2
@@ -1178,7 +1257,7 @@ mod tests {
     #[test]
     fn backtracking_control_verb_is_hard_and_const_size() {
         let tree = Expr::parse_tree(r"(*FAIL)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.min_size, 0);
         assert_eq!(info.min_pos_in_group, 0);
         assert!(info.const_size);
@@ -1187,7 +1266,7 @@ mod tests {
     #[test]
     fn min_pos_in_group_calculated_correctly_with_capture_groups() {
         let tree = Expr::parse_tree(r"a(bc)d(e(f)g)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.min_pos_in_group, 0);
         // before the capture begins, the min pos in group 0 is 1
         assert_eq!(info.children[1].min_pos_in_group, 1);
@@ -1213,7 +1292,7 @@ mod tests {
     #[test]
     fn absent_repeater_is_hard_and_not_const_size() {
         let tree = Expr::parse_tree(r"(?~abc)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.min_size, 0);
         assert!(!info.const_size);
         assert!(info.hard);
@@ -1222,7 +1301,7 @@ mod tests {
     #[test]
     fn absent_expression_is_hard_and_not_const_size() {
         let tree = Expr::parse_tree(r"(?~|abc|\d+)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         // min_size comes from exp part (\d+ has min_size 1)
         assert_eq!(info.min_size, 1);
         assert!(!info.const_size);
@@ -1232,7 +1311,7 @@ mod tests {
     #[test]
     fn range_clear_is_hard_and_const_size() {
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_eq!(info.min_size, 0);
         assert!(info.const_size);
         assert!(info.hard);
@@ -1242,12 +1321,12 @@ mod tests {
     fn left_recursive_subroutine_direct() {
         // Direct left recursion: group 1 calls itself at position 0
         let tree = Expr::parse_tree(r"(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"abc(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1255,11 +1334,11 @@ mod tests {
     #[test]
     fn not_left_recursive_subroutine_after_group() {
         let tree = Expr::parse_tree(r"(a)\g<1>").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(result.is_ok());
 
         let tree = Expr::parse_tree(r"(?<test>a)\g<test>").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(result.is_ok());
     }
 
@@ -1267,12 +1346,12 @@ mod tests {
     fn left_recursive_subroutine_at_start() {
         // Left recursion at start of group: (\g<1>a)
         let tree = Expr::parse_tree(r"(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"(?<test>\g<test>a)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1281,12 +1360,12 @@ mod tests {
     fn left_recursive_subroutine_indirect() {
         // Indirect left recursion: non-nested subroutine calls to each other
         let tree = Expr::parse_tree(r"(\g<2>)(\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
 
         let tree = Expr::parse_tree(r"(\g<2>)(\g<1>a)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1295,7 +1374,7 @@ mod tests {
     fn left_recursive_subroutine_with_alternation() {
         // Left recursion through alternation, depending which branch is taken it could be left-recursive
         let tree = Expr::parse_tree(r"(a|\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1305,7 +1384,7 @@ mod tests {
         // Not left recursive because subroutine call is after a character was consumed,
         // but still never-ending because the recursive call is mandatory.
         let tree = Expr::parse_tree(r"(a\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1313,7 +1392,7 @@ mod tests {
     #[test]
     fn bounded_recursive_after_char_is_allowed() {
         let tree = Expr::parse_tree(r"(a\g<1>?)").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(result.is_ok());
     }
 
@@ -1321,7 +1400,7 @@ mod tests {
     fn not_left_recursive_zero_repetition() {
         // Not left recursive because subroutine call is unreachable
         let tree = Expr::parse_tree(r"(a?\g<1>){0}").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(result.is_ok());
     }
 
@@ -1329,7 +1408,7 @@ mod tests {
     fn left_recursive_with_both_positions() {
         // Left recursive because \g<1> appears at position 0 in the group even though also at end at position 1
         let tree = Expr::parse_tree(r"(\g<1>a\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1337,7 +1416,7 @@ mod tests {
     #[test]
     fn left_recursive_with_lookahead() {
         let tree = Expr::parse_tree(r"((?=a)\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1347,7 +1426,7 @@ mod tests {
         // Self-recursive on group 0 after a character
         let tree = Expr::parse_tree(r"a\g<0>").unwrap();
         // Group 0 calls itself at position 1 (after 'a'), so this is NOT left recursive
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1356,7 +1435,7 @@ mod tests {
     fn not_left_recursive_forward_call() {
         // Forward subroutine call - not left recursive: \g<1>(a)
         let tree = Expr::parse_tree(r"\g<1>(a)").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         // The call happens before the group is defined, but it's at position 0 of group 0 (implicit)
         // which calls group 1. Group 1 doesn't call anything, so no cycle.
         assert!(result.is_ok());
@@ -1366,15 +1445,28 @@ mod tests {
     fn not_left_recursive_group_zero_explicit() {
         // Self-recursive on explicit group 0: (a\g<0>)
         let tree = Expr::parse_tree(r"(a\g<0>)").unwrap();
-        assert_compile_error(analyze(&tree, true, false), |e| {
-            matches!(e, CompileError::NeverEndingRecursion)
-        });
+        assert_compile_error(
+            analyze(
+                &tree,
+                AnalyzeContext {
+                    explicit_capture_group_0: true,
+                    ..Default::default()
+                },
+            ),
+            |e| matches!(e, CompileError::NeverEndingRecursion),
+        );
     }
 
     #[test]
     fn not_left_recursive_group_zero_subroutine_call_unreachable() {
         let tree = Expr::parse_tree(r"\g<0>{0}abc").unwrap();
-        let result = analyze(&tree, true, false);
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        );
         assert!(result.is_ok());
     }
 
@@ -1382,7 +1474,13 @@ mod tests {
     fn left_recursive_group_zero_at_start() {
         // Self-recursive on explicit group 0 at start: (\g<0>a)
         let tree = Expr::parse_tree(r"(\g<0>a)").unwrap();
-        let result = analyze(&tree, true, false);
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        );
         // With explicit group 0, \g<0> at position 0 is left-recursive
         assert!(result.is_err());
     }
@@ -1396,7 +1494,7 @@ mod tests {
         // Group 3 -> Group 1 (at pos 1, after 'a')
         // This forms a cycle, but the call from group 3 to group 1 is at position 1
         // So it's not left-recursive
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::NeverEndingRecursion)
         });
     }
@@ -1405,7 +1503,7 @@ mod tests {
     fn three_way_left_recursive() {
         // Three-way left recursion
         let tree = Expr::parse_tree(r"(\g<2>)(\g<3>)(\g<1>)").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         // Group 1 -> Group 2 (at pos 0)
         // Group 2 -> Group 3 (at pos 0)
         // Group 3 -> Group 1 (at pos 0)
@@ -1413,7 +1511,7 @@ mod tests {
         assert!(result.is_err());
 
         let tree = Expr::parse_tree(r"(\g<2>a)(\g<3>b)(\g<1>c)").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
         assert!(result.is_err());
     }
 
@@ -1425,7 +1523,7 @@ mod tests {
         // Group 2 contains \g<1> - calls group 1 at position 0
         // This creates a cycle: Group 2 -> Group 1 (at pos 0) -> Group 2 (at pos 0)
         let tree = Expr::parse_tree(r"(a?\g<2>){0}(\g<1>)").unwrap();
-        assert_compile_error(analyze(&tree, false, false), |e| {
+        assert_compile_error(analyze(&tree, AnalyzeContext::default()), |e| {
             matches!(e, CompileError::LeftRecursiveSubroutineCall(_))
         });
     }
@@ -1435,7 +1533,7 @@ mod tests {
         // Group n (1): |\g<m>\g<n> - calls m then itself, but m has min_size > 0
         // Group m (2): a(b)\g<m> - calls itself after 'ab'
         let tree = Expr::parse_tree(r"(?<n>|\g<m>\g<n>)\z|\zEND (?<m>a(b)\g<m>)").unwrap();
-        let result = analyze(&tree, false, false);
+        let result = analyze(&tree, AnalyzeContext::default());
 
         assert!(
             result.is_ok(),
@@ -1451,7 +1549,7 @@ mod tests {
     fn forward_subroutine_call_single_group() {
         // Forward reference: calls group 1 before it's defined
         let tree = Expr::parse_tree(r"\g<1>(.a.)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         // The pattern should have 1 capture group
         assert_eq!(info.start_group(), 1);
@@ -1487,7 +1585,7 @@ mod tests {
     fn forward_subroutine_call_with_multiple_groups() {
         // Forward reference with multiple groups defined after the subroutine call
         let tree = Expr::parse_tree(r"\g<2>(a)(bc+)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         // The pattern should have 2 capture groups
         assert_eq!(info.start_group(), 1);
@@ -1525,7 +1623,7 @@ mod tests {
     fn forward_subroutine_call_with_nested_groups() {
         // Forward reference with multiple nested groups defined after the subroutine call
         let tree = Expr::parse_tree(r"(foo)\g<4>(a(b)?)(c(d))(?!e)").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         // The pattern should have 5 capture groups
         assert_eq!(info.start_group(), 1);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -887,7 +887,18 @@ fn populate_group_info_map<'a>(map: &mut Map<usize, &'a Info<'a>>, info: &'a Inf
 }
 
 /// Compile the analyzed expressions into a program.
-pub fn compile(info: &Info<'_>, anchored: bool, contains_subroutines: bool) -> Result<Prog> {
+///
+/// When `hard_context` is `true`, the entire expression is compiled in a hard context, meaning
+/// even easy (non-fancy) subexpressions will be compiled with explicit backtracking VM
+/// instructions rather than being delegated to the NFA engine. This is needed when
+/// `find_not_empty` is set, so that the VM can backtrack through alternation branches to find
+/// a non-empty match instead of accepting the first (possibly empty) match from a delegate.
+pub fn compile(
+    info: &Info<'_>,
+    anchored: bool,
+    contains_subroutines: bool,
+    hard_context: bool,
+) -> Result<Prog> {
     let mut c = Compiler::new(info.end_group());
 
     if contains_subroutines {
@@ -903,7 +914,7 @@ pub fn compile(info: &Info<'_>, anchored: bool, contains_subroutines: bool) -> R
         // so that we bump the haystack index by one when failing to match at the current position
         let current_pc = c.b.pc();
         // we are adding 3 instructions, so the current program counter plus 3 gives us the first real instruction
-        c.b.add(Insn::Split(current_pc + 3, current_pc + 1));
+        c.b.add(Insn::SplitUnanchored(current_pc + 3, current_pc + 1));
         c.b.add(Insn::Any);
         c.b.add(Insn::Jmp(current_pc));
     }
@@ -911,7 +922,7 @@ pub fn compile(info: &Info<'_>, anchored: bool, contains_subroutines: bool) -> R
         // add implicit capture group 0 begin
         c.b.add(Insn::Save(0));
     }
-    c.visit(info, false)?;
+    c.visit(info, hard_context)?;
     if info.start_group() == 1 {
         // add implicit capture group 0 end
         c.b.add(Insn::Save(1));
@@ -1156,27 +1167,31 @@ mod tests {
     fn other_backtracking_control_verbs_error() {
         let tree = Expr::parse_tree(r"(*ACCEPT)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         let tree = Expr::parse_tree(r"(*COMMIT)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         let tree = Expr::parse_tree(r"(*SKIP)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         let tree = Expr::parse_tree(r"(*PRUNE)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
     }
 
     #[test]
@@ -1185,15 +1200,17 @@ mod tests {
         // Without the feature flag, variable-length lookbehinds should error
         let tree = Expr::parse_tree(r"(?<=ab+)x").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::VariableLookBehindRequiresFeature)
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::VariableLookBehindRequiresFeature),
+        );
 
         let tree = Expr::parse_tree(r"(?<=\bab+)x").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::VariableLookBehindRequiresFeature)
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::VariableLookBehindRequiresFeature),
+        );
     }
 
     #[test]
@@ -1283,9 +1300,10 @@ mod tests {
         // the backref to a capture group inside the variable lookbehind makes the capture group hard
         let tree = Expr::parse_tree(r"(?<=a(b+))\1").unwrap();
         let info = analyze(&tree, false).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
     }
 
     #[test]
@@ -1304,23 +1322,26 @@ mod tests {
         // Test that absent expression returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc|\d*)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         // Test that absent stopper returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         // Test that range clear returns feature not supported
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
         let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        assert_compile_error(
+            compile(&info, true, tree.contains_subroutines, false),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
     }
 
     #[test]
@@ -1385,7 +1406,7 @@ mod tests {
     fn compile_prog(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
         let info = analyze(&tree, true).unwrap();
-        let prog = compile(&info, true, tree.contains_subroutines).unwrap();
+        let prog = compile(&info, true, tree.contains_subroutines, false).unwrap();
         prog.body
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -894,12 +894,6 @@ pub struct CompileOptions {
     pub anchored: bool,
     /// Whether the regex contains subroutine calls, requiring group info to be pre-populated.
     pub contains_subroutines: bool,
-    /// When `true`, the entire expression is compiled in a hard context, meaning even easy
-    /// (non-fancy) subexpressions will be compiled with explicit backtracking VM instructions
-    /// rather than being delegated to the NFA engine. This is needed when `find_not_empty` is
-    /// set, so that the VM can backtrack through alternation branches to find a non-empty match
-    /// instead of accepting the first (possibly empty) match from a delegate.
-    pub hard_context: bool,
 }
 
 /// Compile the analyzed expressions into a program.
@@ -927,7 +921,7 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
         // add implicit capture group 0 begin
         c.b.add(Insn::Save(0));
     }
-    c.visit(info, options.hard_context)?;
+    c.visit(info, false)?;
     if info.start_group() == 1 {
         // add implicit capture group 0 end
         c.b.add(Insn::Save(1));
@@ -1048,7 +1042,7 @@ mod tests {
             contains_subroutines: false,
             self_recursive: false,
         };
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
 
         let mut c = Compiler::new(0);
         // Force "hard" so that compiler doesn't just delegate
@@ -1171,7 +1165,7 @@ mod tests {
     #[test]
     fn other_backtracking_control_verbs_error() {
         let tree = Expr::parse_tree(r"(*ACCEPT)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1185,7 +1179,7 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*COMMIT)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1199,7 +1193,7 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*SKIP)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1213,7 +1207,7 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*PRUNE)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1232,7 +1226,7 @@ mod tests {
     fn variable_lookbehind_requires_feature() {
         // Without the feature flag, variable-length lookbehinds should error
         let tree = Expr::parse_tree(r"(?<=ab+)x").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1246,7 +1240,7 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(?<=\bab+)x").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1346,7 +1340,7 @@ mod tests {
         // currently hard variable lookbehinds are unsupported.
         // the backref to a capture group inside the variable lookbehind makes the capture group hard
         let tree = Expr::parse_tree(r"(?<=a(b+))\1").unwrap();
-        let info = analyze(&tree, false).unwrap();
+        let info = analyze(&tree, false, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1375,7 +1369,7 @@ mod tests {
     fn absent_operators_error() {
         // Test that absent expression returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc|\d*)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1390,7 +1384,7 @@ mod tests {
 
         // Test that absent stopper returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1405,7 +1399,7 @@ mod tests {
 
         // Test that range clear returns feature not supported
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1480,7 +1474,7 @@ mod tests {
 
     fn compile_prog(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
-        let info = analyze(&tree, true).unwrap();
+        let info = analyze(&tree, true, false).unwrap();
         let prog = compile(
             &info,
             CompileOptions {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -886,22 +886,27 @@ fn populate_group_info_map<'a>(map: &mut Map<usize, &'a Info<'a>>, info: &'a Inf
     }
 }
 
+/// Options for compiling analyzed expressions into a program.
+#[derive(Debug, Clone, Default)]
+pub struct CompileOptions {
+    /// Whether the regex is anchored (starts matching at the beginning of the input).
+    /// When `false`, a `SplitUnanchored` preamble is emitted to allow matching at any position.
+    pub anchored: bool,
+    /// Whether the regex contains subroutine calls, requiring group info to be pre-populated.
+    pub contains_subroutines: bool,
+    /// When `true`, the entire expression is compiled in a hard context, meaning even easy
+    /// (non-fancy) subexpressions will be compiled with explicit backtracking VM instructions
+    /// rather than being delegated to the NFA engine. This is needed when `find_not_empty` is
+    /// set, so that the VM can backtrack through alternation branches to find a non-empty match
+    /// instead of accepting the first (possibly empty) match from a delegate.
+    pub hard_context: bool,
+}
+
 /// Compile the analyzed expressions into a program.
-///
-/// When `hard_context` is `true`, the entire expression is compiled in a hard context, meaning
-/// even easy (non-fancy) subexpressions will be compiled with explicit backtracking VM
-/// instructions rather than being delegated to the NFA engine. This is needed when
-/// `find_not_empty` is set, so that the VM can backtrack through alternation branches to find
-/// a non-empty match instead of accepting the first (possibly empty) match from a delegate.
-pub fn compile(
-    info: &Info<'_>,
-    anchored: bool,
-    contains_subroutines: bool,
-    hard_context: bool,
-) -> Result<Prog> {
+pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
     let mut c = Compiler::new(info.end_group());
 
-    if contains_subroutines {
+    if options.contains_subroutines {
         // Store root info for group 0 subroutine calls
         c.root_info = Some(info);
 
@@ -909,7 +914,7 @@ pub fn compile(
         populate_group_info_map(&mut c.group_info_map, info);
     }
 
-    if !anchored {
+    if !options.anchored {
         // add instructions as if \O*? was used at the start of the expression
         // so that we bump the haystack index by one when failing to match at the current position
         let current_pc = c.b.pc();
@@ -922,7 +927,7 @@ pub fn compile(
         // add implicit capture group 0 begin
         c.b.add(Insn::Save(0));
     }
-    c.visit(info, hard_context)?;
+    c.visit(info, options.hard_context)?;
     if info.start_group() == 1 {
         // add implicit capture group 0 end
         c.b.add(Insn::Save(1));
@@ -1168,28 +1173,56 @@ mod tests {
         let tree = Expr::parse_tree(r"(*ACCEPT)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
 
         let tree = Expr::parse_tree(r"(*COMMIT)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
 
         let tree = Expr::parse_tree(r"(*SKIP)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
 
         let tree = Expr::parse_tree(r"(*PRUNE)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
     }
@@ -1201,14 +1234,28 @@ mod tests {
         let tree = Expr::parse_tree(r"(?<=ab+)x").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::VariableLookBehindRequiresFeature),
         );
 
         let tree = Expr::parse_tree(r"(?<=\bab+)x").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::VariableLookBehindRequiresFeature),
         );
     }
@@ -1301,7 +1348,14 @@ mod tests {
         let tree = Expr::parse_tree(r"(?<=a(b+))\1").unwrap();
         let info = analyze(&tree, false).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
     }
@@ -1323,7 +1377,14 @@ mod tests {
         let tree = Expr::parse_tree(r"(?~|abc|\d*)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
 
@@ -1331,7 +1392,14 @@ mod tests {
         let tree = Expr::parse_tree(r"(?~|abc)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
 
@@ -1339,7 +1407,14 @@ mod tests {
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
         let info = analyze(&tree, true).unwrap();
         assert_compile_error(
-            compile(&info, true, tree.contains_subroutines, false),
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
             |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
         );
     }
@@ -1406,7 +1481,15 @@ mod tests {
     fn compile_prog(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
         let info = analyze(&tree, true).unwrap();
-        let prog = compile(&info, true, tree.contains_subroutines, false).unwrap();
+        let prog = compile(
+            &info,
+            CompileOptions {
+                anchored: true,
+                contains_subroutines: tree.contains_subroutines,
+                ..CompileOptions::default()
+            },
+        )
+        .unwrap();
         prog.body
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -998,7 +998,7 @@ impl DelegateBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analyze::analyze;
+    use crate::analyze::{analyze, AnalyzeContext};
     use crate::parse::ExprTree;
     use crate::vm::Insn::*;
     use alloc::vec;
@@ -1042,7 +1042,7 @@ mod tests {
             contains_subroutines: false,
             self_recursive: false,
         };
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
 
         let mut c = Compiler::new(0);
         // Force "hard" so that compiler doesn't just delegate
@@ -1165,7 +1165,14 @@ mod tests {
     #[test]
     fn other_backtracking_control_verbs_error() {
         let tree = Expr::parse_tree(r"(*ACCEPT)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1179,7 +1186,14 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*COMMIT)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1193,7 +1207,14 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*SKIP)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1207,7 +1228,14 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(*PRUNE)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1226,7 +1254,14 @@ mod tests {
     fn variable_lookbehind_requires_feature() {
         // Without the feature flag, variable-length lookbehinds should error
         let tree = Expr::parse_tree(r"(?<=ab+)x").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1240,7 +1275,14 @@ mod tests {
         );
 
         let tree = Expr::parse_tree(r"(?<=\bab+)x").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1340,7 +1382,7 @@ mod tests {
         // currently hard variable lookbehinds are unsupported.
         // the backref to a capture group inside the variable lookbehind makes the capture group hard
         let tree = Expr::parse_tree(r"(?<=a(b+))\1").unwrap();
-        let info = analyze(&tree, false, false).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1369,7 +1411,14 @@ mod tests {
     fn absent_operators_error() {
         // Test that absent expression returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc|\d*)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1384,7 +1433,14 @@ mod tests {
 
         // Test that absent stopper returns feature not supported
         let tree = Expr::parse_tree(r"(?~|abc)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1399,7 +1455,14 @@ mod tests {
 
         // Test that range clear returns feature not supported
         let tree = Expr::parse_tree(r"(?~|)").unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_compile_error(
             compile(
                 &info,
@@ -1474,7 +1537,14 @@ mod tests {
 
     fn compile_prog(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
-        let info = analyze(&tree, true, false).unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         let prog = compile(
             &info,
             CompileOptions {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1490,7 +1490,7 @@ mod tests {
 
         assert_eq!(prog.len(), 20, "prog: {:?}", prog);
 
-        assert_matches!(prog[0], Split(3, 1));
+        assert_matches!(prog[0], SplitUnanchored(3, 1));
         assert_matches!(prog[1], Any);
         assert_matches!(prog[2], Jmp(0));
         assert_matches!(prog[3], Save(0));
@@ -1530,17 +1530,33 @@ mod tests {
     fn absent_repeater_nested_absent_error() {
         // Nested absent operators are not yet supported (direct child)
         let tree = Expr::parse_tree(r"(?~(?~abc))").unwrap();
-        let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_compile_error(
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
 
         // Nested absent operators are not yet supported (indirect descendant)
         let tree = Expr::parse_tree(r"(?~a(?<=b(?~c)))").unwrap();
-        let info = analyze(&tree, true).unwrap();
-        assert_compile_error(compile(&info, true, tree.contains_subroutines), |e| {
-            matches!(e, CompileError::FeatureNotYetSupported(_))
-        });
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_compile_error(
+            compile(
+                &info,
+                CompileOptions {
+                    anchored: true,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            ),
+            |e| matches!(e, CompileError::FeatureNotYetSupported(_)),
+        );
     }
 
     #[test]
@@ -1705,8 +1721,16 @@ mod tests {
 
     fn compile_prog_no_explicit_group0(re: &str) -> Vec<Insn> {
         let tree = Expr::parse_tree(re).unwrap();
-        let info = analyze(&tree, false).unwrap();
-        let prog = compile(&info, false, tree.contains_subroutines).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        let prog = compile(
+            &info,
+            CompileOptions {
+                anchored: false,
+                contains_subroutines: tree.contains_subroutines,
+                ..CompileOptions::default()
+            },
+        )
+        .unwrap();
         prog.body
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,10 @@ pub enum CompileError {
     NeverEndingRecursion,
     /// Unexpected general error
     UnexpectedGeneralError(String),
+    /// The pattern combined with the active options can never produce a match. For example,
+    /// setting `find_not_empty` on a pattern whose analysis shows it can only ever produce
+    /// zero-length matches.
+    PatternCanNeverMatch,
 }
 
 /// An error as the result of executing a regex.
@@ -163,6 +167,9 @@ impl fmt::Display for CompileError {
             }
             CompileError::UnexpectedGeneralError(s) => {
                 write!(f, "Unexpected general compilation error: {}", s)
+            }
+            CompileError::PatternCanNeverMatch => {
+                write!(f, "Pattern can never match: the regex is zero-width only but find_not_empty is set")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ pub struct Matches<'r, 't> {
     text: &'t str,
     last_end: usize,
     last_match: Option<usize>,
+    last_skipped_empty: bool,
 }
 
 impl<'r, 't> Matches<'r, 't> {
@@ -163,17 +164,14 @@ impl<'r, 't> Matches<'r, 't> {
             return None;
         }
 
-        let option_flags = if let Some(last_match) = self.last_match {
-            if self.last_end > last_match {
-                OPTION_SKIPPED_EMPTY_MATCH
-            } else {
-                0
-            }
+        let option_flags = if self.last_skipped_empty {
+            OPTION_SKIPPED_EMPTY_MATCH
         } else {
             0
         };
 
-        let (result, mat) = match search(self.re, self.last_end, option_flags) {
+        let pos = self.last_end;
+        let (result, mat) = match search(self.re, pos, option_flags) {
             Err(error) => {
                 // Stop on first error: If an error is encountered, return it, and set the "last match position"
                 // to the string length, so that the next next() call will return None, to prevent an infinite loop.
@@ -189,6 +187,10 @@ impl<'r, 't> Matches<'r, 't> {
             // the next search at the smallest possible starting position
             // of the next match following this one.
             self.last_end = next_utf8(self.text, mat.end);
+            // Only set OPTION_SKIPPED_EMPTY_MATCH on the next call if this was a
+            // truly zero-length match (the VM consumed no bytes from `pos`).
+            // This means that \K won't prevent \G from matching.
+            self.last_skipped_empty = mat.end == pos;
             // Don't accept empty matches immediately following a match.
             // Just move on to the next match.
             if Some(mat.end) == self.last_match {
@@ -196,6 +198,7 @@ impl<'r, 't> Matches<'r, 't> {
             }
         } else {
             self.last_end = mat.end;
+            self.last_skipped_empty = false;
         }
 
         self.last_match = Some(mat.end);
@@ -866,6 +869,7 @@ impl Regex {
             text,
             last_end: 0,
             last_match: None,
+            last_skipped_empty: false,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ use crate::compile::compile;
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::parse_flags::*;
-use crate::vm::{Prog, OPTION_SKIPPED_EMPTY_MATCH};
+use crate::vm::{Prog, OPTION_FIND_NOT_EMPTY, OPTION_SKIPPED_EMPTY_MATCH};
 
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
 pub use crate::expand::Expander;
@@ -93,6 +93,7 @@ pub struct RegexOptionsBuilder {
 pub struct Regex {
     inner: RegexImpl,
     named_groups: Arc<NamedGroups>,
+    find_not_empty: bool,
 }
 
 // Separate enum because we don't want to expose any of this
@@ -400,6 +401,7 @@ struct RegexOptions {
     delegate_size_limit: Option<usize>,
     delegate_dfa_size_limit: Option<usize>,
     oniguruma_mode: bool,
+    find_not_empty: bool,
     hard_regex_runtime_options: HardRegexRuntimeOptions,
 }
 
@@ -567,6 +569,23 @@ impl RegexOptionsBuilder {
         self
     }
 
+    /// Require that matches are non-empty (i.e. match at least one character).
+    ///
+    /// When this is enabled, any match attempt that would result in a zero-length match is
+    /// rejected.
+    ///
+    /// Default is `false`.
+    ///
+    /// N.B. When `find_not_empty` is set and analysis determines the pattern will only ever
+    /// produce an empty match, compiling the regex will return
+    /// `CompileError::PatternCanNeverMatch` instead of silently constructing a regex that can never
+    /// return a result. This catches the user error at compile time rather than allowing the
+    /// combination to execute pointlessly at runtime.
+    pub fn find_not_empty(&mut self, yes: bool) -> &mut Self {
+        self.options.find_not_empty = yes;
+        self
+    }
+
     /// Attempts to better match [Oniguruma](https://github.com/kkos/oniguruma)'s default behavior
     ///
     /// Currently this amounts to changing behavior with:
@@ -691,6 +710,12 @@ impl RegexBuilder {
         self.options.crlf(yes);
         self
     }
+
+    /// See [`RegexOptionsBuilder::find_not_empty`]
+    pub fn find_not_empty(&mut self, yes: bool) -> &mut Self {
+        self.options.find_not_empty(yes);
+        self
+    }
 }
 
 impl fmt::Debug for Regex {
@@ -731,6 +756,21 @@ impl Regex {
         let requires_capture_group_fixup = optimize(&mut tree);
         let info = analyze(&tree, requires_capture_group_fixup)?;
 
+        if options.find_not_empty {
+            // When explicit_capture_group_0 is set (i.e. due to trailing lookahead optimization),
+            // the user-visible match is group 0 (the first child), not the whole expression.
+            // Check group 0's properties instead of the root info's.
+            let (check_const_size, check_min_size) = if requires_capture_group_fixup {
+                let group0_info = &info.children[0];
+                (group0_info.const_size, group0_info.min_size)
+            } else {
+                (info.const_size, info.min_size)
+            };
+            if check_const_size && check_min_size == 0 {
+                return Err(CompileError::PatternCanNeverMatch.into());
+            }
+        }
+
         if !info.hard {
             // easy case, wrap regex
 
@@ -747,6 +787,7 @@ impl Regex {
                     delegated_pattern: re_cooked,
                 },
                 named_groups: Arc::new(tree.named_groups),
+                find_not_empty: options.find_not_empty,
             });
         }
 
@@ -763,6 +804,7 @@ impl Regex {
                 pattern,
             },
             named_groups: Arc::new(tree.named_groups),
+            find_not_empty: options.find_not_empty,
         })
     }
 
@@ -787,6 +829,9 @@ impl Regex {
     /// assert!(re.is_match("mirror mirror on the wall").unwrap());
     /// ```
     pub fn is_match(&self, text: &str) -> Result<bool> {
+        if self.find_not_empty {
+            return self.find(text).map(|m| m.is_some());
+        }
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner.is_match(text)),
             RegexImpl::Fancy { prog, options, .. } => {
@@ -877,23 +922,38 @@ impl Regex {
                 explicit_capture_group_0,
                 ..
             } => {
-                if !*explicit_capture_group_0 {
-                    Ok(inner
-                        .search(&RaInput::new(text).span(pos..text.len()))
-                        .map(|m| Match::new(text, m.start(), m.end())))
+                let result = if !*explicit_capture_group_0 {
+                    find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
+                        let m = inner.search(&RaInput::new(text).span(current_pos..text.len()))?;
+                        Some((Match::new(text, m.start(), m.end()), m.start(), m.end()))
+                    })
                 } else {
                     let mut locations = inner.create_captures();
-                    inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
-                    Ok(locations.is_match().then(|| {
-                        Match::new(
-                            text,
-                            locations.get_group(1).unwrap().start,
-                            locations.get_group(1).unwrap().end,
-                        )
-                    }))
-                }
+                    find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
+                        inner.captures(
+                            RaInput::new(text).span(current_pos..text.len()),
+                            &mut locations,
+                        );
+                        if !locations.is_match() {
+                            return None;
+                        }
+                        let group1 = locations.get_group(1).unwrap();
+                        Some((
+                            Match::new(text, group1.start, group1.end),
+                            group1.start,
+                            group1.end,
+                        ))
+                    })
+                };
+                Ok(result)
             }
             RegexImpl::Fancy { prog, options, .. } => {
+                let option_flags = option_flags
+                    | if self.find_not_empty {
+                        OPTION_FIND_NOT_EMPTY
+                    } else {
+                        0
+                    };
                 let result = vm::run(prog, text, pos, option_flags, options)?;
                 Ok(result.map(|saves| Match::new(text, saves[0], saves[1])))
             }
@@ -1004,20 +1064,33 @@ impl Regex {
                 explicit_capture_group_0,
                 ..
             } => {
+                let explicit = *explicit_capture_group_0;
                 let mut locations = inner.create_captures();
-                inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
-                if locations.is_match() {
-                    Ok(Some(Captures {
-                        inner: CapturesImpl::Wrap {
-                            text,
-                            locations,
-                            explicit_capture_group_0: *explicit_capture_group_0,
-                        },
-                        named_groups,
-                    }))
-                } else {
-                    Ok(None)
-                }
+                let found = find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
+                    inner.captures(
+                        RaInput::new(text).span(current_pos..text.len()),
+                        &mut locations,
+                    );
+                    if !locations.is_match() {
+                        return None;
+                    }
+                    let (start, end) = if explicit {
+                        let group1 = locations.get_group(1).unwrap();
+                        (group1.start, group1.end)
+                    } else {
+                        let m = locations.get_match().unwrap();
+                        (m.start(), m.end())
+                    };
+                    Some(((), start, end))
+                });
+                Ok(found.map(|()| Captures {
+                    inner: CapturesImpl::Wrap {
+                        text,
+                        locations,
+                        explicit_capture_group_0: explicit,
+                    },
+                    named_groups,
+                }))
             }
             RegexImpl::Fancy {
                 prog,
@@ -1025,6 +1098,12 @@ impl Regex {
                 options,
                 ..
             } => {
+                let option_flags = option_flags
+                    | if self.find_not_empty {
+                        OPTION_FIND_NOT_EMPTY
+                    } else {
+                        0
+                    };
                 let result = vm::run(prog, text, pos, option_flags, options)?;
                 Ok(result.map(|mut saves| {
                     saves.truncate(n_groups * 2);
@@ -2105,6 +2184,36 @@ fn codepoint_len(b: u8) -> usize {
         b if b < 0xe0 => 2,
         b if b < 0xf0 => 3,
         _ => 4,
+    }
+}
+
+/// Calls `search_fn` in a loop, skipping empty matches when `find_not_empty` is true.
+///
+/// `search_fn` takes the current search position and returns `Option<(T, usize, usize)>` where
+/// `T` is the search result and the two `usize` values are the user-visible match start and end.
+///
+/// When `find_not_empty` is false, the closure is called once. When true, empty matches
+/// (where start == end) are rejected and the search is retried from the next UTF-8 position.
+fn find_not_empty_loop<T, F>(
+    find_not_empty: bool,
+    text: &str,
+    pos: usize,
+    mut search_fn: F,
+) -> Option<T>
+where
+    F: FnMut(usize) -> Option<(T, usize, usize)>,
+{
+    let mut current_pos = pos;
+    loop {
+        let (result, start, end) = search_fn(current_pos)?;
+        if find_not_empty && start == end {
+            current_pos = next_utf8(text, end);
+            if current_pos > text.len() {
+                return None;
+            }
+            continue;
+        }
+        return Some(result);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,15 +840,7 @@ impl Regex {
     pub fn is_match(&self, text: &str) -> Result<bool> {
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner.is_match(text)),
-            RegexImpl::Fancy { prog, options, .. } => {
-                if options.find_not_empty {
-                    // find_not_empty requires backtracking to find a non-empty match;
-                    // delegate to find() which sets the OPTION_FIND_NOT_EMPTY flag on the VM.
-                    return self.find(text).map(|m| m.is_some());
-                }
-                let result = vm::run(prog, text, 0, 0, options)?;
-                Ok(result.is_some())
-            }
+            RegexImpl::Fancy { .. } => self.find(text).map(|m| m.is_some()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,7 +1064,7 @@ impl Regex {
                 let explicit = *explicit_capture_group_0;
                 let mut locations = inner.create_captures();
                 inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
-                Ok(locations.is_match().then(|| Captures {
+                Ok(locations.is_match().then_some(Captures {
                     inner: CapturesImpl::Wrap {
                         text,
                         locations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -768,13 +768,13 @@ impl Regex {
             // with a fixup of the capture groups
             optimize(&mut tree)
         };
-        let info = analyze(&tree, requires_capture_group_fixup)?;
+        let info = analyze(&tree, requires_capture_group_fixup, find_not_empty)?;
 
         if find_not_empty && info.const_size && info.min_size == 0 {
             return Err(CompileError::PatternCanNeverMatch.into());
         }
 
-        if !info.hard && !find_not_empty {
+        if !info.hard {
             // easy case, wrap regex
 
             // we do our own to_str because escapes are different
@@ -798,7 +798,6 @@ impl Regex {
             CompileOptions {
                 anchored: can_compile_as_anchored(&tree.expr),
                 contains_subroutines: tree.contains_subroutines,
-                hard_context: find_not_empty,
             },
         )?;
         Ok(Regex {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub struct RegexOptionsBuilder {
 pub struct Regex {
     inner: RegexImpl,
     named_groups: Arc<NamedGroups>,
-    find_not_empty: bool,
 }
 
 // Separate enum because we don't want to expose any of this
@@ -404,13 +403,13 @@ struct RegexOptions {
     delegate_size_limit: Option<usize>,
     delegate_dfa_size_limit: Option<usize>,
     oniguruma_mode: bool,
-    find_not_empty: bool,
     hard_regex_runtime_options: HardRegexRuntimeOptions,
 }
 
 #[derive(Copy, Clone, Debug)]
 struct HardRegexRuntimeOptions {
     backtrack_limit: usize,
+    find_not_empty: bool,
 }
 
 impl RegexOptions {
@@ -440,6 +439,7 @@ impl Default for HardRegexRuntimeOptions {
     fn default() -> Self {
         HardRegexRuntimeOptions {
             backtrack_limit: 1_000_000,
+            find_not_empty: false,
         }
     }
 }
@@ -585,7 +585,7 @@ impl RegexOptionsBuilder {
     /// return a result. This catches the user error at compile time rather than allowing the
     /// combination to execute pointlessly at runtime.
     pub fn find_not_empty(&mut self, yes: bool) -> &mut Self {
-        self.options.find_not_empty = yes;
+        self.options.hard_regex_runtime_options.find_not_empty = yes;
         self
     }
 
@@ -755,26 +755,26 @@ impl Regex {
     fn new_options(pattern: String, options: &RegexOptions) -> Result<Regex> {
         let mut tree = Expr::parse_tree_with_flags(&pattern, options.compute_flags())?;
 
-        // try to optimize the expression tree
-        let requires_capture_group_fixup = optimize(&mut tree);
+        let find_not_empty = options.hard_regex_runtime_options.find_not_empty;
+
+        let requires_capture_group_fixup = if find_not_empty {
+            // if the find_not_empty flag is set, we skip optimizations
+            // partially because we have to go though the VM anyway
+            // partially because having the last instruction of the expression not have
+            // ix be at the end of capture group 0 ruins our empty match checking logic.
+            false
+        } else {
+            // try to optimize the expression tree so that a hard pattern could become easy
+            // with a fixup of the capture groups
+            optimize(&mut tree)
+        };
         let info = analyze(&tree, requires_capture_group_fixup)?;
 
-        if options.find_not_empty {
-            // When explicit_capture_group_0 is set (i.e. due to trailing lookahead optimization),
-            // the user-visible match is group 0 (the first child), not the whole expression.
-            // Check group 0's properties instead of the root info's.
-            let (check_const_size, check_min_size) = if requires_capture_group_fixup {
-                let group0_info = &info.children[0];
-                (group0_info.const_size, group0_info.min_size)
-            } else {
-                (info.const_size, info.min_size)
-            };
-            if check_const_size && check_min_size == 0 {
-                return Err(CompileError::PatternCanNeverMatch.into());
-            }
+        if find_not_empty && info.const_size && info.min_size == 0 {
+            return Err(CompileError::PatternCanNeverMatch.into());
         }
 
-        if !info.hard {
+        if !info.hard && !find_not_empty {
             // easy case, wrap regex
 
             // we do our own to_str because escapes are different
@@ -790,7 +790,6 @@ impl Regex {
                     delegated_pattern: re_cooked,
                 },
                 named_groups: Arc::new(tree.named_groups),
-                find_not_empty: options.find_not_empty,
             });
         }
 
@@ -798,6 +797,7 @@ impl Regex {
             &info,
             can_compile_as_anchored(&tree.expr),
             tree.contains_subroutines,
+            find_not_empty,
         )?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
@@ -807,7 +807,6 @@ impl Regex {
                 pattern,
             },
             named_groups: Arc::new(tree.named_groups),
-            find_not_empty: options.find_not_empty,
         })
     }
 
@@ -832,12 +831,14 @@ impl Regex {
     /// assert!(re.is_match("mirror mirror on the wall").unwrap());
     /// ```
     pub fn is_match(&self, text: &str) -> Result<bool> {
-        if self.find_not_empty {
-            return self.find(text).map(|m| m.is_some());
-        }
         match &self.inner {
             RegexImpl::Wrap { inner, .. } => Ok(inner.is_match(text)),
             RegexImpl::Fancy { prog, options, .. } => {
+                if options.find_not_empty {
+                    // find_not_empty requires backtracking to find a non-empty match;
+                    // delegate to find() which sets the OPTION_FIND_NOT_EMPTY flag on the VM.
+                    return self.find(text).map(|m| m.is_some());
+                }
                 let result = vm::run(prog, text, 0, 0, options)?;
                 Ok(result.is_some())
             }
@@ -927,33 +928,21 @@ impl Regex {
                 ..
             } => {
                 let result = if !*explicit_capture_group_0 {
-                    find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
-                        let m = inner.search(&RaInput::new(text).span(current_pos..text.len()))?;
-                        Some((Match::new(text, m.start(), m.end()), m.start(), m.end()))
-                    })
+                    inner
+                        .search(&RaInput::new(text).span(pos..text.len()))
+                        .map(|m| Match::new(text, m.start(), m.end()))
                 } else {
                     let mut locations = inner.create_captures();
-                    find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
-                        inner.captures(
-                            RaInput::new(text).span(current_pos..text.len()),
-                            &mut locations,
-                        );
-                        if !locations.is_match() {
-                            return None;
-                        }
-                        let group1 = locations.get_group(1).unwrap();
-                        Some((
-                            Match::new(text, group1.start, group1.end),
-                            group1.start,
-                            group1.end,
-                        ))
-                    })
+                    inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
+                    locations
+                        .get_group(1)
+                        .map(|group1| Match::new(text, group1.start, group1.end))
                 };
                 Ok(result)
             }
             RegexImpl::Fancy { prog, options, .. } => {
                 let option_flags = option_flags
-                    | if self.find_not_empty {
+                    | if options.find_not_empty {
                         OPTION_FIND_NOT_EMPTY
                     } else {
                         0
@@ -1068,26 +1057,12 @@ impl Regex {
                 explicit_capture_group_0,
                 ..
             } => {
+                // find_not_empty patterns are always compiled as Fancy, so find_not_empty is
+                // always false here.
                 let explicit = *explicit_capture_group_0;
                 let mut locations = inner.create_captures();
-                let found = find_not_empty_loop(self.find_not_empty, text, pos, |current_pos| {
-                    inner.captures(
-                        RaInput::new(text).span(current_pos..text.len()),
-                        &mut locations,
-                    );
-                    if !locations.is_match() {
-                        return None;
-                    }
-                    let (start, end) = if explicit {
-                        let group1 = locations.get_group(1).unwrap();
-                        (group1.start, group1.end)
-                    } else {
-                        let m = locations.get_match().unwrap();
-                        (m.start(), m.end())
-                    };
-                    Some(((), start, end))
-                });
-                Ok(found.map(|()| Captures {
+                inner.captures(RaInput::new(text).span(pos..text.len()), &mut locations);
+                Ok(locations.is_match().then(|| Captures {
                     inner: CapturesImpl::Wrap {
                         text,
                         locations,
@@ -1103,7 +1078,7 @@ impl Regex {
                 ..
             } => {
                 let option_flags = option_flags
-                    | if self.find_not_empty {
+                    | if options.find_not_empty {
                         OPTION_FIND_NOT_EMPTY
                     } else {
                         0
@@ -2188,36 +2163,6 @@ fn codepoint_len(b: u8) -> usize {
         b if b < 0xe0 => 2,
         b if b < 0xf0 => 3,
         _ => 4,
-    }
-}
-
-/// Calls `search_fn` in a loop, skipping empty matches when `find_not_empty` is true.
-///
-/// `search_fn` takes the current search position and returns `Option<(T, usize, usize)>` where
-/// `T` is the search result and the two `usize` values are the user-visible match start and end.
-///
-/// When `find_not_empty` is false, the closure is called once. When true, empty matches
-/// (where start == end) are rejected and the search is retried from the next UTF-8 position.
-fn find_not_empty_loop<T, F>(
-    find_not_empty: bool,
-    text: &str,
-    pos: usize,
-    mut search_fn: F,
-) -> Option<T>
-where
-    F: FnMut(usize) -> Option<(T, usize, usize)>,
-{
-    let mut current_pos = pos;
-    loop {
-        let (result, start, end) = search_fn(current_pos)?;
-        if find_not_empty && start == end {
-            current_pos = next_utf8(text, end);
-            if current_pos > text.len() {
-                return None;
-            }
-            continue;
-        }
-        return Some(result);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,8 @@ mod parse_flags;
 mod replacer;
 mod vm;
 
-use crate::analyze::analyze;
 use crate::analyze::can_compile_as_anchored;
+use crate::analyze::{analyze, AnalyzeContext};
 use crate::compile::{compile, CompileOptions};
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
@@ -768,7 +768,13 @@ impl Regex {
             // with a fixup of the capture groups
             optimize(&mut tree)
         };
-        let info = analyze(&tree, requires_capture_group_fixup, find_not_empty)?;
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                explicit_capture_group_0: requires_capture_group_fixup,
+                find_not_empty,
+            },
+        )?;
 
         if find_not_empty && info.const_size && info.min_size == 0 {
             return Err(CompileError::PatternCanNeverMatch.into());
@@ -2213,7 +2219,7 @@ pub fn detect_possible_backref(re: &str) -> bool {
 /// experimenting.
 #[doc(hidden)]
 pub mod internal {
-    pub use crate::analyze::{analyze, can_compile_as_anchored, Info};
+    pub use crate::analyze::{analyze, can_compile_as_anchored, AnalyzeContext, Info};
     pub use crate::compile::{compile, CompileOptions};
     pub use crate::optimize::optimize;
     pub use crate::parse_flags::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ mod vm;
 
 use crate::analyze::analyze;
 use crate::analyze::can_compile_as_anchored;
-use crate::compile::compile;
+use crate::compile::{compile, CompileOptions};
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::parse_flags::*;
@@ -795,9 +795,11 @@ impl Regex {
 
         let prog = compile(
             &info,
-            can_compile_as_anchored(&tree.expr),
-            tree.contains_subroutines,
-            find_not_empty,
+            CompileOptions {
+                anchored: can_compile_as_anchored(&tree.expr),
+                contains_subroutines: tree.contains_subroutines,
+                hard_context: find_not_empty,
+            },
         )?;
         Ok(Regex {
             inner: RegexImpl::Fancy {
@@ -2213,7 +2215,7 @@ pub fn detect_possible_backref(re: &str) -> bool {
 #[doc(hidden)]
 pub mod internal {
     pub use crate::analyze::{analyze, can_compile_as_anchored, Info};
-    pub use crate::compile::compile;
+    pub use crate::compile::{compile, CompileOptions};
     pub use crate::optimize::optimize;
     pub use crate::parse_flags::{
         FLAG_CASEI, FLAG_CRLF, FLAG_DOTNL, FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -110,10 +110,9 @@ const OPTION_TRACE: u32 = 1 << 0;
 /// the fact that we skipped because of an empty match, it would still treat `\G` as matching. So
 /// this option is for communicating that to the VM. Phew.
 pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 1 << 1;
-/// When this option is set, the VM will reject any match where the physical consumption is zero.
-/// This is used to implement `find_not_empty`, which causes the regex to ignore empty matches.
-/// Note that this deliberately ignores the effect of `\K` when performing the check, because
-/// that only affects what is output, not the actual match which occurred.
+/// When this option is set, the VM will reject any match where the engine consumed no characters.
+/// \K is ignored as part of this check - so empty matches can still be reported if the engine
+/// consumed characters and then \K was used afterwards.
 pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
 
 // TODO: make configurable
@@ -238,6 +237,9 @@ pub enum Insn {
     /// Split execution into two threads. The two fields are positions of instructions. Execution
     /// first tries the first thread. If that fails, the second position is tried.
     Split(usize, usize),
+    /// Like `Split`, but also updates `match_attempt_start` for `OPTION_FIND_NOT_EMPTY` tracking.
+    /// Used exclusively for the unanchored search preamble.
+    SplitUnanchored(usize, usize),
     /// Jump to instruction at position
     Jmp(usize),
     /// Save the current string index into the specified slot
@@ -657,6 +659,7 @@ pub(crate) fn run(
     let mut backtrack_count = 0;
     let mut pc = 0;
     let mut ix = pos;
+    let mut match_attempt_start = pos;
     loop {
         // break from this loop to fail, causes stack to pop
         'fail: loop {
@@ -674,15 +677,19 @@ pub(crate) fn run(
                     if option_flags & OPTION_TRACE != 0 {
                         println!("saves: {:?}", state.saves);
                     }
+                    // Reject the match if it is empty and the flag to do so is enabled.
+                    // `match_attempt_start` is set by `SplitUnanchored` each time the unanchored
+                    // preamble begins a new match attempt at a fresh position, so this correctly
+                    // rejects empty matches regardless of where in the haystack the attempt starts.
+                    if option_flags & OPTION_FIND_NOT_EMPTY != 0 && ix == match_attempt_start {
+                        break 'fail;
+                    }
                     if let Some(&slot1) = state.saves.get(1) {
                         // With some features like keep out (\K), the match start can be after
                         // the match end. Cap the start to <= end.
                         if state.get(0) > slot1 {
                             state.save(0, slot1);
                         }
-                    }
-                    if option_flags & OPTION_FIND_NOT_EMPTY != 0 && ix == pos {
-                        break 'fail;
                     }
                     return Ok(Some(state.saves));
                 }
@@ -763,6 +770,12 @@ pub(crate) fn run(
                     }
                 }
                 Insn::Split(x, y) => {
+                    state.push(y, ix)?;
+                    pc = x;
+                    continue;
+                }
+                Insn::SplitUnanchored(x, y) => {
+                    match_attempt_start = ix;
                     state.push(y, ix)?;
                     pc = x;
                     continue;
@@ -1024,7 +1037,7 @@ pub(crate) fn run(
                         // instead of checking at each position in the haystack
                         // because \G will never match at any other position
                         if at_start && state.stack.len() == 1 {
-                            // The only item on the stack is from the Split instruction for non-anchored search
+                            // The only item on the stack is from the SplitUnanchored instruction for non-anchored search
                             // We can safely return None immediately
                             return Ok(None);
                         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -110,6 +110,11 @@ const OPTION_TRACE: u32 = 1 << 0;
 /// the fact that we skipped because of an empty match, it would still treat `\G` as matching. So
 /// this option is for communicating that to the VM. Phew.
 pub(crate) const OPTION_SKIPPED_EMPTY_MATCH: u32 = 1 << 1;
+/// When this option is set, the VM will reject any match where the physical consumption is zero.
+/// This is used to implement `find_not_empty`, which causes the regex to ignore empty matches.
+/// Note that this deliberately ignores the effect of `\K` when performing the check, because
+/// that only affects what is output, not the actual match which occurred.
+pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
 
 // TODO: make configurable
 const MAX_STACK: usize = 1_000_000;
@@ -675,6 +680,9 @@ pub(crate) fn run(
                         if state.get(0) > slot1 {
                             state.save(0, slot1);
                         }
+                    }
+                    if option_flags & OPTION_FIND_NOT_EMPTY != 0 && ix == pos {
+                        break 'fail;
                     }
                     return Ok(Some(state.saves));
                 }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -366,6 +366,39 @@ fn captures_iter_continue_from_previous_match_end_single_match() {
 }
 
 #[test]
+fn captures_iter_continue_from_previous_match_end_with_keepout() {
+    // \G..\K(?=(.)) — \K resets the match start to after two consumed bytes, producing
+    // zero-length group 0 matches. Iteration must not stop after the first match because
+    // the VM actually consumed real bytes before \K fired, so \G should keep succeeding.
+    let text = "aabbcc";
+
+    // Each match: group 0 is zero-length at the position after the two consumed chars,
+    // group 1 captures the next single char via the lookahead.
+    for (i, caps) in common::regex(r"\G..\K(?=(.))")
+        .captures_iter(text)
+        .enumerate()
+    {
+        let caps = caps.unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(caps.get(0).unwrap().start(), 2);
+                assert_eq!(caps.get(0).unwrap().end(), 2);
+                assert_eq!(caps.get(1).unwrap().start(), 2);
+                assert_eq!(caps.get(1).unwrap().end(), 3);
+            }
+            1 => {
+                assert_eq!(caps.get(0).unwrap().start(), 5);
+                assert_eq!(caps.get(0).unwrap().end(), 5);
+                assert_eq!(caps.get(1).unwrap().start(), 5);
+                assert_eq!(caps.get(1).unwrap().end(), 6);
+            }
+            i => panic!("Expected 2 results, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
 fn captures_from_pos() {
     let text = "11 21 33";
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -810,6 +810,159 @@ fn find_not_empty_trailing_lookahead_with_variable_group0() {
     );
 }
 
+#[test]
+fn find_not_empty_alternation_with_empty_branch() {
+    // (?:|a|b) can match empty, "a", or "b". Without find_not_empty, the empty branch wins
+    // at position 0 (leftmost, first alternative). With find_not_empty, the empty match at
+    // position 0 must be skipped, and the pattern should then find "a" or "b".
+    let pattern = r"(?:|a|b)";
+
+    // Normal mode: empty match at position 0
+    let normal = common::regex(pattern);
+    assert_eq!(
+        normal.find("a").unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 0)),
+    );
+
+    // find_not_empty mode: empty match rejected; "a" found instead
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty.find("a").unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 1)),
+    );
+    assert_eq!(
+        not_empty.find("b").unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 1)),
+    );
+    assert_eq!(
+        not_empty.find("c").unwrap().map(|m| (m.start(), m.end())),
+        None,
+    );
+}
+
+#[test]
+fn find_not_empty_with_keep_out() {
+    // The find_not_empty check compares what the engine consumed, regardless of the match reported,
+    // which could be affected by \K.
+    let not_empty = RegexBuilder::new(r"a\Kb")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty.find("ab").unwrap().map(|m| (m.start(), m.end())),
+        Some((1, 2)),
+    );
+
+    // `ab\K` physically consumes "ab" (ix advances to 2), so it is accepted as non-empty.
+    // `\K` resets saves[0] to 2, giving the reported span (2, 2).
+    let not_empty_abk = RegexBuilder::new(r"ab\K")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty_abk
+            .find("ab")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((2, 2)),
+    );
+}
+
+#[test]
+fn find_not_empty_with_continue_from_previous_match_end() {
+    // \G\d+ with find_not_empty: only matches where the previous match ended and
+    // the match is non-empty. On "1122 33", \G matches at position 0; "1122" is
+    // consumed (non-empty → accepted). The next call starts at pos=4 (space),
+    // \G succeeds but \d+ fails → no further matches.
+    let not_empty = RegexBuilder::new(r"\G\d+")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let matches: Vec<_> = not_empty
+        .find_iter("1122 33")
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(matches, vec![(0, 4)]);
+
+    // \G\d* can produce an empty match after the digits run out. find_not_empty
+    // must reject that empty match. On "1122 33", after the non-empty "1122"
+    // match the next attempt is at position 4 (space); \G\d* would match empty
+    // there, but find_not_empty rejects it, so no further matches are produced.
+    let not_empty_star = RegexBuilder::new(r"\G\d*")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let matches_star: Vec<_> = not_empty_star
+        .find_iter("1122 33")
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(matches_star, vec![(0, 4)]);
+}
+
+#[test]
+fn find_not_empty_with_continue_from_previous_match_end_and_keep_out() {
+    // \G..\K produces a zero-length reported span (saves[0] reset to after the
+    // two consumed bytes), but physically consumes two characters. With
+    // find_not_empty the check is `ix == match_attempt_start`: since two bytes
+    // were consumed, ix > match_attempt_start and the match is accepted despite
+    // the reported span being zero-length.
+    let not_empty = RegexBuilder::new(r"\G..\K")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let matches: Vec<_> = not_empty
+        .find_iter("aabbcc")
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    // Each match physically consumes 2 bytes; \K resets the reported start to
+    // the physical end, yielding zero-length spans. The iterator advances by 1
+    // after each zero-length match (OPTION_SKIPPED_EMPTY_MATCH), so the pattern
+    // matches at positions (2,2) and (5,5), mirroring the behavior without find_not_empty.
+    assert_eq!(matches, vec![(2, 2), (5, 5)]);
+}
+
+#[test]
+fn find_not_empty_with_anchored_pattern() {
+    // ^-anchored patterns with find_not_empty go through the VM path (because
+    // find_not_empty forces the VM) but do NOT emit a SplitUnanchored preamble
+    // (the pattern is compiled as anchored). match_attempt_start stays at pos,
+    // so ix == match_attempt_start still correctly detects the empty match.
+    let not_empty = RegexBuilder::new(r"^\d*")
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+
+    // No leading digits → empty match at position 0 → rejected
+    assert_eq!(
+        not_empty
+            .find("hello")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        None,
+    );
+
+    // Leading digits → non-empty match at position 0 → accepted
+    assert_eq!(
+        not_empty
+            .find("123hello")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((0, 3)),
+    );
+}
+
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     find_match(re, text).map(|m| (m.start(), m.end()))
 }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use fancy_regex::Match;
+use fancy_regex::{Match, RegexBuilder};
 use std::ops::Range;
 
 #[test]
@@ -613,6 +613,183 @@ fn continue_from_previous_match_at_min_position_zero() {
     assert_eq!(find(r"(?=\d)(?=1)\G\d+", text), Some((0, 3)));
     // Atomic group doesn't affect \G position checking
     assert_eq!(find(r"(?>\G)\d+", "123abc"), Some((0, 3)));
+}
+
+#[test]
+fn find_not_empty_skips_zero_length_match() {
+    // \d* on text that doesn't start with a digit: normal mode matches empty at position 0,
+    // find_not_empty mode rejects the zero-length match.
+    let pattern = r"\d*";
+    let text = "hello";
+
+    let normal = common::regex(pattern);
+    assert_eq!(
+        normal.find(text).unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 0)),
+    );
+
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty.find(text).unwrap().map(|m| (m.start(), m.end())),
+        None,
+    );
+}
+
+#[test]
+fn find_not_empty_find_iter() {
+    // With find_iter, find_not_empty should keep non-empty matches but stop
+    // when a zero-length match is encountered (returning None stops the iterator).
+    let pattern = r"\d*";
+    let text = "1a2";
+
+    // Normal mode: "1" at 0-1, empty at 1-1 skipped (adjacent to last match end),
+    // "2" at 2-3, empty at 3-3 skipped (adjacent to last match end), done.
+    let normal: Vec<(usize, usize)> = common::regex(pattern)
+        .find_iter(text)
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(normal, vec![(0, 1), (2, 3)]);
+
+    // find_not_empty: "1" at (0,1) is non-empty → kept. Next search at pos 1: \d* matches ""
+    // at (1,1), find_not_empty rejects and advances past the empty match. At pos 2: \d*
+    // matches "2" at (2,3), which is non-empty → kept. Both non-empty matches are yielded.
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let filtered: Vec<(usize, usize)> = not_empty
+        .find_iter(text)
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(filtered, vec![(0, 1), (2, 3)]);
+}
+
+#[test]
+fn find_not_empty_captures_iter() {
+    // Same as find_not_empty_find_iter but using captures_iter to verify
+    // the captures path also advances past empty matches.
+    let pattern = r"(\d*)";
+    let text = "1a2";
+
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let filtered: Vec<(usize, usize)> = not_empty
+        .captures_iter(text)
+        .map(|c| {
+            let c = c.unwrap();
+            let m = c.get(0).unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(filtered, vec![(0, 1), (2, 3)]);
+}
+
+#[test]
+fn find_not_empty_fancy_path() {
+    // Use a lookbehind to force the fancy/VM path, then verify find_not_empty works there too.
+    // (?<=^)\d* matches an empty string of digits at the start of text.
+    let pattern = r"(?<=^)\d*";
+    let text = "hello";
+
+    let normal = common::regex(pattern);
+    assert_eq!(
+        normal.find(text).unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 0)),
+    );
+
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty.find(text).unwrap().map(|m| (m.start(), m.end())),
+        None,
+    );
+}
+
+#[test]
+fn find_not_empty_fancy_find_iter() {
+    // Atomic group forces the fancy/VM path.
+    // (?>\d*) behaves like \d* but via the backtracking VM.
+    let pattern = r"(?>\d*)";
+    let text = "1a2";
+
+    // Normal mode: same as \d* — "1" at 0-1, "2" at 2-3
+    // (empty matches adjacent to the previous match end are skipped by find_iter)
+    let normal: Vec<(usize, usize)> = common::regex(pattern)
+        .find_iter(text)
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(normal, vec![(0, 1), (2, 3)]);
+
+    // find_not_empty with the fancy/VM path: the VM's unanchored search loop
+    // (Split/Any/Jmp preamble) allows it to advance past positions where the
+    // pattern would produce an empty match. So unlike the Wrap path, the VM
+    // at pos 1 rejects the empty match via OPTION_FIND_NOT_EMPTY but then
+    // advances and finds "2" at (2,3). Both non-empty matches are yielded.
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    let filtered: Vec<(usize, usize)> = not_empty
+        .find_iter(text)
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(filtered, vec![(0, 1), (2, 3)]);
+}
+
+#[test]
+fn find_not_empty_trailing_lookahead_with_variable_group0() {
+    // \d*(?=x) optimizes to (\d*)x with explicit_capture_group_0.
+    // The user-visible match is explicit group 0 (\d*). When \d* matches empty,
+    // find_not_empty should reject the match even though the physical match
+    // (including the "x") is non-empty.
+    let pattern = r"\d*(?=x)";
+    let text = "xhello";
+
+    // Normal mode: matches empty \d* followed by lookahead for x → match at (0, 0)
+    let normal = common::regex(pattern);
+    assert_eq!(
+        normal.find(text).unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 0)),
+    );
+
+    // find_not_empty: the user-visible match (group 0) is empty → rejected
+    let not_empty = RegexBuilder::new(pattern)
+        .find_not_empty(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        not_empty.find(text).unwrap().map(|m| (m.start(), m.end())),
+        None,
+    );
+
+    // But with digits before the x, the match is non-empty → accepted
+    let text_with_digits = "12xhello";
+    assert_eq!(
+        not_empty
+            .find(text_with_digits)
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((0, 2)),
+    );
 }
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -616,6 +616,24 @@ fn continue_from_previous_match_at_min_position_zero() {
 }
 
 #[test]
+fn find_iter_continue_from_previous_match_end_with_keepout() {
+    // \G..\K produces zero-length matches because \K resets the reported start to
+    // after the two consumed characters. Iteration should continue matching across
+    // the whole string, advancing two bytes at a time, not stop after the first match.
+    let text = "aabbcc";
+
+    for (i, mat) in common::regex(r"\G..\K").find_iter(text).enumerate() {
+        let mat = mat.unwrap();
+
+        match i {
+            0 => assert_eq!((mat.start(), mat.end()), (2, 2)),
+            1 => assert_eq!((mat.start(), mat.end()), (5, 5)),
+            i => panic!("Expected 2 results, got {}", i + 1),
+        }
+    }
+}
+
+#[test]
 fn find_not_empty_skips_zero_length_match() {
     // \d* on text that doesn't start with a digit: normal mode matches empty at position 0,
     // find_not_empty mode rejects the zero-length match.

--- a/tests/regex_options.rs
+++ b/tests/regex_options.rs
@@ -1,5 +1,4 @@
-use fancy_regex::Regex;
-use fancy_regex::RegexBuilder;
+use fancy_regex::{CompileError, Error, Regex, RegexBuilder};
 
 fn build_regex(builder: &RegexBuilder) -> Regex {
     let result = builder.build();
@@ -189,4 +188,98 @@ fn changing_builder_options_has_no_effect_on_already_built_regexes() {
     assert!(!regex2.is_match(test_text1).unwrap());
     assert!(!regex3.is_match(test_text2).unwrap());
     assert!(regex4.is_match(test_text2).unwrap());
+}
+
+#[test]
+fn check_find_not_empty_option() {
+    // \d* can match empty, so without find_not_empty it matches at position 0 with zero length.
+    // With find_not_empty enabled, that zero-length match is rejected and find returns None.
+    let pattern = r"\d*";
+    let text = "hello";
+
+    let normal = build_regex(RegexBuilder::new(pattern).find_not_empty(false));
+    assert_eq!(
+        normal.find(text).unwrap().map(|m| (m.start(), m.end())),
+        Some((0, 0))
+    );
+
+    let not_empty = build_regex(RegexBuilder::new(pattern).find_not_empty(true));
+    assert_eq!(
+        not_empty.find(text).unwrap().map(|m| (m.start(), m.end())),
+        None
+    );
+}
+
+#[test]
+fn check_find_not_empty_rejects_zero_width_only_patterns() {
+    // Patterns that can only ever produce zero-length matches should fail to compile
+    // when find_not_empty is set, since they can never return a result.
+    let zero_width_patterns = vec![
+        r"^", r"$", r"\b", r"(?!bar)", r"(?<=x)", r"(?<!y)", r"(?=.)", r"\G",
+    ];
+
+    for pattern in zero_width_patterns {
+        let result = RegexBuilder::new(pattern).find_not_empty(true).build();
+        assert!(
+            matches!(
+                result,
+                Err(Error::CompileError(ref e)) if matches!(**e, CompileError::PatternCanNeverMatch)
+            ),
+            "Expected PatternCanNeverMatch for pattern {:?}, got {:?}",
+            pattern,
+            result,
+        );
+    }
+}
+
+#[test]
+fn check_find_not_empty_allows_patterns_that_can_match_non_empty() {
+    // Patterns that can produce non-empty matches should compile fine even with find_not_empty
+    let patterns = vec![
+        r"\d*",
+        r"a?",
+        r"\d+",
+        r"[a-z]+",
+        r"(?:foo)?",
+        r"\d*(?=x)",
+        r"a(?=b)",
+    ];
+
+    for pattern in patterns {
+        let result = RegexBuilder::new(pattern).find_not_empty(true).build();
+        assert!(
+            result.is_ok(),
+            "Expected pattern {:?} to compile with find_not_empty, got {:?}",
+            pattern,
+            result.err(),
+        );
+    }
+}
+
+#[test]
+fn check_find_not_empty_is_match() {
+    // is_match should respect find_not_empty: \d* normally matches empty at position 0
+    // in "hello", but with find_not_empty it should return false.
+    let pattern = r"\d*";
+    let text = "hello";
+
+    let normal = build_regex(RegexBuilder::new(pattern).find_not_empty(false));
+    assert!(normal.is_match(text).unwrap());
+
+    let not_empty = build_regex(RegexBuilder::new(pattern).find_not_empty(true));
+    assert!(!not_empty.is_match(text).unwrap());
+}
+
+#[test]
+fn check_find_not_empty_allows_trailing_lookahead_with_content() {
+    // a?(?=b) optimizes to (a?)b — group 0 is "a?" which is not always empty, so it should compile
+    let result = RegexBuilder::new(r"a(?=b)").find_not_empty(true).build();
+    assert!(
+        result.is_ok(),
+        "Expected a?(?=b) to compile with find_not_empty"
+    );
+
+    let regex = result.unwrap();
+    assert!(regex.is_match("ab").unwrap());
+    assert!(!regex.is_match("ac").unwrap());
 }


### PR DESCRIPTION
- In the VM, a new `OPTION_FIND_NOT_EMPTY` flag is checked when handling the `End` instruction, ignoring the effect of `\K` when present.
- Public API is exposed via `RegexOptionsBuilder::find_not_empty` and `RegexBuilder::find_not_empty`.
- Return `CompileError::PatternCanNeverMatch` for zero-width-only patterns with `find_not_empty`

When `find_not_empty` is enabled, and some nodes are not const size and have min size 0, we cannot `Wrap` the regex but have to treat those nodes as hard.
This is because otherwise if we have a pattern like `(?:|a|b)`, then it would be delegated to regex-automata and the empty branch would always take precedence - we need to use backtracking to try the other branches.

To help identify where the match attempt started, without `\K` interfering, we introduce a new instruction identical to `Split` which is used to bump the haystack position for unanchored searches, but allows us to track the match attempt start position accurately.

The analyze and compile functions now take a struct argument to make the call sites clearer as opposed to passing in booleans and having to look up what they mean.

I also added the new flag to the playground so we can try it out interactively.