### PR TITLE
add special mode to ignore trailing newline in the haystack

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -50,6 +50,7 @@ pub struct RegexFlags {
     pub oniguruma_mode: bool,
     pub find_not_empty: bool,
     pub ignore_numbered_groups_when_named_groups_exist: bool,
+    pub ignore_trailing_newline: bool,
 }
 
 impl Default for RegexFlags {
@@ -63,6 +64,7 @@ impl Default for RegexFlags {
             oniguruma_mode: true,
             find_not_empty: false,
             ignore_numbered_groups_when_named_groups_exist: false,
+            ignore_trailing_newline: false,
         }
     }
 }
@@ -90,6 +92,7 @@ fn build_regex(pattern: &str, flags: &RegexFlags) -> Result<Regex, String> {
     builder.ignore_numbered_groups_when_named_groups_exist(
         flags.ignore_numbered_groups_when_named_groups_exist,
     );
+    builder.disallow_empty_match_at_eof_after_newline(flags.ignore_trailing_newline);
 
     builder
         .build()
@@ -205,6 +208,7 @@ pub fn analyze_regex(pattern: &str, flags: JsValue) -> Result<String, String> {
                 AnalyzeContext {
                     explicit_capture_group_0: requires_capture_group_fixup,
                     find_not_empty: flags.find_not_empty,
+                    disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
                 },
             ) {
                 Ok(info) => Ok(format!("{:#?}", info)),
@@ -478,6 +482,7 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
                 AnalyzeContext {
                     explicit_capture_group_0: requires_capture_group_fixup,
                     find_not_empty: flags.find_not_empty,
+                    disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
                 },
             ) {
                 Ok(info) => {

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -40,6 +40,7 @@ class FancyRegexPlayground {
                 findNotEmpty: document.getElementById('flag-find-not-empty'),
                 ignoreNumberedGroups: document.getElementById('flag-ignore-numbered-groups'),
                 unicode: document.getElementById('flag-unicode'),
+                ignoreTrailingNewline: document.getElementById('flag-no-match-at-trailing-newline'),
             }
         };
 
@@ -78,6 +79,7 @@ class FancyRegexPlayground {
             oniguruma_mode: this.elements.flags.onigurumaMode.checked,
             find_not_empty: this.elements.flags.findNotEmpty.checked,
             ignore_numbered_groups_when_named_groups_exist: this.elements.flags.ignoreNumberedGroups.checked,
+            ignore_trailing_newline: this.elements.flags.ignoreTrailingNewline.checked,
         };
     }
 

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -58,6 +58,10 @@
                             <input type="checkbox" id="flag-unicode" checked="checked" />
                             <label for="flag-unicode">Unicode</label>
                         </div>
+                        <div class="flag-group flag-group--wide">
+                            <input type="checkbox" id="flag-no-match-at-trailing-newline" />
+                            <label for="flag-no-match-at-trailing-newline">Ignore trailing newline in multi-line mode</label>
+                        </div>
                     </div>
                 </div>
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -31,7 +31,7 @@ use bit_set::BitSet;
 use crate::alloc::string::ToString;
 use crate::parse::ExprTree;
 use crate::vm::CaptureGroupRange;
-use crate::{AstNode, CaptureGroupTarget, CompileError, Error, Expr, Result};
+use crate::{Assertion, AstNode, CaptureGroupTarget, CompileError, Error, Expr, Result};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as Map;
@@ -130,6 +130,9 @@ struct Analyzer<'a> {
     /// When true, nodes that could produce empty matches (min size 0 and not const size)
     /// are promoted to hard so the VM can backtrack past them to find a non-empty match.
     find_not_empty: bool,
+    /// When true, nodes that could produce empty matches (min size 0 and not const size)
+    /// are promoted to hard so the VM can ensure the whole match at EOF isn't empty.
+    disallow_empty_match_at_eof_after_newline: bool,
 }
 
 impl<'a> Analyzer<'a> {
@@ -152,6 +155,12 @@ impl<'a> Analyzer<'a> {
             Expr::Assertion(assertion) if assertion.is_hard() => {
                 const_size = true;
                 hard = true;
+            }
+            Expr::Assertion(Assertion::EndText)
+                if self.disallow_empty_match_at_eof_after_newline =>
+            {
+                const_size = true;
+                hard = true; // NOTE: \Z is already considered hard and covered in the branch above
             }
             Expr::Empty | Expr::Assertion(_) => {
                 const_size = true;
@@ -785,12 +794,15 @@ pub struct AnalyzeContext {
     /// `const_size`) are promoted to `hard` so that the VM can backtrack past them to find a
     /// non-empty match.
     pub find_not_empty: bool,
+    /// To match Oniguruma behavior where only \z can match at EOF if preceeded by a newline character
+    pub disallow_empty_match_at_eof_after_newline: bool,
 }
 
 /// Analyze the parsed expression to determine whether it requires fancy features.
 pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> {
     let explicit_capture_group_0 = ctx.explicit_capture_group_0;
     let find_not_empty = ctx.find_not_empty;
+    let disallow_empty_match_at_eof_after_newline = ctx.disallow_empty_match_at_eof_after_newline;
 
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
     if tree.numbered_groups_ignored
@@ -823,9 +835,10 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
         group_exprs,
         analyzing_groups: BitSet::new(),
         find_not_empty,
+        disallow_empty_match_at_eof_after_newline,
     };
 
-    let analyzed = analyzer.visit(&tree.expr, 0, false, 0)?;
+    let mut analyzed = analyzer.visit(&tree.expr, 0, false, 0)?;
     // With start_group == 1 (no explicit group 0) the valid backref range is 1..=total_groups.
     // With start_group == 0 (explicit group 0) group 0 is the whole match and inner groups are
     // numbered 1..=total_groups-1, so the valid range is 0..=total_groups-1.
@@ -853,6 +866,10 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
     if tree.contains_subroutines {
         analyzer.check_left_recursion(&tree.named_groups)?;
         analyzer.check_unbounded_recursion(&tree.expr)?;
+    }
+
+    if analyzed.min_size == 0 && disallow_empty_match_at_eof_after_newline {
+        analyzed.hard = true;
     }
 
     Ok(analyzed)

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -949,17 +949,16 @@ pub(crate) fn options_to_rabuilder(options: &RegexOptions) -> RaBuilder {
 
     let mut builder = RaBuilder::new();
     builder.configure(config);
-
+    // NOTE: we deliberately don't configure the regex syntax because we rely on our Expr to_str function
+    //       to handle creating the correct string for regex-automata
+    //       otherwise, if the RegexOptions specifies case insensitive mode, then the pattern contains an explicit
+    //       (?-i) flag, then that flag would effectively be ignored unless to_str would encode the flag for every
+    //       node, even when it is the default, which feels like a waste.
     let utf8 = matches!(options.bytes_mode, BytesMode::Unicode);
 
     let syntax = SyntaxConfig::new()
         .utf8(utf8)
-        .unicode(options.syntaxc.get_unicode() && !matches!(options.bytes_mode, BytesMode::Ascii))
-        .case_insensitive(options.syntaxc.get_case_insensitive())
-        .multi_line(options.syntaxc.get_multi_line())
-        .dot_matches_new_line(options.syntaxc.get_dot_matches_new_line())
-        .crlf(options.syntaxc.get_crlf())
-        .ignore_whitespace(options.syntaxc.get_ignore_whitespace());
+        .unicode(options.syntaxc.get_unicode() && !matches!(options.bytes_mode, BytesMode::Ascii));
     builder.syntax(syntax);
 
     builder
@@ -998,6 +997,8 @@ pub struct CompileOptions {
     /// to decide whether it is useful enough to replace the `SplitUnanchored` preamble with a
     /// `Seek` instruction. When `None`, seek is disabled entirely.
     pub seek_filter: Option<fn(&str) -> bool>,
+    /// To match Oniguruma behavior where only \z can match at EOF if preceeded by a newline character
+    pub disallow_empty_match_at_eof_after_newline: bool,
 }
 
 impl core::fmt::Debug for CompileOptions {
@@ -1013,6 +1014,10 @@ impl core::fmt::Debug for CompileOptions {
             .field("anchored", &self.anchored)
             .field("contains_subroutines", &self.contains_subroutines)
             .field("seek_filter", &seek_filter_desc)
+            .field(
+                "disallow_empty_match_at_eof_after_newline",
+                &self.disallow_empty_match_at_eof_after_newline,
+            )
             .finish()
     }
 }
@@ -1079,6 +1084,9 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
     if info.start_group() == 1 {
         // add implicit capture group 0 end
         c.b.add(Insn::Save(1));
+    }
+    if options.disallow_empty_match_at_eof_after_newline {
+        c.b.add(Insn::RejectEmptyMatchAtEOFFollowingNewline);
     }
     c.b.add(Insn::End);
     Ok(c.b.build())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,6 +554,7 @@ impl Default for RegexOptions {
 struct HardRegexRuntimeOptions {
     backtrack_limit: usize,
     find_not_empty: bool,
+    disallow_empty_match_at_eof_after_newline: bool,
 }
 
 impl RegexOptions {
@@ -595,6 +596,7 @@ impl Default for HardRegexRuntimeOptions {
         HardRegexRuntimeOptions {
             backtrack_limit: 1_000_000,
             find_not_empty: false,
+            disallow_empty_match_at_eof_after_newline: false,
         }
     }
 }
@@ -827,7 +829,7 @@ impl RegexOptionsBuilder {
         self
     }
 
-    /// Attempts to better match [Oniguruma](https://github.com/kkos/oniguruma)'s default behavior
+    /// Attempts to better match [Oniguruma](https://github.com/kkos/oniguruma)'s default parsing behavior
     ///
     /// Currently this amounts to changing behavior with:
     ///
@@ -894,6 +896,17 @@ impl RegexOptionsBuilder {
     /// ```
     pub fn bytes_mode(&mut self, mode: BytesMode) -> &mut Self {
         self.options.bytes_mode = mode;
+        self
+    }
+
+    /// Sometimes you want to pass in a haystack containing a trailing newline,
+    /// and have that last position ignored for the purposes of anchors like ^ and $
+    /// and even for lookarounds, unless \z is specifically used to anchor to the end of the string.
+    /// This is how Oniguruma works for example.
+    pub fn disallow_empty_match_at_eof_after_newline(&mut self, yes: bool) -> &mut Self {
+        self.options
+            .hard_regex_runtime_options
+            .disallow_empty_match_at_eof_after_newline = yes;
         self
     }
 }
@@ -1017,6 +1030,12 @@ impl RegexBuilder {
         self.options.seek_filter(filter);
         self
     }
+
+    /// See [`RegexOptionsBuilder::disallow_empty_match_at_eof_after_newline`]
+    pub fn disallow_empty_match_at_eof_after_newline(&mut self, yes: bool) -> &mut Self {
+        self.options.disallow_empty_match_at_eof_after_newline(yes);
+        self
+    }
 }
 
 impl fmt::Debug for Regex {
@@ -1054,6 +1073,9 @@ impl Regex {
         let mut tree = Expr::parse_tree_with_flags(&pattern, options.compute_flags())?;
 
         let find_not_empty = options.hard_regex_runtime_options.find_not_empty;
+        let disallow_empty_match_at_eof_after_newline = options
+            .hard_regex_runtime_options
+            .disallow_empty_match_at_eof_after_newline;
 
         let requires_capture_group_fixup = if find_not_empty {
             // if the find_not_empty flag is set, we skip optimizations
@@ -1071,6 +1093,7 @@ impl Regex {
             AnalyzeContext {
                 explicit_capture_group_0: requires_capture_group_fixup,
                 find_not_empty,
+                disallow_empty_match_at_eof_after_newline,
             },
         )?;
 
@@ -1103,6 +1126,7 @@ impl Regex {
                 anchored: can_compile_as_anchored(&tree.expr),
                 contains_subroutines: tree.contains_subroutines,
                 seek_filter: options.seek_filter,
+                disallow_empty_match_at_eof_after_newline,
             },
         )?;
         Ok(Regex {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -356,6 +356,10 @@ pub enum Insn {
     ///    one codepoint past the match start (or end for zero-width matches), set
     ///    `match_attempt_start = m.start()`, and continue from `pc+1` with `ix = m.start()`.
     Seek(Seek),
+    /// For compatibility with Oniguruma, which ignores empty matches at the end of the input
+    /// if the previous character was a line break. So ^/$ and (?=) all fail to match, unless
+    /// \z was used and matched at this position.
+    RejectEmptyMatchAtEOFFollowingNewline,
 }
 
 /// Sequence of instructions for the VM to execute.
@@ -703,6 +707,7 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
     let mut backtrack_count = 0;
     let mut pc = 0;
     let mut ix = pos;
+    let mut slash_z_matched = false;
     let mut match_attempt_start = pos;
     loop {
         // break from this loop to fail, causes stack to pop
@@ -768,10 +773,14 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                 Insn::Assertion(assertion) => {
                     if !match assertion {
                         Assertion::StartText => look_matcher.is_start(s.as_bytes(), ix),
-                        Assertion::EndText => look_matcher.is_end(s.as_bytes(), ix),
+                        Assertion::EndText => {
+                            let matched = look_matcher.is_end(s.as_bytes(), ix);
+                            slash_z_matched |= matched;
+                            matched
+                        }
                         Assertion::EndTextIgnoreTrailingNewlines { crlf } => {
                             let bytes = s.as_bytes();
-                            if ix == bytes.len() {
+                            let matched = if ix == bytes.len() {
                                 // At the end of string
                                 true
                             } else if crlf {
@@ -780,7 +789,9 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                             } else {
                                 // Check if all remaining bytes are newlines
                                 bytes[ix..].iter().all(|&b| b == b'\n')
-                            }
+                            };
+                            slash_z_matched |= matched;
+                            matched
                         }
                         Assertion::StartLine { crlf: false } => {
                             look_matcher.is_start_lf(s.as_bytes(), ix)
@@ -823,6 +834,7 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                 }
                 Insn::SplitUnanchored(x, y) => {
                     match_attempt_start = ix;
+                    slash_z_matched = false;
                     state.push(y, ix)?;
                     pc = x;
                     continue;
@@ -1130,9 +1142,20 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                             state.push(pc, next_seek_start)?;
                             ix = m.start();
                             match_attempt_start = ix;
+                            slash_z_matched = false;
                             pc += 1;
                             continue;
                         }
+                    }
+                }
+                Insn::RejectEmptyMatchAtEOFFollowingNewline => {
+                    if ix == s.len()
+                        && ix > 0
+                        && matches_literal(s, ix - 1, ix, b"\n")
+                        && !slash_z_matched
+                        && match_attempt_start == ix
+                    {
+                        break 'fail;
                     }
                 }
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -226,3 +226,12 @@ pub fn assert_captures<'t>(re: &str, text: &'t str) -> Option<Captures<'t, str>>
     }
     str_result
 }
+
+use std::fmt;
+#[allow(dead_code)]
+pub struct DebugRegex<'a>(pub &'a Regex);
+impl fmt::Display for DebugRegex<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.debug_print(f)
+    }
+}

--- a/tests/regex_options.rs
+++ b/tests/regex_options.rs
@@ -1,5 +1,7 @@
 use fancy_regex::{CompileError, Error, ParseError, Regex, RegexBuilder};
 
+mod common;
+
 fn build_regex(builder: &RegexBuilder) -> Regex {
     let result = builder.build();
     assert!(
@@ -25,6 +27,12 @@ fn check_override_casing_option() {
     assert!(!regex.is_match("FoObarQuUx").unwrap_or_default());
     assert!(!regex.is_match("fooBARquux").unwrap_or_default());
     assert!(regex.is_match("FOObarquux").unwrap_or_default());
+
+    let regex = build_regex(RegexBuilder::new(r"FOO(?-i:bar)quux").case_insensitive(true));
+
+    assert!(regex.is_match("FoObarQuUx").unwrap_or_default());
+    assert!(!regex.is_match("fooBARquux").unwrap_or_default());
+    assert!(regex.is_match("FOObarquuX").unwrap_or_default());
 }
 
 #[test]
@@ -36,12 +44,25 @@ fn check_casing_insensitive_option() {
 
 #[test]
 fn check_multi_line_option() {
-    let test_text = r"test
-hugo
-test";
+    let test_text = "test\nhugo\ntest";
 
     let regex = build_regex(RegexBuilder::new(r"^test$").multi_line(true));
     assert!(regex.is_match(test_text).unwrap_or_default());
+
+    let test_text = "foo\nbar\ntest";
+
+    let regex = build_regex(RegexBuilder::new(r"^test\z").multi_line(true));
+    assert!(regex.is_match(test_text).unwrap_or_default());
+
+    let test_text = "foo\nbar\ntest";
+
+    let regex = build_regex(RegexBuilder::new(r"^foo\z").multi_line(true));
+    assert!(!regex.is_match(test_text).unwrap_or_default());
+
+    let regex = build_regex(RegexBuilder::new(r"^foo\z").multi_line(false));
+    assert!(!regex.is_match(test_text).unwrap_or_default());
+    let regex = build_regex(RegexBuilder::new(r"^foo$").multi_line(false));
+    assert!(!regex.is_match(test_text).unwrap_or_default());
 }
 
 #[test]
@@ -311,13 +332,7 @@ fn check_find_not_empty_is_match() {
 #[test]
 fn check_find_not_empty_allows_trailing_lookahead_with_content() {
     // a?(?=b) optimizes to (a?)b — group 0 is "a?" which is not always empty, so it should compile
-    let result = RegexBuilder::new(r"a(?=b)").find_not_empty(true).build();
-    assert!(
-        result.is_ok(),
-        "Expected a?(?=b) to compile with find_not_empty"
-    );
-
-    let regex = result.unwrap();
+    let regex = build_regex(RegexBuilder::new(r"a(?=b)").find_not_empty(true));
     assert!(regex.is_match("ab").unwrap());
     assert!(!regex.is_match("ac").unwrap());
 }
@@ -490,4 +505,77 @@ fn unicode_mode_false_hard_pattern_w_is_ascii_only_on_str() {
     assert!(!re_ascii.is_match("café!").unwrap());
     // Pure-ASCII input still matches with unicode disabled.
     assert!(re_ascii.is_match("cafe!").unwrap());
+}
+
+#[test]
+fn disallow_empty_match_at_eof_after_newline_does_as_it_says() {
+    fn find_all_matches(regex: &Regex, text: &'static str) -> Vec<usize> {
+        regex.find_iter(text).map(|m| m.unwrap().start()).collect()
+    }
+
+    fn create_regex(pattern: &str, disallow: bool) -> Regex {
+        let regex = build_regex(
+            RegexBuilder::new(pattern)
+                .multi_line(true)
+                .disallow_empty_match_at_eof_after_newline(disallow),
+        );
+        println!("{}", common::DebugRegex(&regex));
+        regex
+    }
+
+    let haystack = "a\nb\n";
+    assert_eq!(
+        find_all_matches(&create_regex(r"^", true), haystack),
+        [0, 2]
+    );
+    assert_eq!(
+        find_all_matches(&create_regex(r"$", true), haystack),
+        [1, 3]
+    );
+    assert_eq!(
+        find_all_matches(&create_regex(r"(?=)", true), haystack),
+        [0, 1, 2, 3]
+    );
+
+    // to demonstrate the difference, here is how it looks without this option
+    assert_eq!(
+        find_all_matches(&create_regex(r"^", false), haystack),
+        [0, 2, 4]
+    );
+    assert_eq!(
+        find_all_matches(&create_regex(r"$", false), haystack),
+        [1, 3, 4]
+    );
+    assert_eq!(
+        find_all_matches(&create_regex(r"(?=)", false), haystack),
+        [0, 1, 2, 3, 4]
+    );
+}
+
+#[test]
+fn disallow_empty_match_at_eof_after_newline_still_allows_slash_z() {
+    fn find_all_matches(regex: &Regex, text: &'static str) -> Vec<usize> {
+        // only collect the start of the match because they are empty anyway
+        regex.find_iter(text).map(|m| m.unwrap().start()).collect()
+    }
+
+    fn create_regex(pattern: &str, disallow: bool) -> Regex {
+        let regex = build_regex(
+            RegexBuilder::new(pattern)
+                .multi_line(true)
+                .disallow_empty_match_at_eof_after_newline(disallow),
+        );
+        println!("{}", common::DebugRegex(&regex));
+        regex
+    }
+
+    let haystack = "a\nb\n";
+    assert_eq!(find_all_matches(&create_regex(r"\z", true), haystack), [4]);
+    assert_eq!(find_all_matches(&create_regex(r"$\z", true), haystack), [4]);
+
+    assert_eq!(find_all_matches(&create_regex(r"\z", false), haystack), [4]);
+    assert_eq!(
+        find_all_matches(&create_regex(r"$\z", false), haystack),
+        [4]
+    );
 }


### PR DESCRIPTION
add special mode to ignore trailing newline in the haystack, for compatibility with Oniguruma. It is under a separate option in case it is desirable to have Oniguruma parsing rules but not Oniguruma matching rules - especially as patterns which would not normally be considered hard and can return empty matches have to become hard in order to determine whether `\z` was used and matched. Recommended to be used with the seek mode to not hurt performance.

also fixes a bug whereby i.e. a case insensitive option specified on the builder could not be overridden by inline flags in the pattern