### PR TITLE
Add capabilities to the Playground to make patterns and inputs easily shareable

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -81,7 +81,7 @@ Supported parameters:
   - `u`: unicode
   - `O`: oniguruma mode
   - `N`: find not empty
-  - `R`: ignore numbered groups when named groups exist
+  - `G`: ignore numbered groups when named groups exist
   - `T`: ignore trailing newline
 
 ## 🏗️ Architecture

--- a/playground/README.md
+++ b/playground/README.md
@@ -16,6 +16,7 @@ A browser-based interactive playground for testing and exploring the [fancy-rege
 - **Analysis Output**: See detailed analysis information about your regex pattern
 - **Error Handling**: Clear error messages for invalid patterns or runtime errors
 - **Debounced Updates**: Smooth real-time updates with debouncing to prevent excessive computation
+- **Sharable URLs**: Load/save pattern, haystack, and flag settings via query parameters
 - **Responsive Design**: Works well on desktop and mobile devices
 
 ## 🚀 Quick Start
@@ -63,6 +64,25 @@ A browser-based interactive playground for testing and exploring the [fancy-rege
 - Pattern: `\w+(?=\s+world)`
 - Text: `hello world goodbye moon`
 - Result: Matches "hello" (word followed by " world")
+
+### Share Playground State with URL Parameters
+
+Click **Update share URL** to write current state into the address bar so it can be copy/pasted.
+
+Supported parameters:
+
+- `pattern`: regex pattern input
+- `text`: haystack/test text input
+- Flag booleans (accepts `1/0`, `true/false`, `yes/no`, `on/off`):
+  - `i`: case-insensitive
+  - `m`: multi-line
+  - `s`: dot matches newline
+  - `x`: ignore whitespace
+  - `u`: unicode
+  - `O`: oniguruma mode
+  - `N`: find not empty
+  - `R`: ignore numbered groups when named groups exist
+  - `T`: ignore trailing newline in multi-line mode
 
 ## 🏗️ Architecture
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -82,7 +82,7 @@ Supported parameters:
   - `O`: oniguruma mode
   - `N`: find not empty
   - `R`: ignore numbered groups when named groups exist
-  - `T`: ignore trailing newline in multi-line mode
+  - `T`: ignore trailing newline
 
 ## 🏗️ Architecture
 

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -101,7 +101,7 @@ class FancyRegexPlayground {
             { param: 'u', key: 'unicode', element: this.elements.flags.unicode },
             { param: 'O', key: 'oniguruma_mode', element: this.elements.flags.onigurumaMode },
             { param: 'N', key: 'find_not_empty', element: this.elements.flags.findNotEmpty },
-            { param: 'R', key: 'ignore_numbered_groups_when_named_groups_exist', element: this.elements.flags.ignoreNumberedGroups },
+            { param: 'G', key: 'ignore_numbered_groups_when_named_groups_exist', element: this.elements.flags.ignoreNumberedGroups },
             { param: 'T', key: 'ignore_trailing_newline', element: this.elements.flags.ignoreTrailingNewline },
         ];
     }

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -50,7 +50,7 @@ class FancyRegexPlayground {
         this.defaultFlags = this.getFlags();
         this.setupEventListeners();
         if (this.loadStateFromUrl()) {
-            setTimeout(() => this.updateResults(), 100);
+            this.updateResults();
         } else {
             this.loadExampleData();
         }
@@ -146,8 +146,6 @@ class FancyRegexPlayground {
         }
 
         flagConfig.forEach(cfg => {
-            cfg.element.checked = this.defaultFlags[cfg.key];
-
             let rawValue = null;
             if (params.has(cfg.param)) {
                 rawValue = params.get(cfg.param);
@@ -156,9 +154,7 @@ class FancyRegexPlayground {
             }
 
             const parsedValue = this.parseBooleanQueryParam(rawValue);
-            if (parsedValue !== null) {
-                cfg.element.checked = parsedValue;
-            }
+            cfg.element.checked = parsedValue !== null ? parsedValue : this.defaultFlags[cfg.key];
         });
 
         return true;

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -139,10 +139,10 @@ class FancyRegexPlayground {
         }
 
         if (params.has('pattern')) {
-            this.elements.regexInput.value = params.get('pattern') ?? '';
+            this.elements.regexInput.value = params.get('pattern');
         }
         if (params.has('text')) {
-            this.elements.textInput.value = params.get('text') ?? '';
+            this.elements.textInput.value = params.get('text');
         }
 
         flagConfig.forEach(cfg => {

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -10,7 +10,9 @@ class FancyRegexPlayground {
     constructor() {
         this.isInitialized = false;
         this.debounceTimer = null;
+        this.shareUrlFeedbackTimer = null;
         this.elements = {};
+        this.defaultFlags = null;
         this.lastResults = null;
     }
 
@@ -29,6 +31,7 @@ class FancyRegexPlayground {
             parseTreeDisplay: document.getElementById('parse-tree-display'),
             analysisSection: document.getElementById('analysis-section'),
             analysisDisplay: document.getElementById('analysis-display'),
+            updateUrlBtn: document.getElementById('update-url'),
             showParseTreeBtn: document.getElementById('show-parse-tree'),
             showAnalysisBtn: document.getElementById('show-analysis'),
             flags: {
@@ -44,8 +47,13 @@ class FancyRegexPlayground {
             }
         };
 
+        this.defaultFlags = this.getFlags();
         this.setupEventListeners();
-        this.loadExampleData();
+        if (this.loadStateFromUrl()) {
+            setTimeout(() => this.updateResults(), 100);
+        } else {
+            this.loadExampleData();
+        }
     }
 
     setupEventListeners() {
@@ -59,6 +67,7 @@ class FancyRegexPlayground {
         });
 
         // Toggle button handlers
+        this.elements.updateUrlBtn.addEventListener('click', () => this.updateUrlWithCurrentState());
         this.elements.showParseTreeBtn.addEventListener('click', () => this.toggleParseTree());
         this.elements.showAnalysisBtn.addEventListener('click', () => this.toggleAnalysis());
     }
@@ -81,6 +90,108 @@ class FancyRegexPlayground {
             ignore_numbered_groups_when_named_groups_exist: this.elements.flags.ignoreNumberedGroups.checked,
             ignore_trailing_newline: this.elements.flags.ignoreTrailingNewline.checked,
         };
+    }
+
+    getFlagShareConfig() {
+        return [
+            { param: 'i', key: 'case_insensitive', element: this.elements.flags.caseInsensitive },
+            { param: 'm', key: 'multi_line', element: this.elements.flags.multiLine },
+            { param: 's', key: 'dot_matches_new_line', element: this.elements.flags.dotMatchesNewline },
+            { param: 'x', key: 'ignore_whitespace', element: this.elements.flags.ignoreWhitespace },
+            { param: 'u', key: 'unicode', element: this.elements.flags.unicode },
+            { param: 'O', key: 'oniguruma_mode', element: this.elements.flags.onigurumaMode },
+            { param: 'N', key: 'find_not_empty', element: this.elements.flags.findNotEmpty },
+            { param: 'R', key: 'ignore_numbered_groups_when_named_groups_exist', element: this.elements.flags.ignoreNumberedGroups },
+            { param: 'T', key: 'ignore_trailing_newline', element: this.elements.flags.ignoreTrailingNewline },
+        ];
+    }
+
+    parseBooleanQueryParam(value) {
+        if (value === null) {
+            return null;
+        }
+
+        switch (value.toLowerCase()) {
+            case '1':
+            case 'true':
+            case 'yes':
+            case 'on':
+                return true;
+            case '0':
+            case 'false':
+            case 'no':
+            case 'off':
+                return false;
+            default:
+                return null;
+        }
+    }
+
+    loadStateFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        const flagConfig = this.getFlagShareConfig();
+        const hasState = params.has('pattern')
+            || params.has('text')
+            || flagConfig.some(cfg => params.has(cfg.param) || params.has(cfg.key));
+
+        if (!hasState) {
+            return false;
+        }
+
+        if (params.has('pattern')) {
+            this.elements.regexInput.value = params.get('pattern') ?? '';
+        }
+        if (params.has('text')) {
+            this.elements.textInput.value = params.get('text') ?? '';
+        }
+
+        flagConfig.forEach(cfg => {
+            cfg.element.checked = this.defaultFlags[cfg.key];
+
+            let rawValue = null;
+            if (params.has(cfg.param)) {
+                rawValue = params.get(cfg.param);
+            } else if (params.has(cfg.key)) {
+                rawValue = params.get(cfg.key);
+            }
+
+            const parsedValue = this.parseBooleanQueryParam(rawValue);
+            if (parsedValue !== null) {
+                cfg.element.checked = parsedValue;
+            }
+        });
+
+        return true;
+    }
+
+    updateUrlWithCurrentState() {
+        const params = new URLSearchParams();
+        const pattern = this.elements.regexInput.value;
+        const text = this.elements.textInput.value;
+        const currentFlags = this.getFlags();
+
+        if (pattern !== '') {
+            params.set('pattern', pattern);
+        }
+        if (text !== '') {
+            params.set('text', text);
+        }
+
+        this.getFlagShareConfig().forEach(cfg => {
+            if (currentFlags[cfg.key] !== this.defaultFlags[cfg.key]) {
+                params.set(cfg.param, currentFlags[cfg.key] ? '1' : '0');
+            }
+        });
+
+        const query = params.toString();
+        const url = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+        window.history.replaceState({}, '', url);
+
+        clearTimeout(this.shareUrlFeedbackTimer);
+        this.elements.updateUrlBtn.textContent = 'URL updated!';
+        this.shareUrlFeedbackTimer = setTimeout(() => {
+            this.elements.updateUrlBtn.textContent = 'Update share URL';
+        }, 1500);
     }
 
     async updateResults() {

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -71,6 +71,7 @@
                 </div>
 
                 <div class="toggle-section">
+                    <button id="update-url" class="toggle-btn">Update share URL</button>
                     <button id="show-parse-tree" class="toggle-btn">Show parse tree</button>
                     <button id="show-analysis" class="toggle-btn">Show analysis</button>
                 </div>

--- a/playground/web/playground.css
+++ b/playground/web/playground.css
@@ -206,6 +206,9 @@ textarea:focus, input[type="text"]:focus {
 
 .toggle-section {
     margin-bottom: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .toggle-btn {
@@ -225,6 +228,14 @@ textarea:focus, input[type="text"]:focus {
 
 .toggle-btn.active {
     background: #27ae60;
+}
+
+#update-url {
+    background: #8e44ad;
+}
+
+#update-url:hover {
+    background: #7d3c98;
 }
 
 .hidden {
@@ -408,4 +419,3 @@ footer a {
 .analysis-children--collapsed {
     display: none;
 }
-


### PR DESCRIPTION
To make it easier to collaboratively debug patterns etc, it makes sense to add support to the playground for reading the pattern, input and flags from the query string and to add a button to update the query string based on the current input values, so it can easily be copy/pasted/shared