### PR TITLE
implement Seek optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ with the exception that 0.x versions can break between minor versions.
 - Add support for Oniguruma's absent repeater `(?~abc)` (#233)
 - Add support for ignoring empty matches (#240)
 - Add support for treating unnamed capture groups as non-capturing when named groups exist (#241)
+- Add experimental seek optimization to only invoke the VM at candidate positions where a match could occur (#246)
 ### Changed
 - `RegexBuilder` can now build multiple patterns with the same options (#213)
 - Parsing of capture group names is now more lenient (#241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Added
+- Add experimental seek optimization to only invoke the VM at candidate positions where a match could occur (#246)
+### Changed
+### Fixed
+
 ## [0.18.0] - 2026-04-24
 ### Added
 - Add support for `\N` to mean any character except newline, for Oniguruma compatibility (#206)
@@ -18,7 +24,6 @@ with the exception that 0.x versions can break between minor versions.
 - Add support for Oniguruma's absent repeater `(?~abc)` (#233)
 - Add support for ignoring empty matches (#240)
 - Add support for treating unnamed capture groups as non-capturing when named groups exist (#241)
-- Add experimental seek optimization to only invoke the VM at candidate positions where a match could occur (#246)
 ### Changed
 - `RegexBuilder` can now build multiple patterns with the same options (#213)
 - Parsing of capture group names is now more lenient (#241)

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -76,12 +76,23 @@ Oniguruma doesn't have a problem with this particular case because its
 optimization saves it again: It checks if there's a `c` in the input
 before doing any matching.
 
-There's nothing preventing fancy-regex from adding similar optimizations
-in the future, but it's not done yet.
+fancy-regex now has a **Seek** pre-filter optimization (disabled by
+default) for hard (backtracking) patterns, which provides similar
+benefits for many cases. It derives a regular approximation of the
+pattern and uses it to skip directly to the earliest plausible match
+position in the haystack, so the backtracking VM only needs to run from
+that position onward. For patterns where the hard parts leave useful
+literals or anchors in the approximation — for example, backreferences
+like `(\w+) \1` or anchored patterns like `(.{5})\1$` — the Seek
+pre-filter can dramatically reduce the number of positions the VM tries.
+Lookarounds are currently dropped when building the approximation pattern,
+so the Seek pre-filter does not directly replicate Oniguruma's "find `c`
+first" step in that specific case. The Seek optimization can be toggled
+on/off via the `seek` method on `RegexBuilder`/`RegexOptionsBuilder`.
 
 Note that how much fancy-regex can do without backtracking depends on
 the structure of the regex. For example, with `(?=(a|b|ab)*bc)`, the
-inner part of the look-ahead can be delegated to regex entirely.
+inner part of the look-ahead can be delegated to regex-automata entirely.
 
 ### Summary
 
@@ -91,7 +102,11 @@ inner part of the look-ahead can be delegated to regex entirely.
   Oniguruma's exponential worst-case.
 * Even if the regex doesn't use any fancy features, Oniguruma can be
   faster because it is a mature and highly optimized engine.
-* With fancy features, Oniguruma can be faster because of optimizations.
+* With fancy features, Oniguruma can still be faster in some cases. Its
+  mature literal pre-search covers more patterns than the Seek pre-filter
+  (for example, lookaround patterns where the Seek approximation drops
+  the lookahead). The Seek pre-filter can be turned on or off via
+  `RegexBuilder::seek(seek_enabled)` if needed.
 
 [Runaway Regular Expressions: Catastrophic Backtracking]: https://www.regular-expressions.info/catastrophic.html
 [Oniguruma]: https://github.com/kkos/oniguruma

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Still in development, though the basic ideas are in place. Currently,
 the following features are missing:
 
 * Backreferences at recursion levels
-* Optimizations
 
 ## Acknowledgements
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -316,13 +316,71 @@ criterion_group!(
     no_seek_backref_in_long_haystack_no_match,
 );
 
+/// Shared logic for the worst-case seek benchmarks.
+///
+/// Compiles `(\d{3})\1` with the given `seek` setting and builds a haystack of
+/// `"1234567890"` repeated 100 times (optionally followed by `"00000"` to place a
+/// match at the very end).  Because every position in the all-digits haystack is
+/// a candidate for `\d{3}`, the seek pre-filter cannot skip any positions — it
+/// becomes pure overhead compared to running without seek.
+fn bench_digit_backref_worst_case(c: &mut Criterion, name: &str, seek: bool, with_match: bool) {
+    let tree = Expr::parse_tree(r"(\d{3})\1").unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            seek_filter: if seek {
+                Some(seek_pattern_is_useful)
+            } else {
+                None
+            },
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
+    let mut haystack = "1234567890".repeat(100);
+    if with_match {
+        // Append 5 zeros so the string ends with 6 zeros giving a match ("000" + "000")
+        // near the very end, forcing the seek pre-filter to traverse the whole haystack.
+        haystack.push_str("00000");
+    }
+    c.bench_function(name, |b| b.iter(|| run_default(&p, &haystack, 0).unwrap()));
+}
+
+fn seek_digit_backref_worst_case(c: &mut Criterion) {
+    bench_digit_backref_worst_case(c, "seek_digit_backref_worst_case", true, true);
+}
+
+fn seek_digit_backref_worst_case_no_match(c: &mut Criterion) {
+    bench_digit_backref_worst_case(c, "seek_digit_backref_worst_case_no_match", true, false);
+}
+
+fn no_seek_digit_backref_worst_case(c: &mut Criterion) {
+    bench_digit_backref_worst_case(c, "no_seek_digit_backref_worst_case", false, true);
+}
+
+fn no_seek_digit_backref_worst_case_no_match(c: &mut Criterion) {
+    bench_digit_backref_worst_case(c, "no_seek_digit_backref_worst_case_no_match", false, false);
+}
+
+criterion_group!(
+    name = seek_worst_case_benches;
+    config = Criterion::default();
+    targets = seek_digit_backref_worst_case,
+    seek_digit_backref_worst_case_no_match,
+    no_seek_digit_backref_worst_case,
+    no_seek_digit_backref_worst_case_no_match,
+);
+
 #[cfg(feature = "variable-lookbehinds")]
 criterion_main!(
     benches,
     slow_benches,
     lookbehind_benches,
     continue_from_end_of_prev_match_benches,
-    seek_benches
+    seek_benches,
+    seek_worst_case_benches
 );
 
 #[cfg(not(feature = "variable-lookbehinds"))]
@@ -330,5 +388,6 @@ criterion_main!(
     benches,
     slow_benches,
     continue_from_end_of_prev_match_benches,
-    seek_benches
+    seek_benches,
+    seek_worst_case_benches
 );

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -25,8 +25,8 @@ use criterion::Criterion;
 use std::time::Duration;
 
 use fancy_regex::internal::{analyze, compile, run_default, AnalyzeContext, CompileOptions};
-use fancy_regex::Expr;
 use fancy_regex::seek_pattern_is_useful;
+use fancy_regex::Expr;
 use regex::Regex;
 
 fn parse_lifetime_re(c: &mut Criterion) {
@@ -270,7 +270,11 @@ fn bench_backref_in_long_haystack(c: &mut Criterion, name: &str, seek: bool, wit
         &a,
         CompileOptions {
             contains_subroutines: tree.contains_subroutines,
-            seek_filter: if seek { Some(seek_pattern_is_useful) } else { None },
+            seek_filter: if seek {
+                Some(seek_pattern_is_useful)
+            } else {
+                None
+            },
             ..CompileOptions::default()
         },
     )

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use fancy_regex::internal::{analyze, compile, run_default, AnalyzeContext, CompileOptions};
 use fancy_regex::Expr;
+use fancy_regex::seek_pattern_is_useful;
 use regex::Regex;
 
 fn parse_lifetime_re(c: &mut Criterion) {
@@ -255,17 +256,75 @@ criterion_group!(
     continue_from_end_of_prev_match_long_haystack,
 );
 
+/// Shared logic for the backref-in-long-haystack seek benchmarks.
+///
+/// Compiles `(abc)\1` with the given `seek` setting, builds a 10,000-`x` haystack
+/// (optionally with `"abcabc"` appended), and registers a criterion benchmark under
+/// `name`.
+fn bench_backref_in_long_haystack(c: &mut Criterion, name: &str, seek: bool, with_match: bool) {
+    // Pattern with a backref — when seek is true the approximation inlines the group
+    // body ("abc"), so the engine jumps directly to "abc" occurrences and skips the rest.
+    let tree = Expr::parse_tree(r"(abc)\1").unwrap();
+    let a = analyze(&tree, AnalyzeContext::default()).unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            seek_filter: if seek { Some(seek_pattern_is_useful) } else { None },
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
+    let mut haystack = String::new();
+    for _ in 0..10_000 {
+        haystack.push('x');
+    }
+    if with_match {
+        // Place the match target at the very end so the seek pre-filter must scan
+        // the entire haystack before finding the single candidate position.
+        haystack.push_str("abcabc");
+    }
+    c.bench_function(name, |b| b.iter(|| run_default(&p, &haystack, 0).unwrap()));
+}
+
+fn seek_backref_in_long_haystack(c: &mut Criterion) {
+    bench_backref_in_long_haystack(c, "seek_backref_in_long_haystack", true, true);
+}
+
+fn seek_backref_in_long_haystack_no_match(c: &mut Criterion) {
+    bench_backref_in_long_haystack(c, "seek_backref_in_long_haystack_no_match", true, false);
+}
+
+fn no_seek_backref_in_long_haystack(c: &mut Criterion) {
+    bench_backref_in_long_haystack(c, "no_seek_backref_in_long_haystack", false, true);
+}
+
+fn no_seek_backref_in_long_haystack_no_match(c: &mut Criterion) {
+    bench_backref_in_long_haystack(c, "no_seek_backref_in_long_haystack_no_match", false, false);
+}
+
+criterion_group!(
+    name = seek_benches;
+    config = Criterion::default();
+    targets = seek_backref_in_long_haystack,
+    seek_backref_in_long_haystack_no_match,
+    no_seek_backref_in_long_haystack,
+    no_seek_backref_in_long_haystack_no_match,
+);
+
 #[cfg(feature = "variable-lookbehinds")]
 criterion_main!(
     benches,
     slow_benches,
     lookbehind_benches,
-    continue_from_end_of_prev_match_benches
+    continue_from_end_of_prev_match_benches,
+    seek_benches
 );
 
 #[cfg(not(feature = "variable-lookbehinds"))]
 criterion_main!(
     benches,
     slow_benches,
-    continue_from_end_of_prev_match_benches
+    continue_from_end_of_prev_match_benches,
+    seek_benches
 );

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -96,6 +96,7 @@ fn main() {
                 CompileOptions {
                     anchored: true,
                     contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
                 },
             )
             .unwrap();
@@ -172,6 +173,7 @@ fn prog(re: &str) -> Prog {
         CompileOptions {
             anchored: can_compile_as_anchored(&tree.expr),
             contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
         },
     )
     .expect("Expected compile to succeed")
@@ -199,6 +201,7 @@ impl<'a> Display for CompileFormatterWrapper<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::RegexBuilder;
     use crate::Write;
 
     #[test]
@@ -278,7 +281,31 @@ digraph G {
 
     #[test]
     fn test_compilation_fancy_debug_output() {
-        let expected = "  ".to_owned()
+        // With seek enabled (default): the SplitUnanchored preamble is replaced by a Seek
+        // instruction that pre-filters positions before running the full VM.
+        let expected_with_seek = "  ".to_owned()
+            + "\
+  0: Seek(Seek { pattern: \"a+b*b*\" })
+  1: Save(0)
+  2: Lit(\"a\")
+  3: Split(2, 4)
+  4: SaveCaptureGroupStart(1)
+  5: Split(6, 8)
+  6: Lit(\"b\")
+  7: Jmp(5)
+  8: Save(3)
+  9: Save(4)
+ 10: Lit(\"c\")
+ 11: Restore(4)
+ 12: Backref { slot: 2, casei: false }
+ 13: Save(1)
+ 14: End
+";
+
+        assert_compiled_prog_with_seek("a+(?<b>b*)(?=c)\\k<b>", &expected_with_seek);
+
+        // With seek disabled: the classic SplitUnanchored preamble is used.
+        let expected_no_seek = "  ".to_owned()
             + "\
   0: SplitUnanchored(3, 1)
   1: Any
@@ -299,13 +326,30 @@ digraph G {
  16: End
 ";
 
-        assert_compiled_prog("a+(?<b>b*)(?=c)\\k<b>", &expected);
+        assert_compiled_prog_no_seek("a+(?<b>b*)(?=c)\\k<b>", &expected_no_seek);
     }
 
     #[test]
     #[cfg(feature = "variable-lookbehinds")]
     fn test_compilation_variable_lookbehind_debug_output() {
-        let expected = "  ".to_owned()
+        // With seek enabled (default): the SplitUnanchored preamble is replaced by a Seek
+        // instruction that pre-filters positions before running the full VM.
+        let expected_with_seek = "  ".to_owned()
+            + "\
+  0: Seek(Seek { pattern: \"x\" })
+  1: Save(0)
+  2: Save(2)
+  3: BackwardsDelegate(ReverseBackwardsDelegate { pattern: \"ab+\", capture_groups: None })
+  4: Restore(2)
+  5: Lit(\"x\")
+  6: Save(1)
+  7: End
+";
+
+        assert_compiled_prog_with_seek("(?<=ab+)x", &expected_with_seek);
+
+        // With seek disabled: the classic SplitUnanchored preamble is used.
+        let expected_no_seek = "  ".to_owned()
             + "\
   0: SplitUnanchored(3, 1)
   1: Any
@@ -319,28 +363,28 @@ digraph G {
   9: End
 ";
 
-        assert_compiled_prog("(?<=ab+)x", &expected);
+        assert_compiled_prog_no_seek("(?<=ab+)x", &expected_no_seek);
     }
 
     #[test]
     fn test_compilation_wrapped_debug_output() {
         let expected = "wrapped Regex \"a+bc?\", explicit_capture_group_0: false";
 
-        assert_compiled_prog("a+bc?", &expected);
+        assert_compiled_prog_with_seek("a+bc?", &expected);
     }
 
     #[test]
     fn test_compilation_wrapped_debug_output_explict_capture_group_zero() {
         let expected = "wrapped Regex \"(a+b)c\", explicit_capture_group_0: true";
 
-        assert_compiled_prog("a+b(?=c)", &expected);
+        assert_compiled_prog_no_seek("a+b(?=c)", &expected);
     }
 
     #[test]
     fn test_compilation_wrapped_debug_output_explict_capture_group_zero_with_non_capture_group() {
         let expected = "wrapped Regex \"(a+b)(?:c|d)\", explicit_capture_group_0: true";
 
-        assert_compiled_prog("a+b(?=c|d)", &expected);
+        assert_compiled_prog_no_seek("a+b(?=c|d)", &expected);
     }
 
     fn assert_graph(re: &str, expected: &str) {
@@ -351,12 +395,35 @@ digraph G {
         assert_eq!(&output, &expected);
     }
 
-    fn assert_compiled_prog(re: &str, expected: &str) {
-        use crate::CompileFormatterWrapper;
-        let mut buf = Vec::new();
-        write!(&mut buf, "{}", CompileFormatterWrapper { regex: &re })
+    fn assert_compiled_prog_with_seek(re: &str, expected: &str) {
+        use std::fmt::{Display, Formatter};
+        struct DebugPrintWrapper<'a>(&'a fancy_regex::Regex);
+        impl<'a> Display for DebugPrintWrapper<'a> {
+            fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+                self.0.debug_print(f)
+            }
+        }
+        let r = RegexBuilder::new(re)
+            .seek(true)
+            .build()
             .expect("error compiling regexp");
-        let output = String::from_utf8(buf).expect("string not utf8");
+        let output = format!("{}", DebugPrintWrapper(&r));
+        assert_eq!(&output, &expected);
+    }
+
+    fn assert_compiled_prog_no_seek(re: &str, expected: &str) {
+        use std::fmt::{Display, Formatter};
+        struct DebugPrintWrapper<'a>(&'a fancy_regex::Regex);
+        impl<'a> Display for DebugPrintWrapper<'a> {
+            fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+                self.0.debug_print(f)
+            }
+        }
+        let r = RegexBuilder::new(re)
+            .seek(false)
+            .build()
+            .expect("error compiling regexp");
+        let output = format!("{}", DebugPrintWrapper(&r));
         assert_eq!(&output, &expected);
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1002,10 +1002,17 @@ pub struct CompileOptions {
 
 impl std::fmt::Debug for CompileOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let seek_filter_desc = match self.seek_filter {
+            None => "None",
+            Some(f_ptr) if f_ptr as usize == crate::seek::seek_pattern_is_useful as usize => {
+                "Some(seek_pattern_is_useful)"
+            }
+            Some(_) => "Some(<custom>)",
+        };
         f.debug_struct("CompileOptions")
             .field("anchored", &self.anchored)
             .field("contains_subroutines", &self.contains_subroutines)
-            .field("seek_filter", &self.seek_filter.map(|f| f as *const ()))
+            .field("seek_filter", &seek_filter_desc)
             .finish()
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -41,9 +41,10 @@ use alloc::collections::BTreeMap as Map;
 use std::collections::HashMap as Map;
 
 use crate::analyze::Info;
+use crate::seek::build_seek_pattern;
 #[cfg(feature = "variable-lookbehinds")]
 use crate::vm::{CachePoolFn, ReverseBackwardsDelegate};
-use crate::vm::{CaptureGroupRange, Delegate, Insn, Prog};
+use crate::vm::{CaptureGroupRange, Delegate, Insn, Prog, Seek};
 use crate::LookAround::*;
 use crate::{
     Absent, BacktrackingControlVerb, BytesMode, CompileError, Error, Expr, LookAround,
@@ -51,7 +52,7 @@ use crate::{
 };
 
 /// Maximum recursion depth for subroutine calls (matches Oniguruma's limit)
-const MAX_SUBROUTINE_RECURSION_DEPTH: usize = 19;
+pub(crate) const MAX_SUBROUTINE_RECURSION_DEPTH: usize = 19;
 
 // I'm thinking it probably doesn't make a lot of sense having this split
 // out from Compiler.
@@ -965,7 +966,7 @@ pub(crate) fn options_to_rabuilder(options: &RegexOptions) -> RaBuilder {
 }
 
 /// Recursively populate the group_info_map with all capture groups in the Info tree
-fn populate_group_info_map<'a>(map: &mut Map<usize, &'a Info<'a>>, info: &'a Info<'a>) {
+pub(crate) fn populate_group_info_map<'a>(map: &mut Map<usize, &'a Info<'a>>, info: &'a Info<'a>) {
     match info.expr {
         Expr::Group(_) => {
             let group = info.start_group();
@@ -992,6 +993,11 @@ pub struct CompileOptions {
     pub anchored: bool,
     /// Whether the regex contains subroutine calls, requiring group info to be pre-populated.
     pub contains_subroutines: bool,
+    /// Optional filter function for the Seek pre-filter optimization.
+    /// When `Some(f)` and a seek pattern can be derived, `f` is called with the pattern string
+    /// to decide whether it is useful enough to replace the `SplitUnanchored` preamble with a
+    /// `Seek` instruction. When `None`, seek is disabled entirely.
+    pub seek_filter: Option<fn(&str) -> bool>,
 }
 
 /// Compile the analyzed expressions into a program.
@@ -1007,13 +1013,49 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
     }
 
     if !options.anchored {
-        // add instructions as if \O*? was used at the start of the expression
-        // so that we bump the haystack index by one when failing to match at the current position
-        let current_pc = c.b.pc();
-        // we are adding 3 instructions, so the current program counter plus 3 gives us the first real instruction
-        c.b.add(Insn::SplitUnanchored(current_pc + 3, current_pc + 1));
-        c.b.add(Insn::Any);
-        c.b.add(Insn::Jmp(current_pc));
+        // Attempt to build a Seek pre-filter when requested.
+        let mut used_seek = false;
+        if let Some(filter) = options.seek_filter {
+            if info.hard {
+                // Build the group_info_map if not already populated (needed for backref inlining).
+                let mut local_group_info_map: Map<usize, &Info<'_>>;
+                let group_info_map: &Map<usize, &Info<'_>> = if options.contains_subroutines {
+                    &c.group_info_map
+                } else {
+                    local_group_info_map = Map::new();
+                    populate_group_info_map(&mut local_group_info_map, info);
+                    &local_group_info_map
+                };
+
+                let mut seek_pat = String::new();
+                build_seek_pattern(info, group_info_map, 0, &mut seek_pat, 0);
+
+                if filter(&seek_pat) {
+                    match compile_inner(&seek_pat, &c.options) {
+                        Ok(inner) => {
+                            c.b.add(Insn::Seek(Seek {
+                                inner,
+                                pattern: seek_pat,
+                            }));
+                            used_seek = true;
+                        }
+                        // If compilation of the seek pattern fails for any reason, fall back to the
+                        // standard SplitUnanchored preamble.
+                        Err(_) => {}
+                    }
+                }
+            }
+        }
+
+        if !used_seek {
+            // add instructions as if \O*? was used at the start of the expression
+            // so that we bump the haystack index by one when failing to match at the current position
+            let current_pc = c.b.pc();
+            // we are adding 3 instructions, so the current program counter plus 3 gives us the first real instruction
+            c.b.add(Insn::SplitUnanchored(current_pc + 3, current_pc + 1));
+            c.b.add(Insn::Any);
+            c.b.add(Insn::Jmp(current_pc));
+        }
     }
     if info.start_group() == 1 {
         // add implicit capture group 0 begin

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1000,8 +1000,8 @@ pub struct CompileOptions {
     pub seek_filter: Option<fn(&str) -> bool>,
 }
 
-impl std::fmt::Debug for CompileOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CompileOptions {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let seek_filter_desc = match self.seek_filter {
             None => "None",
             Some(f_ptr) if f_ptr as usize == crate::seek::seek_pattern_is_useful as usize => {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -986,7 +986,7 @@ pub(crate) fn populate_group_info_map<'a>(map: &mut Map<usize, &'a Info<'a>>, in
 }
 
 /// Options for compiling analyzed expressions into a program.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct CompileOptions {
     /// Whether the regex is anchored (starts matching at the beginning of the input).
     /// When `false`, a `SplitUnanchored` preamble is emitted to allow matching at any position.
@@ -998,6 +998,16 @@ pub struct CompileOptions {
     /// to decide whether it is useful enough to replace the `SplitUnanchored` preamble with a
     /// `Seek` instruction. When `None`, seek is disabled entirely.
     pub seek_filter: Option<fn(&str) -> bool>,
+}
+
+impl std::fmt::Debug for CompileOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompileOptions")
+            .field("anchored", &self.anchored)
+            .field("contains_subroutines", &self.contains_subroutines)
+            .field("seek_filter", &self.seek_filter.map(|f| f as *const ()))
+            .finish()
+    }
 }
 
 /// Compile the analyzed expressions into a program.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1031,22 +1031,19 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
                 build_seek_pattern(info, group_info_map, 0, &mut seek_pat, 0);
 
                 if filter(&seek_pat) {
-                    match compile_inner(&seek_pat, &c.options) {
-                        Ok(inner) => {
-                            c.b.add(Insn::Seek(Seek {
-                                inner,
-                                pattern: seek_pat,
-                            }));
-                            used_seek = true;
-                        }
-                        // If compilation of the seek pattern fails for any reason, fall back to the
-                        // standard SplitUnanchored preamble.
-                        Err(_) => {}
+                    if let Ok(inner) = compile_inner(&seek_pat, &c.options) {
+                        c.b.add(Insn::Seek(Seek {
+                            inner,
+                            pattern: seek_pat,
+                        }));
+                        used_seek = true;
                     }
                 }
             }
         }
 
+        // If compilation of the seek pattern fails for any reason, or seeking for this
+        // pattern is disabled, fall back to the standard SplitUnanchored preamble.
         if !used_seek {
             // add instructions as if \O*? was used at the start of the expression
             // so that we bump the haystack index by one when failing to match at the current position

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ impl<'r, 'h> Iterator for SplitN<'r, 'h> {
 
 impl<'r, 'h> core::iter::FusedIterator for SplitN<'r, 'h> {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct RegexOptions {
     syntaxc: SyntaxConfig,
     delegate_size_limit: Option<usize>,
@@ -506,6 +506,33 @@ struct RegexOptions {
     hard_regex_runtime_options: HardRegexRuntimeOptions,
     bytes_mode: BytesMode,
     seek_filter: Option<fn(&str) -> bool>,
+}
+
+impl fmt::Debug for RegexOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let seek_filter_desc = match self.seek_filter {
+            None => "None",
+            Some(f_ptr) if f_ptr as usize == seek_pattern_is_useful as usize => {
+                "Some(seek_pattern_is_useful)"
+            }
+            Some(_) => "Some(<custom>)",
+        };
+        f.debug_struct("RegexOptions")
+            .field("syntaxc", &self.syntaxc)
+            .field("delegate_size_limit", &self.delegate_size_limit)
+            .field("delegate_dfa_size_limit", &self.delegate_dfa_size_limit)
+            .field("oniguruma_mode", &self.oniguruma_mode)
+            .field(
+                "ignore_numbered_groups_when_named_groups_exist",
+                &self.ignore_numbered_groups_when_named_groups_exist,
+            )
+            .field(
+                "hard_regex_runtime_options",
+                &self.hard_regex_runtime_options,
+            )
+            .field("seek_filter", &seek_filter_desc)
+            .finish()
+    }
 }
 
 impl Default for RegexOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod optimize;
 mod parse;
 mod parse_flags;
 mod replacer;
+mod seek;
 mod vm;
 
 use crate::analyze::can_compile_as_anchored;
@@ -74,6 +75,7 @@ pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
 pub use crate::expand::Expander;
 pub use crate::input::RegexInput;
 pub use crate::replacer::{NoExpand, Replacer, ReplacerRef};
+pub use crate::seek::seek_pattern_is_useful;
 
 /// Controls how the regex engine handles input encoding.
 ///
@@ -503,6 +505,7 @@ struct RegexOptions {
     ignore_numbered_groups_when_named_groups_exist: bool,
     hard_regex_runtime_options: HardRegexRuntimeOptions,
     bytes_mode: BytesMode,
+    seek_filter: Option<fn(&str) -> bool>,
 }
 
 impl Default for RegexOptions {
@@ -515,6 +518,7 @@ impl Default for RegexOptions {
             ignore_numbered_groups_when_named_groups_exist: false,
             hard_regex_runtime_options: HardRegexRuntimeOptions::default(),
             bytes_mode: BytesMode::default(),
+            seek_filter: None, // when we are ready to enable seek by default, use: `Some(seek_pattern_is_useful)`
         }
     }
 }
@@ -742,6 +746,60 @@ impl RegexOptionsBuilder {
         self
     }
 
+    /// ⚠️ Experimental: This API may change, be removed without notice, or cause matches to be
+    /// skipped. This requires more real-world testing to prove correctness and observe in which
+    /// circumstances it brings performance benefits and in which it has the opposite effect.
+    /// Feedback (and benchmarks on real-world patterns/haystacks) would be very welcome!
+    ///
+    /// Enable the Seek pre-filter optimization for hard (backtracking) patterns.
+    ///
+    /// When enabled, the compiler attempts to derive a regular approximation of the pattern
+    /// which is used to skip to the earliest plausible match position in the haystack before
+    /// invoking the backtracking VM. This can dramatically speed up searches in long haystacks
+    /// when the pattern can only match at infrequent positions.
+    ///
+    /// The seek pattern is always a conservative over-approximation — it may report false-positive
+    /// positions but will never skip a true match.
+    ///
+    /// When `yes` is `true`, uses the default [`seek_pattern_is_useful`] filter to decide
+    /// whether the derived pattern is worth using. When `false`, disables seek entirely.
+    ///
+    /// To supply a custom filter, use [`seek_filter`](Self::seek_filter) instead.
+    pub fn seek(&mut self, yes: bool) -> &mut Self {
+        self.options.seek_filter = if yes {
+            Some(seek_pattern_is_useful)
+        } else {
+            None
+        };
+        self
+    }
+
+    /// Set a custom filter function that decides whether the derived seek pattern is useful.
+    ///
+    /// The function receives the seek pattern string and returns `true` if the pattern should
+    /// be used as a pre-filter, or `false` to fall back to the standard unanchored search.
+    ///
+    /// Calling this method implicitly enables seek. Pass [`seek_pattern_is_useful`] to restore
+    /// the default behavior.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use fancy_regex::{RegexOptionsBuilder, seek_pattern_is_useful};
+    ///
+    /// // Use the default filter (equivalent to seek(true))
+    /// let mut builder = RegexOptionsBuilder::new();
+    /// builder.seek_filter(seek_pattern_is_useful);
+    ///
+    /// // Use a custom filter that additionally requires the pattern to be longer than 3 bytes
+    /// let mut builder = RegexOptionsBuilder::new();
+    /// builder.seek_filter(|pat| pat.len() > 3 && seek_pattern_is_useful(pat));
+    /// ```
+    pub fn seek_filter(&mut self, filter: fn(&str) -> bool) -> &mut Self {
+        self.options.seek_filter = Some(filter);
+        self
+    }
+
     /// Attempts to better match [Oniguruma](https://github.com/kkos/oniguruma)'s default behavior
     ///
     /// Currently this amounts to changing behavior with:
@@ -920,6 +978,18 @@ impl RegexBuilder {
             .ignore_numbered_groups_when_named_groups_exist(yes);
         self
     }
+
+    /// See [`RegexOptionsBuilder::seek`]
+    pub fn seek(&mut self, yes: bool) -> &mut Self {
+        self.options.seek(yes);
+        self
+    }
+
+    /// See [`RegexOptionsBuilder::seek_filter`]
+    pub fn seek_filter(&mut self, filter: fn(&str) -> bool) -> &mut Self {
+        self.options.seek_filter(filter);
+        self
+    }
 }
 
 impl fmt::Debug for Regex {
@@ -1005,6 +1075,7 @@ impl Regex {
             CompileOptions {
                 anchored: can_compile_as_anchored(&tree.expr),
                 contains_subroutines: tree.contains_subroutines,
+                seek_filter: options.seek_filter,
             },
         )?;
         Ok(Regex {
@@ -2059,6 +2130,31 @@ fn push_usize(s: &mut String, x: usize) {
     }
 }
 
+/// Emit a repeat quantifier `?`, `*`, `+`, or `{lo,hi}` (optionally non-greedy) into `buf`.
+///
+/// This is shared between [`Expr::to_str`] and `build_seek_pattern` in the compiler.
+pub(crate) fn write_quantifier(buf: &mut String, lo: usize, hi: usize, greedy: bool) {
+    match (lo, hi) {
+        (0, 1) => buf.push('?'),
+        (0, usize::MAX) => buf.push('*'),
+        (1, usize::MAX) => buf.push('+'),
+        (lo, hi) => {
+            buf.push('{');
+            push_usize(buf, lo);
+            if lo != hi {
+                buf.push(',');
+                if hi != usize::MAX {
+                    push_usize(buf, hi);
+                }
+            }
+            buf.push('}');
+        }
+    }
+    if !greedy {
+        buf.push('?');
+    }
+}
+
 fn is_special(c: char) -> bool {
     matches!(
         c,
@@ -2404,25 +2500,7 @@ impl Expr {
                     buf.push_str("(?:");
                 }
                 child.to_str(buf, 3);
-                match (lo, hi) {
-                    (0, 1) => buf.push('?'),
-                    (0, usize::MAX) => buf.push('*'),
-                    (1, usize::MAX) => buf.push('+'),
-                    (lo, hi) => {
-                        buf.push('{');
-                        push_usize(buf, lo);
-                        if lo != hi {
-                            buf.push(',');
-                            if hi != usize::MAX {
-                                push_usize(buf, hi);
-                            }
-                        }
-                        buf.push('}');
-                    }
-                }
-                if !greedy {
-                    buf.push('?');
-                }
+                write_quantifier(buf, lo, hi, greedy);
                 if precedence > 2 {
                     buf.push(')');
                 }
@@ -2511,7 +2589,7 @@ pub mod internal {
         FLAG_CASEI, FLAG_CRLF, FLAG_DOTNL, FLAG_IGNORE_NUMBERED_GROUPS_WHEN_NAMED_GROUPS_EXIST,
         FLAG_IGNORE_SPACE, FLAG_MULTI, FLAG_ONIGURUMA_MODE, FLAG_UNICODE,
     };
-    pub use crate::vm::{run_default, run_trace, Insn, Prog};
+    pub use crate::vm::{run_default, run_trace, Insn, Prog, Seek};
 }
 
 #[cfg(test)]

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -1,0 +1,577 @@
+// Copyright 2026 The Fancy Regex Authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Seek pre-filter: build a simplified approximation of a pattern used to
+//! skip to plausible match positions before handing off to the backtracking VM.
+
+use alloc::format;
+use alloc::string::String;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap as Map;
+#[cfg(feature = "std")]
+use std::collections::HashMap as Map;
+
+use crate::analyze::Info;
+use crate::compile::MAX_SUBROUTINE_RECURSION_DEPTH;
+use crate::{write_quantifier, Absent, Assertion, Expr};
+
+/// Returns `true` if the expression tree contains a `StartText` or `EndText` assertion anywhere.
+///
+/// This is used to decide whether it is safe to inline a group body when approximating a backref:
+/// text-anchor assertions in an inlined body would be evaluated at the wrong string position and
+/// could cause false negatives (missing valid match positions).
+pub(crate) fn expr_contains_positional_anchor(expr: &Expr) -> bool {
+    match expr {
+        // StartText (^), EndText ($), StartLine ((?m)^), EndLine ((?m)$) are positional anchors
+        // that depend on absolute position in the string.  When a group containing such anchors
+        // is inlined for a backref approximation, the anchors would be evaluated at the wrong
+        // position (the backref position rather than the original capture position), potentially
+        // producing false negatives.
+        Expr::Assertion(
+            Assertion::StartText
+            | Assertion::EndText
+            | Assertion::EndTextIgnoreTrailingNewlines { .. }
+            | Assertion::StartLine { .. }
+            | Assertion::EndLine { .. },
+        ) => true,
+        _ => expr
+            .children_iter()
+            .any(|child| expr_contains_positional_anchor(child)),
+    }
+}
+
+/// Emit a permissive size placeholder — `(?s:.)+` or `(?s:.){N,}` — into `buf`.
+///
+/// Used when a hard node cannot be represented in the seek pattern but has a known minimum
+/// size.  The placeholder is an over-approximation that avoids false negatives: it admits any
+/// run of characters of at least `min_size` length.
+pub(crate) fn emit_min_size_placeholder(buf: &mut String, min_size: usize, precedence: u8) {
+    if min_size == 0 {
+        return; // zero width: safe to drop without emitting anything
+    }
+    if precedence > 2 {
+        buf.push_str("(?:");
+    }
+    buf.push_str("(?s:.)");
+    match min_size {
+        1 => buf.push('+'),
+        n => {
+            buf.push('{');
+            crate::push_usize(buf, n);
+            buf.push_str(",}");
+        }
+    }
+    if precedence > 2 {
+        buf.push(')');
+    }
+}
+
+/// Write the seek-pattern approximation for `info` into `buf`.
+///
+/// Easy (non-hard) subtrees are serialised verbatim via [`Expr::to_str`].
+/// Hard nodes are handled as follows:
+/// - `Backref` / `SubroutineCall`: inline the referenced group's body (up to
+///   `MAX_SUBROUTINE_RECURSION_DEPTH`). For backrefs, positional anchors (`^`, `$`, `\b`) etc.
+///   are dropped from the inlined body because backreferences only capture text, not positions.
+///   If inlining is not possible, a permissive `(?s:.){min_size,}` placeholder is emitted
+///   instead of silently dropping, to maintain correctness.
+/// - `LookAround`, `KeepOut`, `ContinueFromPreviousMatchEnd`, `BacktrackingControlVerb`,
+///   `BackrefExistsCondition`, `Absent`: dropped (emit nothing — safe over-approximation,
+///   their `min_size` is 0).
+/// - `AtomicGroup`: keep the contents, discard the atomicity wrapper.
+/// - `Group`: keep the contents, discard the capture group wrapper.
+/// - `Conditional`: emit the union of the true and false branches.
+/// - `GeneralNewline`: replaced with an explicit alternation.
+/// - `Assertion`: anchors and word-boundary assertions are emitted; half-boundaries are
+///   dropped (over-approximation — `\b` would be too restrictive).
+pub(crate) fn build_seek_pattern<'a>(
+    info: &Info<'a>,
+    group_info_map: &Map<usize, &'a Info<'a>>,
+    depth: usize,
+    buf: &mut String,
+    precedence: u8,
+) {
+    build_seek_pattern_impl(info, group_info_map, depth, buf, precedence, false);
+}
+
+pub(crate) fn build_seek_pattern_impl<'a>(
+    info: &Info<'a>,
+    group_info_map: &Map<usize, &'a Info<'a>>,
+    depth: usize,
+    buf: &mut String,
+    precedence: u8,
+    drop_positional_anchors: bool,
+) {
+    // Drop positional anchors at this node when requested (used when inlining for a backref).
+    if drop_positional_anchors {
+        if let Expr::Assertion(
+            Assertion::StartText
+            | Assertion::EndText
+            | Assertion::StartLine { .. }
+            | Assertion::EndLine { .. },
+        ) = info.expr
+        {
+            return;
+        }
+        // \Z is an odd one out, although it is a zero-width assertion, for the purposes of seeking
+        // it still needs to consume the newlines
+        if let Expr::Assertion(Assertion::EndTextIgnoreTrailingNewlines { crlf }) = info.expr {
+            if *crlf {
+                buf.push_str(r"[\r\n]*");
+            } else {
+                buf.push_str(r"\n*");
+            }
+            return;
+        }
+    }
+
+    if !info.hard {
+        // Easy subtree — use to_str directly when no positional-anchor dropping is needed,
+        // or when the subtree contains no positional anchors (so dropping is a no-op).
+        if !drop_positional_anchors || !expr_contains_positional_anchor(info.expr) {
+            info.expr.to_str(buf, precedence);
+            return;
+        }
+        // The easy subtree contains positional anchors that need to be stripped.
+        // Fall through to the match below, which recurses via build_seek_pattern_impl.
+    }
+
+    match info.expr {
+        Expr::Empty | Expr::DefineGroup { .. } => {}
+        Expr::Assertion(assertion) => {
+            // Emit all assertion types, approximating half-word-boundaries with \b.
+            // Note: easy positional assertions (StartText, EndText, StartLine, EndLine) are
+            // handled by the to_str early return above (drop_positional_anchors=false) or by
+            // the early drop at the top of this function (drop_positional_anchors=true).
+            // Only hard assertions reach this arm.
+            match assertion {
+                Assertion::EndTextIgnoreTrailingNewlines { crlf: false } => buf.push_str(r"\n*$"),
+                Assertion::EndTextIgnoreTrailingNewlines { crlf: true } => {
+                    buf.push_str(r"[\r\n]*$")
+                }
+                Assertion::WordBoundary => buf.push_str(r"\b"),
+                Assertion::NotWordBoundary => buf.push_str(r"\B"),
+                // Full word boundaries: \< and \> — overapproximate with \b.
+                Assertion::LeftWordBoundary | Assertion::RightWordBoundary => buf.push_str(r"\b"),
+                // Half-boundaries (\b{start-half}, \b{end-half}) can match in positions where
+                // \b does not (e.g. before punctuation), so \b would be an under-approximation.
+                // Drop them (emit nothing) which is a safe over-approximation.
+                Assertion::LeftWordHalfBoundary | Assertion::RightWordHalfBoundary => {}
+                // Easy positional anchors — handled by early return / early drop above.
+                // They can only reach here when drop_positional_anchors=false and the subtree
+                // is easy (handled by to_str) but the Group/Concat parent fell through to match.
+                // Emit them faithfully.
+                Assertion::StartText => buf.push('^'),
+                Assertion::EndText => buf.push('$'),
+                Assertion::StartLine { crlf: false } => buf.push_str("(?m:^)"),
+                Assertion::StartLine { crlf: true } => buf.push_str("(?Rm:^)"),
+                Assertion::EndLine { crlf: false } => buf.push_str("(?m:$)"),
+                Assertion::EndLine { crlf: true } => buf.push_str("(?Rm:$)"),
+            }
+        }
+        Expr::Concat(_) => {
+            if precedence > 1 {
+                buf.push_str("(?:");
+            }
+            for child in &info.children {
+                build_seek_pattern_impl(
+                    child,
+                    group_info_map,
+                    depth,
+                    buf,
+                    2,
+                    drop_positional_anchors,
+                );
+            }
+            if precedence > 1 {
+                buf.push(')');
+            }
+        }
+        Expr::Alt(_) => {
+            if precedence > 0 {
+                buf.push_str("(?:");
+            }
+            let mut first = true;
+            for child in &info.children {
+                if !first {
+                    buf.push('|');
+                }
+                build_seek_pattern_impl(
+                    child,
+                    group_info_map,
+                    depth,
+                    buf,
+                    1,
+                    drop_positional_anchors,
+                );
+                first = false;
+            }
+            if precedence > 0 {
+                buf.push(')');
+            }
+        }
+        Expr::Group(_) => {
+            // Drop the capture group wrapper; keep the contents.
+            if !info.children.is_empty() {
+                build_seek_pattern_impl(
+                    &info.children[0],
+                    group_info_map,
+                    depth,
+                    buf,
+                    precedence,
+                    drop_positional_anchors,
+                );
+            }
+        }
+        Expr::Repeat { lo, hi, greedy, .. } => {
+            if precedence > 2 {
+                buf.push_str("(?:");
+            }
+            if !info.children.is_empty() {
+                build_seek_pattern_impl(
+                    &info.children[0],
+                    group_info_map,
+                    depth,
+                    buf,
+                    3,
+                    drop_positional_anchors,
+                );
+            }
+            write_quantifier(buf, *lo, *hi, *greedy);
+            if precedence > 2 {
+                buf.push(')');
+            }
+        }
+        Expr::Backref { group, casei }
+        | Expr::BackrefWithRelativeRecursionLevel { group, casei, .. } => {
+            // Inline the body of the referenced capture group, wrapping with (?i:...) when
+            // the backref is case-insensitive so the approximation remains correct.
+            //
+            // Positional anchors are dropped from the inlined body: a backref matches the
+            // captured text, not a position, so anchors from the group definition do not hold
+            // at the backref's position.
+            //
+            // For BackrefWithRelativeRecursionLevel, the relative_level is ignored here:
+            // for seeking purposes, the group body is the same regardless of recursion level.
+            //
+            // If inlining is not possible (depth limit, group not in map), emit a permissive
+            // placeholder so that no match positions are incorrectly skipped.
+            if depth < MAX_SUBROUTINE_RECURSION_DEPTH {
+                if let Some(group_info) = group_info_map.get(group) {
+                    if !group_info.children.is_empty() {
+                        let child = &group_info.children[0];
+                        if *casei {
+                            let mut inner = String::new();
+                            build_seek_pattern_impl(
+                                child,
+                                group_info_map,
+                                depth + 1,
+                                &mut inner,
+                                // Precedence 0 (alternation) so content inside (?i:...) is unambiguous.
+                                0,
+                                true,
+                            );
+                            if !inner.is_empty() {
+                                buf.push_str("(?i:");
+                                buf.push_str(&inner);
+                                buf.push(')');
+                            }
+                        } else {
+                            build_seek_pattern_impl(
+                                child,
+                                group_info_map,
+                                depth + 1,
+                                buf,
+                                precedence,
+                                true,
+                            );
+                        }
+                        return;
+                    }
+                    // Empty group (no children): min_size=0, nothing to emit.
+                    return;
+                }
+            }
+            // Could not inline (depth limit or group not found): emit a permissive placeholder
+            // so we don't falsely skip positions where the backref's target could have matched.
+            emit_min_size_placeholder(buf, info.min_size, precedence);
+        }
+        Expr::SubroutineCall(target_group) => {
+            // Inline the body of the target group, honouring the recursion depth limit.
+            if depth < MAX_SUBROUTINE_RECURSION_DEPTH {
+                if let Some(group_info) = group_info_map.get(target_group) {
+                    if !group_info.children.is_empty() {
+                        build_seek_pattern_impl(
+                            &group_info.children[0],
+                            group_info_map,
+                            depth + 1,
+                            buf,
+                            precedence,
+                            drop_positional_anchors,
+                        );
+                        return;
+                    }
+                    return;
+                }
+            }
+            emit_min_size_placeholder(buf, info.min_size, precedence);
+        }
+        // LookAround is zero-width — drop it.
+        Expr::LookAround(_, _) => {}
+        Expr::AtomicGroup(_) => {
+            // Keep the contents; atomicity is invisible to the seek approximation.
+            if !info.children.is_empty() {
+                build_seek_pattern_impl(
+                    &info.children[0],
+                    group_info_map,
+                    depth,
+                    buf,
+                    precedence,
+                    drop_positional_anchors,
+                );
+            }
+        }
+        Expr::GeneralNewline { unicode } => {
+            // Replace \R with an explicit alternation accepted by regex-automata.
+            if *unicode {
+                buf.push_str(r"(?:\r\n|[\n\x0B\x0C\r\x85\u{2028}\u{2029}])");
+            } else {
+                buf.push_str(r"(?:\r\n|[\n\x0B\x0C\r])");
+            }
+        }
+        Expr::Conditional { .. } => {
+            // Emit the union of (condition + true_branch) and (false_branch).
+            //
+            // Including the condition prefix in the true alternative ensures that consuming
+            // conditions (e.g. `(?(a)b|c)` where `a` is matched and consumed) are
+            // over-approximated correctly.  For zero-width conditions (e.g. backref-exists
+            // checks) the condition emits nothing and the result degenerates to
+            // `true_branch | false_branch`, preserving the original behaviour.
+            let mut cond_pat = String::new();
+            let mut true_pat = String::new();
+            let mut false_pat = String::new();
+            if info.children.len() >= 1 {
+                build_seek_pattern_impl(
+                    &info.children[0],
+                    group_info_map,
+                    depth,
+                    &mut cond_pat,
+                    2,
+                    drop_positional_anchors,
+                );
+            }
+            if info.children.len() >= 2 {
+                build_seek_pattern_impl(
+                    &info.children[1],
+                    group_info_map,
+                    depth,
+                    &mut true_pat,
+                    2,
+                    drop_positional_anchors,
+                );
+            }
+            if info.children.len() >= 3 {
+                build_seek_pattern_impl(
+                    &info.children[2],
+                    group_info_map,
+                    depth,
+                    &mut false_pat,
+                    1,
+                    drop_positional_anchors,
+                );
+            }
+            // Build the "condition then true-branch" alternative.
+            let cond_true = if cond_pat.is_empty() {
+                true_pat.clone()
+            } else if true_pat.is_empty() {
+                cond_pat.clone()
+            } else {
+                format!("(?:{}{})", cond_pat, true_pat)
+            };
+            match (cond_true.is_empty(), false_pat.is_empty()) {
+                (true, true) => {}
+                (true, false) => buf.push_str(&false_pat),
+                (false, true) => buf.push_str(&cond_true),
+                (false, false) => {
+                    if precedence > 0 {
+                        buf.push_str("(?:");
+                    }
+                    buf.push_str(&cond_true);
+                    buf.push('|');
+                    buf.push_str(&false_pat);
+                    if precedence > 0 {
+                        buf.push(')');
+                    }
+                }
+            }
+        }
+        // Absent repeater `(?~expr)` matches any content not containing `expr`.
+        // Approximate with `(?s:.*)` (any characters, including newline) since the repeater
+        // can consume an arbitrary number of characters.
+        Expr::Absent(Absent::Repeater(_)) => buf.push_str("(?s:.*)"),
+        // Absent expression `(?~|absent|exp)` matches `exp` subject to the absent constraint.
+        // Approximate by seeking only for `exp`, dropping the constraint — this is a safe
+        // over-approximation since any position where `exp` matches (ignoring the constraint)
+        // is a superset of positions where the full expression matches.
+        Expr::Absent(crate::Absent::Expression { .. }) => {
+            if info.children.len() >= 2 {
+                build_seek_pattern_impl(
+                    &info.children[1],
+                    group_info_map,
+                    depth,
+                    buf,
+                    precedence,
+                    drop_positional_anchors,
+                );
+            }
+        }
+        // Zero-width / control nodes — drop them (all have min_size = 0).
+        Expr::KeepOut
+        | Expr::ContinueFromPreviousMatchEnd
+        | Expr::BacktrackingControlVerb(_)
+        | Expr::BackrefExistsCondition { .. }
+        | Expr::Absent(_) => {}
+        // Easy leaf nodes (Literal, Any, Delegate) are always handled by the `!info.hard`
+        // early return above and never reach here.  Listed explicitly so that adding a new
+        // Expr variant produces a compile error until the seek-pattern case is handled.
+        Expr::Literal { .. } | Expr::Any { .. } | Expr::Delegate { .. } => {
+            info.expr.to_str(buf, precedence)
+        }
+        // These variants cause a compile error during analysis and are therefore unreachable
+        // after a successful `analyze()` call.
+        Expr::AstNode(..) => {
+            unreachable!("unexpected expr variant after analysis")
+        }
+    }
+}
+
+/// Returns `true` if `pattern` contains at least one character that provides useful filtering
+/// (i.e. a literal character, character class, or anchor rather than just wildcards/quantifiers).
+///
+/// This is a conservative approximation: any pattern containing `[`, `\`, `^`, `$`, or an
+/// alphanumeric character is considered useful. The primary goal is to reject fully
+/// unconstrained patterns such as `.*`.
+pub fn seek_pattern_is_useful(pattern: &str) -> bool {
+    pattern
+        .bytes()
+        .any(|b| matches!(b, b'[' | b'\\' | b'^' | b'$' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyze::{analyze, AnalyzeContext};
+    use crate::compile::populate_group_info_map;
+
+    /// Build the seek pattern for a regex string and return it.
+    fn get_seek_pattern(re: &str) -> String {
+        let tree = Expr::parse_tree(re).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        let mut group_info_map = Map::new();
+        populate_group_info_map(&mut group_info_map, &info);
+        let mut buf = String::new();
+        build_seek_pattern(&info, &group_info_map, 0, &mut buf, 0);
+        buf
+    }
+
+    #[test]
+    fn seek_pattern_backref_no_anchor() {
+        // Simple backref with no positional anchors: group body is inlined verbatim.
+        // The `(?:...)` wrapping comes from Concat precedence handling when stripping groups.
+        assert_eq!(get_seek_pattern(r"(abc)\1"), "(?:abc)(?:abc)");
+    }
+
+    #[test]
+    fn seek_pattern_backref_with_start_anchor() {
+        // Backref to a group whose body starts with `^`: the anchor should be dropped from the
+        // inlined backref position but kept at the group definition site.
+        // `(^a)\1` — seek = `(?:^a)` (group) + `(?:a)` (backref, anchor dropped)
+        assert_eq!(get_seek_pattern(r"(^a)\1"), "(?:^a)(?:a)");
+    }
+
+    #[test]
+    fn seek_pattern_backref_with_start_anchor_variable_length() {
+        // The group has a start anchor plus a variable-length content.
+        // Anchor is dropped when inlining for the backref.
+        assert_eq!(get_seek_pattern(r"(^a+)\1"), "(?:^a+)(?:a+)");
+    }
+
+    #[test]
+    fn seek_pattern_backref_with_end_anchor() {
+        // Backref to a group ending with `$`: the anchor is dropped in the inline position.
+        assert_eq!(get_seek_pattern(r"(a$)\1"), "(?:a$)(?:a)");
+    }
+
+    #[test]
+    fn seek_pattern_backref_only_anchor() {
+        // Backref to a group that is only a positional anchor.
+        // The group emits `^` (min_size=0); the backref drops `^` and emits nothing.
+        assert_eq!(get_seek_pattern(r"(^)\1"), "^");
+    }
+
+    #[test]
+    fn seek_pattern_lookahead_dropped() {
+        // Lookahead is zero-width and is dropped; only the literal is kept.
+        assert_eq!(get_seek_pattern(r"(?=foo)bar"), "bar");
+    }
+
+    #[test]
+    fn seek_pattern_casei_literal_backref_with_anchor() {
+        // Group contains a case-insensitive literal and a start anchor.
+        // The anchor is dropped during backref inlining; the casei literal emits (?i:...).
+        assert_eq!(get_seek_pattern(r"(?i:(^a))\1"), "(?:^(?i:a))(?:(?i:a))");
+    }
+
+    #[test]
+    fn seek_pattern_easy_expr_preserved() {
+        // An easy (non-hard) expression is serialised verbatim via to_str.
+        assert_eq!(get_seek_pattern(r"abc"), "abc");
+        assert_eq!(get_seek_pattern(r"a|b"), "a|b");
+        assert_eq!(get_seek_pattern(r"a+b*c?"), "a+b*c?");
+    }
+
+    #[test]
+    fn seek_pattern_end_text_ignore_trailing_newlines_non_crlf() {
+        // \Z (non-CRLF mode) — approximate with `\n*$` so the seek only visits positions
+        // near end-of-text.
+        assert_eq!(get_seek_pattern(r"abc\Z"), r"abc\n*$");
+    }
+
+    #[test]
+    fn seek_pattern_end_text_ignore_trailing_newlines_crlf() {
+        // \Z in CRLF mode — approximate with `(?:\r?\n)*$`.
+        assert_eq!(get_seek_pattern(r"(?R)abc\Z"), r"abc[\r\n]*$");
+    }
+
+    #[test]
+    fn seek_pattern_end_text_ignore_trailing_newlines_only() {
+        // \Z alone (hard assertion) — just the seek pattern with no surrounding literal.
+        assert_eq!(get_seek_pattern(r"\Z"), r"\n*$");
+    }
+
+    #[test]
+    fn seek_pattern_backref_with_end_text_ignore_trailing_newlines() {
+        // Backref to a group that ends with \Z: \Z is a positional anchor and should be
+        // dropped when inlining the group body for the backref.
+        // `(a\Z)\1` — seek = `(?:a\n*$)` (group) + `(?:a\n*)` (backref, \Z anchor dropped, newline matching kept)
+        assert_eq!(get_seek_pattern(r"(a\Z)\1"), r"(?:a\n*$)(?:a\n*)");
+    }
+}

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -52,9 +52,7 @@ pub(crate) fn expr_contains_positional_anchor(expr: &Expr) -> bool {
             | Assertion::StartLine { .. }
             | Assertion::EndLine { .. },
         ) => true,
-        _ => expr
-            .children_iter()
-            .any(|child| expr_contains_positional_anchor(child)),
+        _ => expr.children_iter().any(expr_contains_positional_anchor),
     }
 }
 
@@ -368,7 +366,7 @@ pub(crate) fn build_seek_pattern_impl<'a>(
             let mut cond_pat = String::new();
             let mut true_pat = String::new();
             let mut false_pat = String::new();
-            if info.children.len() >= 1 {
+            if !info.children.is_empty() {
                 build_seek_pattern_impl(
                     &info.children[0],
                     group_info_map,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -170,6 +170,24 @@ impl core::fmt::Debug for Delegate {
     }
 }
 
+/// Seek pre-filter: find the next plausible match position using a simplified approximation of the
+/// pattern, then hand off to the backtracking VM at that position.
+pub struct Seek {
+    /// The compiled seek pre-filter regex (un-anchored, finds leftmost match).
+    pub inner: Regex,
+    /// The seek-pattern string (for debug display).
+    pub pattern: String,
+}
+
+impl core::fmt::Debug for Seek {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        // Ensures it fails to compile if the struct changes
+        let Self { inner: _, pattern } = self;
+
+        f.debug_struct("Seek").field("pattern", pattern).finish()
+    }
+}
+
 #[cfg(feature = "variable-lookbehinds")]
 /// Delegate matching in reverse to regex-automata
 pub struct ReverseBackwardsDelegate {
@@ -327,6 +345,17 @@ pub enum Insn {
     BackwardsDelegate(ReverseBackwardsDelegate),
     /// Absent repeater operator - matches if delegate does not match from current position
     AbsentRepeater(Delegate),
+    /// Seek pre-filter: advance `ix` to the next position where the pattern could plausibly match,
+    /// using an over-approximating regular expression.  Replaces the `SplitUnanchored` / `Any` /
+    /// `Jmp` preamble for hard patterns when a useful seek approximation is available.
+    ///
+    /// Execution:
+    /// 1. Search `s[ix..]` un-anchored for the seek regex.
+    /// 2. If no match exists, return `None` immediately (the full pattern can never match).
+    /// 3. Otherwise push a backtrack branch `(pc, next_seek_start)` where `next_seek_start` is
+    ///    one codepoint past the match start (or end for zero-width matches), set
+    ///    `match_attempt_start = m.start()`, and continue from `pc+1` with `ix = m.start()`.
+    Seek(Seek),
 }
 
 /// Sequence of instructions for the VM to execute.
@@ -1062,11 +1091,48 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                         // instead of checking at each position in the haystack
                         // because \G will never match at any other position
                         if at_start && state.stack.len() == 1 {
-                            // The only item on the stack is from the SplitUnanchored instruction for non-anchored search
-                            // We can safely return None immediately
+                            // The only item on the stack is from the SplitUnanchored (or Seek)
+                            // instruction for non-anchored search.
+                            // We can safely return None immediately.
                             return Ok(None);
                         }
                         break 'fail;
+                    }
+                }
+                Insn::Seek(Seek { ref inner, .. }) => {
+                    // A sentinel value greater than s.len() is pushed onto the backtrack stack
+                    // when the seek found a zero-width match at end-of-string.  On re-entry with
+                    // that sentinel, there are no more positions to try.
+                    if ix > s.len() {
+                        return Ok(None);
+                    }
+
+                    let input = Input::new(s.as_bytes()).span(ix..s.len());
+                    match inner.search(&input) {
+                        None => return Ok(None),
+                        Some(m) => {
+                            // Compute the next position to retry the seek from on backtrack:
+                            // one codepoint past the start of this match (or past the end for
+                            // zero-width matches) so we make progress.
+                            let next_seek_start = if m.start() == m.end() {
+                                if m.end() < s.len() {
+                                    m.end() + codepoint_len_at(s, m.end())
+                                } else {
+                                    // Zero-width match at end-of-string.  Push a sentinel value
+                                    // (s.len() + 1) so that if the main pattern fails and we
+                                    // backtrack here, the `ix > s.len()` guard above returns None
+                                    // immediately instead of looping.
+                                    s.len() + 1
+                                }
+                            } else {
+                                m.start() + codepoint_len_at(s, m.start())
+                            };
+                            state.push(pc, next_seek_start)?;
+                            ix = m.start();
+                            match_attempt_start = ix;
+                            pc += 1;
+                            continue;
+                        }
                     }
                 }
             }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1062,3 +1062,84 @@ fn find_match<'t>(re: &str, text: &'t str) -> Option<Match<'t>> {
     );
     result.unwrap()
 }
+
+/// Build a regex with the seek pre-filter enabled.
+fn seek_regex(re: &str) -> fancy_regex::Regex {
+    let result = RegexBuilder::new(re).seek(true).build();
+    assert!(
+        result.is_ok(),
+        "Expected regex '{}' to compile successfully with seek enabled, got {:?}",
+        re,
+        result.err()
+    );
+    result.unwrap()
+}
+
+/// Assert that `seek(true)` produces the same first match as the default.
+fn assert_seek_same(re: &str, text: &str) {
+    let default_result = common::regex(re).find(text).unwrap();
+    let seek_result = seek_regex(re).find(text).unwrap();
+    assert_eq!(
+        default_result.map(|m| (m.start(), m.end())),
+        seek_result.map(|m| (m.start(), m.end())),
+        "seek=true gave different result for /{re}/ on {:?}",
+        text
+    );
+}
+
+#[test]
+fn seek_backref_finds_match() {
+    // The seek pattern inlines the group body ("abc") and jumps past irrelevant text.
+    assert_seek_same(r"(abc)\1", "xxxabcabcyyy");
+    assert_seek_same(r"(abc)\1", "xabcabcx");
+}
+
+#[test]
+fn seek_backref_no_match() {
+    assert_seek_same(r"(abc)\1", "xxxyyy");
+    assert_seek_same(r"(abc)\1", "abcxabc");
+}
+
+#[test]
+fn seek_matches_identical_to_default() {
+    let cases: &[(&str, &str)] = &[
+        // backref patterns
+        (r"(\w+) \1", "hello hello world"),
+        (r"(\w+) \1", "no match here"),
+        (r"(a|b)\1", "aabb"),
+        // lookahead
+        (r"foo(?=bar)", "foobar"),
+        (r"foo(?=bar)", "foobaz"),
+        // lookbehind
+        (r"(?<=foo)bar", "foobar"),
+        (r"(?<=foo)bar", "bazbar"),
+        // long haystack with rare match
+        (
+            r"(xyz)\1",
+            &format!("{}{}", "abcdefghij".repeat(1000), "xyzxyz"),
+        ),
+        // long haystack with no match
+        (r"(xyz)\1", &"abcdefghij".repeat(1000)),
+    ];
+    for (re, text) in cases {
+        assert_seek_same(re, text);
+    }
+}
+
+#[test]
+fn seek_find_iter_matches_identical_to_default() {
+    let re = r"(\w+) \1";
+    let text = "the the cat sat on on the mat mat";
+
+    let default_matches: Vec<_> = common::regex(re)
+        .find_iter(text)
+        .map(|m| m.unwrap())
+        .map(|m| (m.start(), m.end()))
+        .collect();
+    let seek_matches: Vec<_> = seek_regex(re)
+        .find_iter(text)
+        .map(|m| m.unwrap())
+        .map(|m| (m.start(), m.end()))
+        .collect();
+    assert_eq!(default_matches, seek_matches);
+}

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -111,8 +111,12 @@ fn atomic_group() {
 
 #[test]
 fn backtrack_limit() {
+    // Disable the seek pre-filter so the backtracking VM actually explores all positions and
+    // hits the limit.  With seek enabled the engine would correctly determine there is no `c`
+    // in the haystack and return `None` immediately without backtracking.
     let re = RegexBuilder::new(r"(?i)(a|b|ab)*(?>c)")
         .backtrack_limit(100_000)
+        .seek(false)
         .build()
         .expect("regex to compile successfully");
     let s = "abababababababababababababababababababababababababababab";

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -110,7 +110,7 @@ fn atomic_group() {
 }
 
 #[test]
-fn backtrack_limit() {
+fn backtrack_limit_hit_when_not_seeking() {
     // Disable the seek pre-filter so the backtracking VM actually explores all positions and
     // hits the limit.  With seek enabled the engine would correctly determine there is no `c`
     // in the haystack and return `None` immediately without backtracking.
@@ -140,6 +140,34 @@ fn backtrack_limit() {
         Some(Error::RuntimeError(RuntimeError::BacktrackLimitExceeded)) => {}
         _ => panic!("Expected RuntimeError::BacktrackLimitExceeded"),
     }
+}
+
+#[test]
+fn backtrack_limit_not_applicable_when_seeking() {
+    // Enable the seek pre-filter so the backtracking VM would only explore all positions
+    // which could match.  With seek enabled the engine will correctly determine there is no `c`
+    // in the haystack and return `None` immediately without backtracking.
+    let re = RegexBuilder::new(r"(?i)(a|b|ab)*(?>c)")
+        .backtrack_limit(1)
+        .seek(true)
+        .build()
+        .expect("regex to compile successfully");
+    let s = "abababababababababababababababababababababababababababab";
+    let result = re.is_match(s);
+    assert!(result.is_ok());
+    assert!(!result.unwrap());
+}
+
+#[test]
+fn can_find_matches_when_seeking() {
+    let re = RegexBuilder::new(r"(abc|def)\1")
+        .seek(true)
+        .build()
+        .expect("regex to compile successfully");
+    let s = "abcdefabcdefabcdefdef";
+    let result = re.is_match(s);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
 }
 
 #[test]


### PR DESCRIPTION
fixes #101 

Implements a Seek pre-filter optimization. It derives a regular approximation of the pattern and uses it to skip directly to the earliest/next plausible match position in the haystack, so the backtracking VM only needs to run from that position onward. For patterns where the hard parts leave useful literals or anchors in the approximation - for example, anchored patterns like `(.{5})\1$` - the `Seek` pre-filter can dramatically reduce the number of positions the VM tries.

While the goal is that the seek pattern would always be a conservative over-approximation, and may report false-positive positions but never skip a true match, it is currently disabled by default, and opt-in only, because it isn't battle tested. (For example, right now, it could accidentally skip matches or perform worse with certain patterns and haystack combinations.) If you are willing to try it, please let us know how you get on!

Currently it decides whether seeking for a pattern is worth it by checking for literals or anchors in the approximation pattern. If no such nodes are found, it will resort to the older checking every position in the haystack approach. The function/callback it uses to check the seek pattern is controllable, so feel free to experiment.