### PR TITLE
Oniguruma parity: empty group repeat + out-of-bounds search pos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -920,6 +920,9 @@ impl Regex {
         pos: usize,
         option_flags: u32,
     ) -> Result<Option<Match<'t>>> {
+        if pos > text.len() {
+            return Ok(None);
+        }
         match &self.inner {
             RegexImpl::Wrap {
                 inner,
@@ -1049,6 +1052,9 @@ impl Regex {
         pos: usize,
         option_flags: u32,
     ) -> Result<Option<Captures<'t>>> {
+        if pos > text.len() {
+            return Ok(None);
+        }
         let named_groups = self.named_groups.clone();
         match &self.inner {
             RegexImpl::Wrap {

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -444,6 +444,42 @@ fn captures_from_pos() {
 }
 
 #[test]
+fn captures_from_pos_past_end_wrap() {
+    let re = fancy_regex::RegexBuilder::new(r"^(<{7})(?:\s+(\S.*?))?$\n?")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let result = re.captures_from_pos("ab", 12);
+    assert!(
+        matches!(result, Ok(None)),
+        "expected Ok(None) for pos past end, got {result:?}"
+    );
+}
+
+#[test]
+fn captures_from_pos_past_end_fancy() {
+    let re = fancy_regex::RegexBuilder::new(r"(?<=a)b")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let result = re.captures_from_pos("ab", 12);
+    assert!(
+        matches!(result, Ok(None)),
+        "expected Ok(None) for pos past end, got {result:?}"
+    );
+}
+
+#[test]
+fn captures_from_pos_at_end_still_runs() {
+    let re = fancy_regex::RegexBuilder::new("$")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let result = re.captures_from_pos("ab", 2).unwrap();
+    assert!(result.is_some(), "pattern `$` must match at end-of-text");
+}
+
+#[test]
 fn captures_from_pos_looking_left() {
     let regex = common::regex(r"\b(\w)");
 

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1010,6 +1010,39 @@ fn find_not_empty_with_anchored_pattern() {
     );
 }
 
+#[test]
+fn find_from_pos_past_end_wrap() {
+    let re = RegexBuilder::new(r"^(<{7})(?:\s+(\S.*?))?$\n?")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let result = re.find_from_pos("ab", 12);
+    assert!(
+        matches!(result, Ok(None)),
+        "expected Ok(None) for pos past end, got {result:?}"
+    );
+}
+
+#[test]
+fn find_from_pos_past_end_fancy() {
+    let re = RegexBuilder::new(r"(?<=a)b")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let result = re.find_from_pos("ab", 12);
+    assert!(
+        matches!(result, Ok(None)),
+        "expected Ok(None) for pos past end, got {result:?}"
+    );
+}
+
+#[test]
+fn find_from_pos_at_end_still_runs() {
+    let re = RegexBuilder::new("$").oniguruma_mode(true).build().unwrap();
+    let result = re.find_from_pos("ab", 2).unwrap();
+    assert!(result.is_some(), "pattern `$` must match at end-of-text");
+}
+
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {
     find_match(re, text).map(|m| (m.start(), m.end()))
 }


### PR DESCRIPTION
Part of a series closing Oniguruma parity gaps surfaced by syntect's `syntest` baselines. Downstream integration + baseline regeneration: trishume/syntect#651.

## Fixes

1. `parse.rs`: accept `(?:)` + quantifier in Oniguruma mode.
2. `lib.rs`: return `Ok(None)` from `{find,captures}_from_pos[_with_option_flags]` when `pos > text.len()` (was panicking on both Wrap and Fancy VM paths).

See per-commit messages for reproducer details.

## Stack

Re-lands #242 after it was merged into `find_not_empty` (instead of `main`) and that base branch was then deleted, auto-closing #243. Targets `main` directly. Supersedes #242 and #243; follows up on #240.