### PR TITLE
refactor how compile options are passed to the compiler and fix seek mode

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -124,18 +124,6 @@ struct Compiler<'a> {
 }
 
 impl<'a> Compiler<'a> {
-    #[cfg(test)]
-    fn new(max_group: usize) -> Compiler<'a> {
-        Compiler {
-            b: VMBuilder::new(max_group),
-            options: Default::default(),
-            inside_alternation: false,
-            group_info_map: Map::new(),
-            subroutine_recursion_stack: Vec::new(),
-            root_info: None,
-        }
-    }
-
     fn visit(&mut self, info: &Info<'_>, hard: bool) -> Result<()> {
         if !hard && !info.hard {
             // easy case, delegate entire subexpr
@@ -1193,8 +1181,7 @@ mod tests {
     use crate::analyze::{analyze, AnalyzeContext};
     use crate::parse::ExprTree;
     use crate::vm::Insn::*;
-    use alloc::vec;
-    use bit_set::BitSet;
+
     use matches::assert_matches;
 
     #[cfg_attr(feature = "track_caller", track_caller)]
@@ -1213,38 +1200,7 @@ mod tests {
 
     #[test]
     fn jumps_for_alternation() {
-        let tree = ExprTree {
-            expr: Expr::Alt(vec![
-                Expr::Literal {
-                    val: "a".into(),
-                    casei: false,
-                },
-                Expr::Literal {
-                    val: "b".into(),
-                    casei: false,
-                },
-                Expr::Literal {
-                    val: "c".into(),
-                    casei: false,
-                },
-            ]),
-            backrefs: BitSet::new(),
-            named_groups: Default::default(),
-            numeric_capture_group_references: false,
-            contains_subroutines: false,
-            self_recursive: false,
-            total_groups: 0,
-            out_of_range_backref: None,
-            numbered_groups_ignored: false,
-        };
-        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-
-        let mut c = Compiler::new(0);
-        // Force "hard" so that compiler doesn't just delegate
-        c.visit(&info, true).unwrap();
-        c.b.add(Insn::End);
-
-        let prog = c.b.prog;
+        let prog = compile_prog_forced_hard("a|b|c");
 
         assert_eq!(prog.len(), 8, "prog: {:?}", prog);
         assert_matches!(prog[0], Split(1, 3));
@@ -1847,40 +1803,72 @@ mod tests {
     }
 
     fn compile_prog(re: &str) -> Vec<Insn> {
-        let tree = Expr::parse_tree(re).unwrap();
-        let info = analyze(
-            &tree,
+        compile_prog_with(
+            re,
             AnalyzeContext {
                 explicit_capture_group_0: true,
                 ..Default::default()
             },
-        )
-        .unwrap();
-        let prog = compile(
-            &info,
-            CompileOptions {
-                anchored: true,
-                contains_subroutines: tree.contains_subroutines,
-                ..CompileOptions::default()
+            |info, tree| {
+                compile(
+                    info,
+                    CompileOptions {
+                        anchored: true,
+                        contains_subroutines: tree.contains_subroutines,
+                        ..CompileOptions::default()
+                    },
+                )
+                .unwrap()
+                .body
             },
         )
-        .unwrap();
-        prog.body
     }
 
     fn compile_prog_no_explicit_group0(re: &str) -> Vec<Insn> {
-        let tree = Expr::parse_tree(re).unwrap();
-        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        let prog = compile(
-            &info,
-            CompileOptions {
-                anchored: false,
-                contains_subroutines: tree.contains_subroutines,
-                ..CompileOptions::default()
+        compile_prog_with(re, AnalyzeContext::default(), |info, tree| {
+            compile(
+                info,
+                CompileOptions {
+                    anchored: false,
+                    contains_subroutines: tree.contains_subroutines,
+                    ..CompileOptions::default()
+                },
+            )
+            .unwrap()
+            .body
+        })
+    }
+
+    fn compile_prog_forced_hard(re: &str) -> Vec<Insn> {
+        compile_prog_with(
+            re,
+            AnalyzeContext {
+                explicit_capture_group_0: true,
+                ..Default::default()
+            },
+            |info, tree| {
+                info.hard = true;
+                compile(
+                    info,
+                    CompileOptions {
+                        anchored: true,
+                        contains_subroutines: tree.contains_subroutines,
+                        ..CompileOptions::default()
+                    },
+                )
+                .unwrap()
+                .body
             },
         )
-        .unwrap();
-        prog.body
+    }
+
+    fn compile_prog_with<F>(re: &str, analyze_context: AnalyzeContext, compile_fn: F) -> Vec<Insn>
+    where
+        F: FnOnce(&mut Info<'_>, &ExprTree) -> Vec<Insn>,
+    {
+        let tree = Expr::parse_tree(re).unwrap();
+        let mut info = analyze(&tree, analyze_context).unwrap();
+        compile_fn(&mut info, &tree)
     }
 
     fn assert_delegate_insn(insn: &Insn, re: &str, captures: Option<CaptureGroupRange>) {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -32,8 +32,6 @@ use regex_automata::meta::Regex as RaRegex;
 use regex_automata::meta::{Builder as RaBuilder, Config as RaConfig};
 #[cfg(feature = "variable-lookbehinds")]
 use regex_automata::util::pool::Pool;
-#[cfg(all(test, feature = "std"))]
-use std::{collections::BTreeMap, sync::RwLock};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as Map;
@@ -917,13 +915,6 @@ impl<'a> Compiler<'a> {
     }
 }
 
-// Unlike Regex in `regex`, `regex-automata` does not store the pattern string,
-// and we cannot retrieve the pattern string using `as_str`.
-// Unfortunately we need to get the pattern string in our tests,
-// so we just store it in a global map.
-#[cfg(all(test, feature = "std"))]
-static PATTERN_MAPPING: RwLock<BTreeMap<String, String>> = RwLock::new(BTreeMap::new());
-
 pub(crate) fn compile_inner(inner_re: &str, options: &CompileOptions) -> Result<RaRegex> {
     let builder = options_to_rabuilder(options);
 
@@ -931,12 +922,6 @@ pub(crate) fn compile_inner(inner_re: &str, options: &CompileOptions) -> Result<
         .build(inner_re)
         .map_err(CompileError::InnerError)
         .map_err(|e| Error::CompileError(Box::new(e)))?;
-
-    #[cfg(all(test, feature = "std"))]
-    PATTERN_MAPPING
-        .write()
-        .unwrap()
-        .insert(format!("{:?}", re), inner_re.to_owned());
 
     Ok(re)
 }
@@ -1272,7 +1257,6 @@ mod tests {
         assert_matches!(prog[7], End);
     }
 
-    #[cfg_attr(not(feature = "std"), ignore = "this test need std")]
     #[test]
     fn look_around_pattern_can_be_delegated() {
         let prog = compile_prog("(?=ab*)c");
@@ -1285,7 +1269,6 @@ mod tests {
         assert_matches!(prog[4], End);
     }
 
-    #[cfg_attr(not(feature = "std"), ignore = "this test need std")]
     #[test]
     fn easy_concat_can_delegate_end() {
         let prog = compile_prog("(?!x)(?:a|ab)x*");
@@ -1298,7 +1281,6 @@ mod tests {
         assert_matches!(prog[4], End);
     }
 
-    #[cfg_attr(not(feature = "std"), ignore = "this test need std")]
     #[test]
     fn hard_concat_can_delegate_const_size_end() {
         let prog = compile_prog("(?:(?!x)(?:a|b)c)x*");
@@ -1312,7 +1294,6 @@ mod tests {
         assert_matches!(prog[5], End);
     }
 
-    #[cfg_attr(not(feature = "std"), ignore = "this test need std")]
     #[test]
     fn hard_concat_can_not_delegate_variable_end() {
         let prog = compile_prog("(?:(?!x)(?:a|ab))x*");
@@ -1920,23 +1901,12 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
     fn assert_delegate(
         delegate: &crate::vm::Delegate,
         re: &str,
         captures: Option<CaptureGroupRange>,
     ) {
-        assert_eq!(
-            PATTERN_MAPPING
-                .read()
-                .unwrap()
-                .get(&alloc::format!("{:?}", delegate.inner))
-                .unwrap(),
-            re
-        );
+        assert_eq!(delegate.pattern, re);
         assert_eq!(captures, delegate.capture_groups);
     }
-
-    #[cfg(not(feature = "std"))]
-    fn assert_delegate(_: &crate::vm::Delegate, _: &str, _: Option<CaptureGroupRange>) {}
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -47,8 +47,7 @@ use crate::vm::{CachePoolFn, ReverseBackwardsDelegate};
 use crate::vm::{CaptureGroupRange, Delegate, Insn, Prog, Seek};
 use crate::LookAround::*;
 use crate::{
-    Absent, BacktrackingControlVerb, BytesMode, CompileError, Error, Expr, LookAround,
-    RegexOptions, Result,
+    Absent, BacktrackingControlVerb, BytesMode, CompileError, Error, Expr, LookAround, Result,
 };
 
 /// Maximum recursion depth for subroutine calls (matches Oniguruma's limit)
@@ -59,7 +58,6 @@ pub(crate) const MAX_SUBROUTINE_RECURSION_DEPTH: usize = 19;
 struct VMBuilder {
     prog: Vec<Insn>,
     n_saves: usize,
-    bytes_mode: BytesMode,
 }
 
 impl VMBuilder {
@@ -67,12 +65,11 @@ impl VMBuilder {
         VMBuilder {
             prog: Vec::new(),
             n_saves: max_group * 2,
-            bytes_mode: BytesMode::default(),
         }
     }
 
-    fn build(self) -> Prog {
-        Prog::new(self.prog, self.n_saves, self.bytes_mode)
+    fn build(self, bytes_mode: BytesMode) -> Prog {
+        Prog::new(self.prog, self.n_saves, bytes_mode)
     }
 
     fn newsave(&mut self) -> usize {
@@ -118,7 +115,7 @@ impl VMBuilder {
 
 struct Compiler<'a> {
     b: VMBuilder,
-    options: RegexOptions,
+    options: CompileOptions,
     inside_alternation: bool,
     /// Map from group number to its Info node for subroutine expansion
     group_info_map: Map<usize, &'a Info<'a>>,
@@ -129,6 +126,7 @@ struct Compiler<'a> {
 }
 
 impl<'a> Compiler<'a> {
+    #[cfg(test)]
     fn new(max_group: usize) -> Compiler<'a> {
         Compiler {
             b: VMBuilder::new(max_group),
@@ -198,7 +196,8 @@ impl<'a> Compiler<'a> {
                 self.b.add(Insn::Backref {
                     slot: group * 2,
                     casei,
-                    unicode: self.options.syntaxc.get_unicode(),
+                    // use the pre-computed effective unicode flag (unicode && !Ascii bytes mode)
+                    unicode: self.options.unicode,
                 });
             }
             Expr::BackrefExistsCondition {
@@ -925,7 +924,7 @@ impl<'a> Compiler<'a> {
 #[cfg(all(test, feature = "std"))]
 static PATTERN_MAPPING: RwLock<BTreeMap<String, String>> = RwLock::new(BTreeMap::new());
 
-pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<RaRegex> {
+pub(crate) fn compile_inner(inner_re: &str, options: &CompileOptions) -> Result<RaRegex> {
     let builder = options_to_rabuilder(options);
 
     let re = builder
@@ -942,7 +941,7 @@ pub(crate) fn compile_inner(inner_re: &str, options: &RegexOptions) -> Result<Ra
     Ok(re)
 }
 
-pub(crate) fn options_to_rabuilder(options: &RegexOptions) -> RaBuilder {
+pub(crate) fn options_to_rabuilder(options: &CompileOptions) -> RaBuilder {
     use regex_automata::util::syntax::Config as SyntaxConfig;
 
     let mut config = RaConfig::new();
@@ -955,16 +954,14 @@ pub(crate) fn options_to_rabuilder(options: &RegexOptions) -> RaBuilder {
 
     let mut builder = RaBuilder::new();
     builder.configure(config);
-    // NOTE: we deliberately don't configure the regex syntax because we rely on our Expr to_str function
-    //       to handle creating the correct string for regex-automata
-    //       otherwise, if the RegexOptions specifies case insensitive mode, then the pattern contains an explicit
-    //       (?-i) flag, then that flag would effectively be ignored unless to_str would encode the flag for every
-    //       node, even when it is the default, which feels like a waste.
+    // NOTE: our Expr to_str function handles creating the correct pattern string for regex-automata
+    //       using the default SyntaxConfig. If we were to set i.e. case sensitivity directly on
+    //       the SyntaxConfig here, and the pattern includes the (?-i) flag, then that flag would
+    //       effectively be ignored unless to_str would encode the flag for every node, even when it
+    //       is the default, which feels too verbose and hurts readability, is more to parse etc.
     let utf8 = matches!(options.bytes_mode, BytesMode::Unicode);
 
-    let syntax = SyntaxConfig::new()
-        .utf8(utf8)
-        .unicode(options.syntaxc.get_unicode() && !matches!(options.bytes_mode, BytesMode::Ascii));
+    let syntax = SyntaxConfig::new().utf8(utf8).unicode(options.unicode);
     builder.syntax(syntax);
 
     builder
@@ -1007,8 +1004,14 @@ pub struct CompileOptions {
     pub disallow_empty_match_at_eof_after_newline: bool,
     /// How the VM should advance positions: byte-level (Ascii) vs codepoint-level (Unicode/UnicodeBytes).
     pub bytes_mode: BytesMode,
-    /// Whether Unicode mode is enabled for the regex.
+    /// Whether Unicode mode is enabled for the regex. This is the effective value combining
+    /// the unicode flag and bytes_mode: `syntaxc.get_unicode() && !matches!(bytes_mode, BytesMode::Ascii)`.
+    /// It is always `false` in Ascii bytes mode, regardless of the unicode flag.
     pub unicode: bool,
+    /// Optional size limit in bytes for the NFA of each delegated sub-expression.
+    pub delegate_size_limit: Option<usize>,
+    /// Optional size limit in bytes for the DFA of each delegated sub-expression.
+    pub delegate_dfa_size_limit: Option<usize>,
 }
 
 impl core::fmt::Debug for CompileOptions {
@@ -1030,6 +1033,8 @@ impl core::fmt::Debug for CompileOptions {
             )
             .field("bytes_mode", &self.bytes_mode)
             .field("unicode", &self.unicode)
+            .field("delegate_size_limit", &self.delegate_size_limit)
+            .field("delegate_dfa_size_limit", &self.delegate_dfa_size_limit)
             .finish()
     }
 }
@@ -1043,18 +1048,25 @@ impl Default for CompileOptions {
             disallow_empty_match_at_eof_after_newline: false,
             bytes_mode: BytesMode::default(),
             unicode: true,
+            delegate_size_limit: None,
+            delegate_dfa_size_limit: None,
         }
     }
 }
 
 /// Compile the analyzed expressions into a program.
 pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
-    let mut c = Compiler::new(info.end_group());
-    c.options.bytes_mode = options.bytes_mode;
-    c.options.syntaxc = c.options.syntaxc.unicode(options.unicode);
-    c.b.bytes_mode = options.bytes_mode;
+    let bytes_mode = options.bytes_mode;
+    let mut c = Compiler {
+        b: VMBuilder::new(info.end_group()),
+        options,
+        inside_alternation: false,
+        group_info_map: Map::new(),
+        subroutine_recursion_stack: Vec::new(),
+        root_info: None,
+    };
 
-    if options.contains_subroutines {
+    if c.options.contains_subroutines {
         // Store root info for group 0 subroutine calls
         c.root_info = Some(info);
 
@@ -1062,14 +1074,14 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
         populate_group_info_map(&mut c.group_info_map, info);
     }
 
-    if !options.anchored {
+    if !c.options.anchored {
         // Attempt to build a Seek pre-filter when requested.
         let mut used_seek = false;
-        if let Some(filter) = options.seek_filter {
+        if let Some(filter) = c.options.seek_filter {
             if info.hard {
                 // Build the group_info_map if not already populated (needed for backref inlining).
                 let mut local_group_info_map: Map<usize, &Info<'_>>;
-                let group_info_map: &Map<usize, &Info<'_>> = if options.contains_subroutines {
+                let group_info_map: &Map<usize, &Info<'_>> = if c.options.contains_subroutines {
                     &c.group_info_map
                 } else {
                     local_group_info_map = Map::new();
@@ -1113,11 +1125,11 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
         // add implicit capture group 0 end
         c.b.add(Insn::Save(1));
     }
-    if options.disallow_empty_match_at_eof_after_newline {
+    if c.options.disallow_empty_match_at_eof_after_newline {
         c.b.add(Insn::RejectEmptyMatchAtEOFFollowingNewline);
     }
     c.b.add(Insn::End);
-    Ok(c.b.build())
+    Ok(c.b.build(bytes_mode))
 }
 
 struct DelegateBuilder {
@@ -1171,11 +1183,11 @@ impl DelegateBuilder {
         self
     }
 
-    fn build(&self, options: &RegexOptions) -> Result<Insn> {
+    fn build(&self, options: &CompileOptions) -> Result<Insn> {
         Ok(Insn::Delegate(self.build_delegate(options)?))
     }
 
-    fn build_delegate(&self, options: &RegexOptions) -> Result<Delegate> {
+    fn build_delegate(&self, options: &CompileOptions) -> Result<Delegate> {
         let capture_groups = self
             .capture_groups
             .expect("Expected at least one expression");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1111,7 +1111,18 @@ impl Regex {
             // NOTE: there is a good opportunity here to use Hir to avoid regex-automata re-parsing it
             let mut re_cooked = String::new();
             tree.expr.to_str(&mut re_cooked, 0);
-            let inner = compile::compile_inner(&re_cooked, options)?;
+            let compile_options = CompileOptions {
+                bytes_mode: options.bytes_mode,
+                unicode: options.syntaxc.get_unicode()
+                    && !matches!(options.bytes_mode, BytesMode::Ascii),
+                delegate_size_limit: options.delegate_size_limit,
+                delegate_dfa_size_limit: options.delegate_dfa_size_limit,
+                // The remaining fields (anchored, contains_subroutines, seek_filter,
+                // disallow_empty_match_at_eof_after_newline) are irrelevant for a plain
+                // delegate compile in the easy path and their defaults are correct.
+                ..CompileOptions::default()
+            };
+            let inner = compile::compile_inner(&re_cooked, &compile_options)?;
             return Ok(Regex {
                 inner: RegexImpl::Wrap {
                     inner,
@@ -1133,6 +1144,8 @@ impl Regex {
                 bytes_mode: options.bytes_mode,
                 unicode: options.syntaxc.get_unicode()
                     && !matches!(options.bytes_mode, BytesMode::Ascii),
+                delegate_size_limit: options.delegate_size_limit,
+                delegate_dfa_size_limit: options.delegate_dfa_size_limit,
             },
         )?;
         Ok(Regex {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1159,7 +1159,10 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                         return Ok(None);
                     }
 
-                    let input = Input::new(s.as_bytes()).span(ix..s.len()).earliest(true);
+                    // TODO: ideally we would be able to use .earliest(true) as an extra optimization
+                    //       as we only care about the start of the match, but unfortunately this doesn't
+                    //       always return the correct start position, perhaps a bug in regex-automata
+                    let input = Input::new(s.as_bytes()).span(ix..s.len());
                     match inner.search(&input) {
                         None => return Ok(None),
                         Some(m) => {

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -618,6 +618,45 @@ fn find_endtext_ignore_trailing_newlines_crlf() {
 }
 
 #[test]
+fn find_endtext_ignore_trailing_newlines_crlf_seek() {
+    // (?R) enables CRLF mode; \Z should then treat \r as part of trailing newlines too.
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .seek(true) // TODO: ideally we would test every pattern with seek on and off automatically to compare them. Otherwise if we change the default, we might miss test case combinations in our tests.
+            .build()
+            .unwrap()
+            .find("abc\r\n")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .seek(true)
+            .build()
+            .unwrap()
+            .find("abc\r\r")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
+    // bare \n still works in CRLF mode
+    assert_eq!(
+        RegexBuilder::new(r"\Z")
+            .crlf(true)
+            .seek(true)
+            .build()
+            .unwrap()
+            .find("abc\n")
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((3, 3))
+    );
+}
+
+#[test]
 fn continue_from_previous_match_with_lookahead_before() {
     let text = "123abc";
 


### PR DESCRIPTION
refactor how regex options are passed into the compiler

- replace RegexOptions in Compiler with CompileOptions
- remove VMBuilder.bytes_mode duplication
- fix delegate size limit bug (limits were not being forwarded when compiling delegates)

fix bug causing seek mode to skip matches