### PR TITLE
Rework RegexInput to allow searching within a range without slicing

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -65,6 +65,25 @@ let group = captures.get(1).expect("No group");
 assert_eq!(group.as_str(), "20");
 ```
 
+## Example: Searching within a range without slicing
+
+```rust
+use fancy_regex::{Regex, RegexInput};
+
+let re = Regex::new(r"\bat\b").unwrap();
+let haystack = "batter at";
+
+assert!(re.find("at").unwrap().is_some());
+assert!(re
+    .find_input(RegexInput::new(haystack).range(1..3))
+    .unwrap()
+    .is_none());
+```
+
+Using [`RegexInput`] preserves the original haystack for anchors, word
+boundaries, and lookaround while still constraining the reported match to a
+specific byte range.
+
 ## Example: Splitting text
 
 ```rust

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,7 @@
 use crate::bytes::MatchBytes;
 use crate::Match;
 use alloc::string::String;
+use core::ops::Range;
 
 /// Returns the smallest possible index of the next valid UTF-8 sequence
 /// starting after `i`.
@@ -14,10 +15,89 @@ pub(crate) fn next_input_pos(text: &[u8], i: usize) -> usize {
     i + crate::codepoint_len(b)
 }
 
-/// A trait abstracting over input types for regex matching.
+/// A search configuration for matching against a haystack.
 ///
-/// This trait is implemented for `str`, `String`, `[u8]`, and `[u8; N]`, allowing
-/// regex methods to work with both UTF-8 text and raw byte slices.
+/// This keeps the original haystack together with a starting search position
+/// and a range that constrains where the overall match may occur. Unlike
+/// slicing a haystack, anchors and lookaround can still inspect the full
+/// original input, and reported offsets remain absolute.
+#[derive(Clone, Debug)]
+pub struct RegexInput<'h, S: Input + ?Sized> {
+    haystack: &'h S,
+    start: usize,
+    range: Range<usize>,
+}
+
+impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
+    /// Create a new search input over the full haystack.
+    pub fn new(haystack: &'h S) -> Self {
+        Self {
+            haystack,
+            start: 0,
+            range: 0..haystack.len(),
+        }
+    }
+
+    /// Return the haystack being searched.
+    pub fn haystack(&self) -> &'h S {
+        self.haystack
+    }
+
+    /// Return the requested starting position for this search.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Return the range constraining where match `0` may occur.
+    pub fn get_range(&self) -> Range<usize> {
+        self.range.clone()
+    }
+
+    /// Return a copy of this input with a different search start.
+    pub fn from_pos(mut self, start: usize) -> Self {
+        self.start = start;
+        self
+    }
+
+    /// Return a copy of this input with a different search range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is not within the haystack bounds or if
+    /// `range.start > range.end`.
+    pub fn range(mut self, range: Range<usize>) -> Self {
+        assert!(range.start <= range.end, "range start must be <= range end");
+        assert!(
+            range.end <= self.haystack.len(),
+            "range end must be within haystack bounds"
+        );
+        self.range = range;
+        self
+    }
+
+    pub(crate) fn effective_start(&self) -> usize {
+        self.start.max(self.range.start)
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.effective_start() > self.range.end
+    }
+
+    pub(crate) fn set_start(&mut self, start: usize) {
+        self.start = start;
+    }
+}
+
+impl<'h, S: Input + ?Sized> From<&'h S> for RegexInput<'h, S> {
+    fn from(haystack: &'h S) -> Self {
+        Self::new(haystack)
+    }
+}
+
+/// A trait abstracting over haystack types for regex matching.
+///
+/// This trait is implemented for `str`, `String`, `[u8]`, and `[u8; N]`,
+/// allowing regex methods to work with both UTF-8 text and raw byte slices.
 ///
 /// When the regex is compiled with [`BytesMode::Ascii`](crate::BytesMode),
 /// patterns like `.` will match any byte in `[u8]` input. Without bytes mode,
@@ -26,7 +106,7 @@ pub(crate) fn next_input_pos(text: &[u8], i: usize) -> usize {
 /// The associated type [`Match<'t>`](Self::Match) is the concrete match type
 /// returned for a given input: [`Match<'t>`](crate::Match) for string inputs,
 /// [`MatchBytes<'t>`](crate::MatchBytes) for byte slice inputs.
-pub trait RegexInput {
+pub trait Input {
     /// The match type produced for this input.
     type Match<'t>
     where
@@ -52,7 +132,7 @@ pub trait RegexInput {
     fn advance_position(&self, i: usize) -> usize;
 }
 
-impl<S: RegexInput + ?Sized> RegexInput for &S {
+impl<S: Input + ?Sized> Input for &S {
     type Match<'t>
         = S::Match<'t>
     where
@@ -81,7 +161,7 @@ impl<S: RegexInput + ?Sized> RegexInput for &S {
     }
 }
 
-impl RegexInput for str {
+impl Input for str {
     type Match<'t> = Match<'t>;
 
     fn len(&self) -> usize {
@@ -107,7 +187,7 @@ impl RegexInput for str {
     }
 }
 
-impl RegexInput for String {
+impl Input for String {
     type Match<'t> = Match<'t>;
 
     fn len(&self) -> usize {
@@ -133,7 +213,7 @@ impl RegexInput for String {
     }
 }
 
-impl RegexInput for [u8] {
+impl Input for [u8] {
     type Match<'t> = MatchBytes<'t>;
 
     fn len(&self) -> usize {
@@ -163,7 +243,7 @@ impl RegexInput for [u8] {
     }
 }
 
-impl<const N: usize> RegexInput for [u8; N] {
+impl<const N: usize> Input for [u8; N] {
     type Match<'t> = MatchBytes<'t>;
 
     fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ use crate::vm::{Prog, OPTION_FIND_NOT_EMPTY, OPTION_SKIPPED_EMPTY_MATCH};
 pub use crate::bytes::MatchBytes;
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
 pub use crate::expand::Expander;
-pub use crate::input::RegexInput;
+pub use crate::input::{Input, RegexInput};
 pub use crate::replacer::{NoExpand, Replacer, ReplacerRef};
 pub use crate::seek::seek_pattern_is_useful;
 
@@ -195,15 +195,14 @@ pub struct Match<'t> {
 /// `'r` is the lifetime of the compiled regular expression and `'t` is the
 /// lifetime of the matched input.
 #[derive(Debug)]
-pub struct Matches<'r, 't, S: input::RegexInput + ?Sized> {
+pub struct Matches<'r, 't, S: input::Input + ?Sized> {
     re: &'r Regex,
-    text: &'t S,
-    last_end: usize,
+    input: RegexInput<'t, S>,
     last_match: Option<usize>,
     last_skipped_empty: bool,
 }
 
-impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
+impl<'r, 't, S: input::Input + ?Sized> Matches<'r, 't, S> {
     /// Return the underlying regex.
     pub fn regex(&self) -> &'r Regex {
         self.re
@@ -211,7 +210,12 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
 
     /// Return the text being searched.
     pub fn text(&self) -> &'t S {
-        self.text
+        self.input.haystack()
+    }
+
+    /// Return the current search input configuration.
+    pub fn input(&self) -> &RegexInput<'t, S> {
+        &self.input
     }
 
     /// Adapted from the `regex` crate. Calls `find_from_pos`/`captures_from_pos` repeatedly.
@@ -219,9 +223,9 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
     /// Also passes a flag when skipping an empty match, so that \G wouldn't match at the new start position.
     fn next_with<F, R>(&mut self, mut search: F) -> Option<Result<R>>
     where
-        F: FnMut(&Regex, usize, u32) -> Result<Option<(R, (usize, usize))>>,
+        F: FnMut(&Regex, &RegexInput<'t, S>, u32) -> Result<Option<(R, (usize, usize))>>,
     {
-        if self.last_end > self.text.len() {
+        if self.input.is_done() {
             return None;
         }
 
@@ -231,12 +235,13 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
             0
         };
 
-        let pos = self.last_end;
-        let (result, (match_start, match_end)) = match search(self.re, pos, option_flags) {
+        let pos = self.input.effective_start();
+        let (result, (match_start, match_end)) = match search(self.re, &self.input, option_flags) {
             Err(error) => {
                 // Stop on first error: If an error is encountered, return it, and set the "last match position"
                 // to the string length, so that the next next() call will return None, to prevent an infinite loop.
-                self.last_end = self.text.len() + 1;
+                self.input
+                    .set_start(self.input.get_range().end.saturating_add(1));
                 return Some(Err(error));
             }
             Ok(None) => return None,
@@ -247,7 +252,8 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
             // This is an empty match. To ensure we make progress, start
             // the next search at the smallest possible starting position
             // of the next match following this one.
-            self.last_end = self.text.advance_position(match_end);
+            self.input
+                .set_start(self.input.haystack().advance_position(match_end));
             // Only set OPTION_SKIPPED_EMPTY_MATCH on the next call if this was a
             // truly zero-length match (the VM consumed no bytes from `pos`).
             // This means that \K won't prevent \G from matching.
@@ -258,7 +264,7 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
                 return self.next_with(search);
             }
         } else {
-            self.last_end = match_end;
+            self.input.set_start(match_end);
             self.last_skipped_empty = false;
         }
 
@@ -268,13 +274,13 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Matches<'r, 't, S> {
     }
 }
 
-impl<'r, 't, S: input::RegexInput + ?Sized> Iterator for Matches<'r, 't, S> {
+impl<'r, 't, S: input::Input + ?Sized> Iterator for Matches<'r, 't, S> {
     type Item = Result<S::Match<'t>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let text = self.text;
-        self.next_with(move |re, pos, flags| {
-            re.find_from_pos_raw(text, pos, flags)
+        let text = self.input.haystack();
+        self.next_with(move |re, input, flags| {
+            re.find_input_raw(input, flags)
                 .map(|opt| opt.map(|(s, e)| (text.make_match(s, e), (s, e))))
         })
     }
@@ -288,12 +294,12 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Iterator for Matches<'r, 't, S> {
 /// `'r` is the lifetime of the compiled regular expression and `'t` is the
 /// lifetime of the matched string.
 #[derive(Debug)]
-pub struct CaptureMatches<'r, 't, S: input::RegexInput + ?Sized>(Matches<'r, 't, S>);
+pub struct CaptureMatches<'r, 't, S: input::Input + ?Sized>(Matches<'r, 't, S>);
 
-impl<'r, 't, S: input::RegexInput + ?Sized> CaptureMatches<'r, 't, S> {
+impl<'r, 't, S: input::Input + ?Sized> CaptureMatches<'r, 't, S> {
     /// Return the text being searched.
     pub fn text(&self) -> &'t S {
-        self.0.text
+        self.0.input.haystack()
     }
 
     /// Return the underlying regex.
@@ -302,13 +308,12 @@ impl<'r, 't, S: input::RegexInput + ?Sized> CaptureMatches<'r, 't, S> {
     }
 }
 
-impl<'r, 't, S: input::RegexInput + ?Sized> Iterator for CaptureMatches<'r, 't, S> {
+impl<'r, 't, S: input::Input + ?Sized> Iterator for CaptureMatches<'r, 't, S> {
     type Item = Result<Captures<'t, S>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let text = self.0.text;
-        self.0.next_with(move |re, pos, flags| {
-            let captures = re.captures_from_pos_with_option_flags(text, pos, flags)?;
+        self.0.next_with(move |re, input, flags| {
+            let captures = re.captures_input_with_option_flags(input, flags)?;
             Ok(captures.map(|c| {
                 let (start, end) = c
                     .inner
@@ -324,7 +329,7 @@ impl<'r, 't, S: input::RegexInput + ?Sized> Iterator for CaptureMatches<'r, 't, 
 ///
 /// `S` is the input type (`str` or `[u8]`).
 #[derive(Debug)]
-pub struct Captures<'t, S: input::RegexInput + ?Sized> {
+pub struct Captures<'t, S: input::Input + ?Sized> {
     inner: CapturesImpl,
     named_groups: Arc<NamedGroups>,
     input: &'t S,
@@ -381,7 +386,7 @@ impl CapturesImpl {
 
 /// Iterator for captured groups in order in which they appear in the regex.
 #[derive(Debug)]
-pub struct SubCaptureMatches<'c, 't, S: input::RegexInput + ?Sized> {
+pub struct SubCaptureMatches<'c, 't, S: input::Input + ?Sized> {
     data: &'c Captures<'t, S>,
     i: usize,
 }
@@ -1169,7 +1174,7 @@ impl Regex {
 
     /// Check if the regex matches the input.
     ///
-    /// Accepts any type implementing [`RegexInput`]: `&str`, `&String`, or `&[u8]`.
+    /// Accepts any type implementing [`Input`]: `&str`, `&String`, or `&[u8]`.
     ///
     /// # Example
     ///
@@ -1193,10 +1198,25 @@ impl Regex {
     ///     .unwrap();
     /// assert!(re.is_match(b"abc 123").unwrap());
     /// ```
-    pub fn is_match<S: input::RegexInput + ?Sized>(&self, input: &S) -> Result<bool> {
+    pub fn is_match<S: input::Input + ?Sized>(&self, input: &S) -> Result<bool> {
+        self.is_match_input(RegexInput::new(input))
+    }
+
+    /// Returns true if and only if this regex matches anywhere in the given
+    /// search input.
+    pub fn is_match_input<S: input::Input + ?Sized>(
+        &self,
+        input: RegexInput<'_, S>,
+    ) -> Result<bool> {
         match &self.inner {
-            RegexImpl::Wrap { inner, .. } => Ok(inner.is_match(RaInput::new(input.as_bytes()))),
-            RegexImpl::Fancy { .. } => self.find_from_pos_raw(input, 0, 0).map(|m| m.is_some()),
+            RegexImpl::Wrap { inner, .. } => {
+                if input.is_done() {
+                    Ok(false)
+                } else {
+                    Ok(inner.is_match(ra_input(&input)))
+                }
+            }
+            RegexImpl::Fancy { .. } => self.find_input_raw(&input, 0).map(|m| m.is_some()),
         }
     }
 
@@ -1219,14 +1239,22 @@ impl Regex {
     /// assert_eq!(matches.next().unwrap().unwrap().as_str(), "iterators");
     /// assert!(matches.next().is_none());
     /// ```
-    pub fn find_iter<'r, 't, S: input::RegexInput + ?Sized>(
+    pub fn find_iter<'r, 't, S: input::Input + ?Sized>(
         &'r self,
         text: &'t S,
     ) -> Matches<'r, 't, S> {
+        self.find_iter_input(RegexInput::new(text))
+    }
+
+    /// Returns an iterator for each successive non-overlapping match in the
+    /// given search input.
+    pub fn find_iter_input<'r, 't, S: input::Input + ?Sized>(
+        &'r self,
+        input: RegexInput<'t, S>,
+    ) -> Matches<'r, 't, S> {
         Matches {
             re: self,
-            text,
-            last_end: 0,
+            input,
             last_match: None,
             last_skipped_empty: false,
         }
@@ -1234,7 +1262,7 @@ impl Regex {
 
     /// Find the first match in the input.
     ///
-    /// Accepts any type implementing [`RegexInput`]: `&str`, `&String`, or `&[u8]`.
+    /// Accepts any type implementing [`Input`]: `&str`, `&String`, or `&[u8]`.
     ///
     /// # Example
     ///
@@ -1246,11 +1274,18 @@ impl Regex {
     /// let re = Regex::new(r"\w+(?=!)").unwrap();
     /// assert_eq!(re.find("so fancy!").unwrap().unwrap().as_str(), "fancy");
     /// ```
-    pub fn find<'t, S: input::RegexInput + ?Sized>(
+    pub fn find<'t, S: input::Input + ?Sized>(&self, input: &'t S) -> Result<Option<S::Match<'t>>> {
+        self.find_input(RegexInput::new(input))
+    }
+
+    /// Find the first match in the given search input.
+    pub fn find_input<'t, S: input::Input + ?Sized>(
         &self,
-        input: &'t S,
+        input: RegexInput<'t, S>,
     ) -> Result<Option<S::Match<'t>>> {
-        self.find_from_pos(input, 0)
+        Ok(self
+            .find_input_raw(&input, 0)?
+            .map(|(s, e)| input.haystack().make_match(s, e)))
     }
 
     /// Returns the first match in `input`, starting from the specified byte position `pos`.
@@ -1270,24 +1305,23 @@ impl Regex {
     /// ```
     ///
     /// Note that in some cases this is not the same as using the `find`
-    /// method and passing a slice of the string, see [Regex::captures_from_pos()] for details.
-    pub fn find_from_pos<'t, S: input::RegexInput + ?Sized>(
+    /// method and passing a slice of the string, see [Regex::captures_from_pos()]
+    /// for details. To constrain matching to a byte range without slicing, use
+    /// [Regex::find_input()] with [`RegexInput`].
+    pub fn find_from_pos<'t, S: input::Input + ?Sized>(
         &self,
         input: &'t S,
         pos: usize,
     ) -> Result<Option<S::Match<'t>>> {
-        Ok(self
-            .find_from_pos_raw(input, pos, 0)?
-            .map(|(s, e)| input.make_match(s, e)))
+        self.find_input(RegexInput::new(input).from_pos(pos))
     }
 
-    fn find_from_pos_raw<S: input::RegexInput + ?Sized>(
+    fn find_input_raw<S: input::Input + ?Sized>(
         &self,
-        input: &S,
-        pos: usize,
+        input: &RegexInput<'_, S>,
         option_flags: u32,
     ) -> Result<Option<(usize, usize)>> {
-        if pos > input.len() {
+        if input.is_done() {
             return Ok(None);
         }
         match &self.inner {
@@ -1297,15 +1331,10 @@ impl Regex {
                 ..
             } => {
                 let result = if !*explicit_capture_group_0 {
-                    inner
-                        .search(&RaInput::new(input.as_bytes()).span(pos..input.len()))
-                        .map(|m| (m.start(), m.end()))
+                    inner.search(&ra_input(input)).map(|m| (m.start(), m.end()))
                 } else {
                     let mut locations = inner.create_captures();
-                    inner.captures(
-                        RaInput::new(input.as_bytes()).span(pos..input.len()),
-                        &mut locations,
-                    );
+                    inner.captures(ra_input(input), &mut locations);
                     locations
                         .get_group(1)
                         .map(|group1| (group1.start, group1.end))
@@ -1319,7 +1348,7 @@ impl Regex {
                     } else {
                         0
                     };
-                let result = vm::run(prog, input, pos, option_flags, options)?;
+                let result = vm::run(prog, input, option_flags, options)?;
                 Ok(result.map(|saves| (saves[0], saves[1])))
             }
         }
@@ -1350,11 +1379,20 @@ impl Regex {
     ///
     /// assert!(all_captures.next().is_none());
     /// ```
-    pub fn captures_iter<'r, 't, S: input::RegexInput + ?Sized>(
+    pub fn captures_iter<'r, 't, S: input::Input + ?Sized>(
         &'r self,
         text: &'t S,
     ) -> CaptureMatches<'r, 't, S> {
-        CaptureMatches(self.find_iter(text))
+        self.captures_iter_input(RegexInput::new(text))
+    }
+
+    /// Returns an iterator over all the non-overlapping capture groups matched
+    /// in the given search input.
+    pub fn captures_iter_input<'r, 't, S: input::Input + ?Sized>(
+        &'r self,
+        input: RegexInput<'t, S>,
+    ) -> CaptureMatches<'r, 't, S> {
+        CaptureMatches(self.find_iter_input(input))
     }
 
     /// Returns the capture groups for the first match in `text`.
@@ -1377,11 +1415,20 @@ impl Regex {
     /// assert_eq!(captures.get(3).unwrap().as_str(), "07");
     /// assert_eq!(captures.get(0).unwrap().as_str(), "2018-04-07");
     /// ```
-    pub fn captures<'t, S: input::RegexInput + ?Sized>(
+    pub fn captures<'t, S: input::Input + ?Sized>(
         &self,
         text: &'t S,
     ) -> Result<Option<Captures<'t, S>>> {
-        self.captures_from_pos(text, 0)
+        self.captures_input(RegexInput::new(text))
+    }
+
+    /// Returns the capture groups for the first match in the given search
+    /// input.
+    pub fn captures_input<'t, S: input::Input + ?Sized>(
+        &self,
+        input: RegexInput<'t, S>,
+    ) -> Result<Option<Captures<'t, S>>> {
+        self.captures_input_with_option_flags(&input, 0)
     }
 
     /// Returns the capture groups for the first match in `text`, starting from
@@ -1418,25 +1465,27 @@ impl Regex {
     /// This matched the number "123" because it's at the beginning of the text
     /// of the string slice.
     ///
-    pub fn captures_from_pos<'t, S: input::RegexInput + ?Sized>(
+    /// To constrain matching to a byte range without slicing, use
+    /// [Regex::captures_input()] with [`RegexInput`].
+    ///
+    pub fn captures_from_pos<'t, S: input::Input + ?Sized>(
         &self,
         text: &'t S,
         pos: usize,
     ) -> Result<Option<Captures<'t, S>>> {
-        self.captures_from_pos_with_option_flags(text, pos, 0)
+        self.captures_input(RegexInput::new(text).from_pos(pos))
     }
 
-    fn captures_from_pos_with_option_flags<'t, S: input::RegexInput + ?Sized>(
+    fn captures_input_with_option_flags<'t, S: input::Input + ?Sized>(
         &self,
-        input: &'t S,
-        pos: usize,
+        input: &RegexInput<'t, S>,
         option_flags: u32,
     ) -> Result<Option<Captures<'t, S>>> {
-        if pos > input.len() {
+        if input.is_done() {
             return Ok(None);
         }
         let named_groups = self.named_groups.clone();
-        let bytes = input.as_bytes();
+        let haystack = input.haystack();
         match &self.inner {
             RegexImpl::Wrap {
                 inner,
@@ -1447,14 +1496,14 @@ impl Regex {
                 // always false here.
                 let explicit = *explicit_capture_group_0;
                 let mut locations = inner.create_captures();
-                inner.captures(RaInput::new(bytes).span(pos..bytes.len()), &mut locations);
+                inner.captures(ra_input(input), &mut locations);
                 Ok(locations.is_match().then_some(Captures {
                     inner: CapturesImpl::Wrap {
                         locations,
                         explicit_capture_group_0: explicit,
                     },
                     named_groups,
-                    input,
+                    input: haystack,
                 }))
             }
             RegexImpl::Fancy {
@@ -1469,13 +1518,13 @@ impl Regex {
                     } else {
                         0
                     };
-                let result = vm::run(prog, input, pos, option_flags, options)?;
+                let result = vm::run(prog, input, option_flags, options)?;
                 Ok(result.map(|mut saves| {
                     saves.truncate(n_groups * 2);
                     Captures {
                         inner: CapturesImpl::Fancy { saves },
                         named_groups,
-                        input,
+                        input: haystack,
                     }
                 }))
             }
@@ -1764,6 +1813,12 @@ impl Regex {
     }
 }
 
+fn ra_input<'a, S: input::Input + ?Sized>(input: &'a RegexInput<'a, S>) -> RaInput<'a> {
+    let mut ra_input = RaInput::new(input.haystack().as_bytes()).range(input.get_range());
+    ra_input.set_start(input.effective_start());
+    ra_input
+}
+
 impl TryFrom<&str> for Regex {
     type Error = Error;
 
@@ -1826,7 +1881,7 @@ impl<'t> From<Match<'t>> for Range<usize> {
 }
 
 #[allow(clippy::len_without_is_empty)] // follow regex's API
-impl<'t, S: input::RegexInput + ?Sized> Captures<'t, S> {
+impl<'t, S: input::Input + ?Sized> Captures<'t, S> {
     /// Get the capture group by its index in the regex.
     ///
     /// If there is no match for that group or the index does not correspond to a group, `None` is
@@ -1931,7 +1986,7 @@ impl<'t, 'i> Index<&'i str> for Captures<'t, str> {
     }
 }
 
-impl<'c, 't, S: input::RegexInput + ?Sized> Iterator for SubCaptureMatches<'c, 't, S> {
+impl<'c, 't, S: input::Input + ?Sized> Iterator for SubCaptureMatches<'c, 't, S> {
     type Item = Option<S::Match<'t>>;
 
     fn next(&mut self) -> Option<Option<S::Match<'t>>> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -744,7 +744,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
     if input.is_done() {
         return Ok(None);
     }
-    let s = input.haystack();
+    let haystack = input.haystack();
     let pos = input.effective_start();
     let match_range = input.get_range();
     let mut state = State::new(prog.n_saves, MAX_STACK, option_flags);
@@ -796,43 +796,43 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     return Ok(Some(state.saves));
                 }
                 Insn::Any => {
-                    if ix < s.len() {
-                        ix += advance_one(s, ix, prog.bytes_mode);
+                    if ix < haystack.len() {
+                        ix += advance_one(haystack, ix, prog.bytes_mode);
                     } else {
                         break 'fail;
                     }
                 }
                 Insn::AnyNoNL => {
-                    if ix < s.len() && s.as_bytes()[ix] != b'\n' {
-                        ix += advance_one(s, ix, prog.bytes_mode);
+                    if ix < haystack.len() && haystack.as_bytes()[ix] != b'\n' {
+                        ix += advance_one(haystack, ix, prog.bytes_mode);
                     } else {
                         break 'fail;
                     }
                 }
                 Insn::AnyNoCRLF => {
-                    if ix < s.len() && s.as_bytes()[ix] != b'\r' && s.as_bytes()[ix] != b'\n' {
-                        ix += advance_one(s, ix, prog.bytes_mode);
+                    if ix < haystack.len() && haystack.as_bytes()[ix] != b'\r' && haystack.as_bytes()[ix] != b'\n' {
+                        ix += advance_one(haystack, ix, prog.bytes_mode);
                     } else {
                         break 'fail;
                     }
                 }
                 Insn::Lit(ref val) => {
                     let ix_end = ix + val.len();
-                    if !matches_literal(s, ix, ix_end, val.as_bytes()) {
+                    if !matches_literal(haystack, ix, ix_end, val.as_bytes()) {
                         break 'fail;
                     }
                     ix = ix_end
                 }
                 Insn::Assertion(assertion) => {
                     if !match assertion {
-                        Assertion::StartText => look_matcher.is_start(s.as_bytes(), ix),
+                        Assertion::StartText => look_matcher.is_start(haystack.as_bytes(), ix),
                         Assertion::EndText => {
-                            let matched = look_matcher.is_end(s.as_bytes(), ix);
+                            let matched = look_matcher.is_end(haystack.as_bytes(), ix);
                             slash_z_matched |= matched;
                             matched
                         }
                         Assertion::EndTextIgnoreTrailingNewlines { crlf } => {
-                            let bytes = s.as_bytes();
+                            let bytes = haystack.as_bytes();
                             let matched = if ix == bytes.len() {
                                 // At the end of string
                                 true
@@ -847,34 +847,34 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                             matched
                         }
                         Assertion::StartLine { crlf: false } => {
-                            look_matcher.is_start_lf(s.as_bytes(), ix)
+                            look_matcher.is_start_lf(haystack.as_bytes(), ix)
                         }
                         Assertion::StartLine { crlf: true } => {
-                            look_matcher.is_start_crlf(s.as_bytes(), ix)
+                            look_matcher.is_start_crlf(haystack.as_bytes(), ix)
                         }
                         Assertion::EndLine { crlf: false } => {
-                            look_matcher.is_end_lf(s.as_bytes(), ix)
+                            look_matcher.is_end_lf(haystack.as_bytes(), ix)
                         }
                         Assertion::EndLine { crlf: true } => {
-                            look_matcher.is_end_crlf(s.as_bytes(), ix)
+                            look_matcher.is_end_crlf(haystack.as_bytes(), ix)
                         }
                         Assertion::LeftWordBoundary => look_matcher
-                            .is_word_start_unicode(s.as_bytes(), ix)
+                            .is_word_start_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
                         Assertion::RightWordBoundary => {
-                            look_matcher.is_word_end_unicode(s.as_bytes(), ix).unwrap()
+                            look_matcher.is_word_end_unicode(haystack.as_bytes(), ix).unwrap()
                         }
                         Assertion::LeftWordHalfBoundary => look_matcher
-                            .is_word_start_half_unicode(s.as_bytes(), ix)
+                            .is_word_start_half_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
                         Assertion::RightWordHalfBoundary => look_matcher
-                            .is_word_end_half_unicode(s.as_bytes(), ix)
+                            .is_word_end_half_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
                         Assertion::WordBoundary => {
-                            look_matcher.is_word_unicode(s.as_bytes(), ix).unwrap()
+                            look_matcher.is_word_unicode(haystack.as_bytes(), ix).unwrap()
                         }
                         Assertion::NotWordBoundary => look_matcher
-                            .is_word_unicode_negate(s.as_bytes(), ix)
+                            .is_word_unicode_negate(haystack.as_bytes(), ix)
                             .unwrap(),
                     } {
                         break 'fail;
@@ -989,7 +989,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         if ix == 0 {
                             break 'fail;
                         }
-                        ix = prev_ix(s, ix, prog.bytes_mode);
+                        ix = prev_ix(haystack, ix, prog.bytes_mode);
                     }
                 }
                 Insn::FailNegativeLookAround => {
@@ -1025,13 +1025,13 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         // Referenced group hasn't matched, so the backref doesn't match either
                         break 'fail;
                     }
-                    let ref_text = &s.as_bytes()[lo..hi];
+                    let ref_text = &haystack.as_bytes()[lo..hi];
                     let ix_end = ix + ref_text.len();
                     if casei {
-                        if !matches_literal_casei(s, ix, ix_end, ref_text, unicode) {
+                        if !matches_literal_casei(haystack, ix, ix_end, ref_text, unicode) {
                             break 'fail;
                         }
-                    } else if !matches_literal(s, ix, ix_end, ref_text) {
+                    } else if !matches_literal(haystack, ix, ix_end, ref_text) {
                         break 'fail;
                     }
                     ix = ix_end;
@@ -1057,7 +1057,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                 }) => {
                     // Use regex-automata to search backwards from current position
                     let mut cache_guard = cache_pool.get();
-                    let input = Input::new(s.as_bytes())
+                    let input = Input::new(haystack.as_bytes())
                         .anchored(Anchored::Yes)
                         .range(0..ix);
 
@@ -1069,7 +1069,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                             if let Some(inner) = capture_group_extraction_inner {
                                 if let Some(range) = capture_groups {
                                     // There are capture groups, need to search forward to populate them
-                                    let forward_input = Input::new(s.as_bytes())
+                                    let forward_input = Input::new(haystack.as_bytes())
                                         .span(match_start..ix)
                                         .anchored(Anchored::Yes);
                                     inner_slots.resize((range.end() - range.start() + 1) * 2, None);
@@ -1108,8 +1108,8 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     pattern: _,
                     capture_groups,
                 }) => {
-                    let input = Input::new(s.as_bytes())
-                        .span(ix..s.len())
+                    let input = Input::new(haystack.as_bytes())
+                        .span(ix..haystack.len())
                         .anchored(Anchored::Yes);
                     if let Some(range) = capture_groups {
                         // Has capture groups, need to extract them
@@ -1136,8 +1136,8 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     // If we reach end of string without delegate matching, we also continue
 
                     // Check if delegate matches at current position
-                    let input = Input::new(s.as_bytes())
-                        .span(ix..s.len())
+                    let input = Input::new(haystack.as_bytes())
+                        .span(ix..haystack.len())
                         .anchored(Anchored::Yes);
                     // capture groups in the delegate are always ignored, so we can use the quicker search_half method
                     let delegate_matches_here = delegate.inner.search_half(&input).is_some();
@@ -1146,10 +1146,10 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         // Delegate matches at current position - we've reached the boundary
                         // Continue to next instruction without consuming any characters
                         // Fall through via pc += 1 below
-                    } else if ix < s.len() {
+                    } else if ix < haystack.len() {
                         // Try advancing one character and checking again
                         state.push(pc + 1, ix)?;
-                        ix += advance_one(s, ix, prog.bytes_mode);
+                        ix += advance_one(haystack, ix, prog.bytes_mode);
                         // Stay at same pc to check delegate match at new position
                         continue;
                     } else {
@@ -1172,7 +1172,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     }
                 }
                 Insn::Seek(Seek { ref inner, .. }) => {
-                    // A sentinel value greater than s.len() is pushed onto the backtrack stack
+                    // A sentinel value greater than haystack.len() is pushed onto the backtrack stack
                     // when the seek found a zero-width match at end-of-string.  On re-entry with
                     // that sentinel, there are no more positions to try.
                     if ix > match_range.end {
@@ -1182,7 +1182,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     // TODO: ideally we would be able to use .earliest(true) as an extra optimization
                     //       as we only care about the start of the match, but unfortunately this doesn't
                     //       always return the correct start position, perhaps a bug in regex-automata
-                    let seek_input = Input::new(s.as_bytes()).span(ix..match_range.end);
+                    let seek_input = Input::new(haystack.as_bytes()).span(ix..match_range.end);
                     match inner.search(&seek_input) {
                         None => return Ok(None),
                         Some(m) => {
@@ -1190,17 +1190,17 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                             // one codepoint past the start of this match (or past the end for
                             // zero-width matches) so we make progress.
                             let next_seek_start = if m.start() == m.end() {
-                                if m.end() < s.len() {
-                                    m.end() + advance_one(s, m.end(), prog.bytes_mode)
+                                if m.end() < haystack.len() {
+                                    m.end() + advance_one(haystack, m.end(), prog.bytes_mode)
                                 } else {
                                     // Zero-width match at end-of-string.  Push a sentinel value
-                                    // (s.len() + 1) so that if the main pattern fails and we
-                                    // backtrack here, the `ix > s.len()` guard above returns None
+                                    // (haystack.len() + 1) so that if the main pattern fails and we
+                                    // backtrack here, the `ix > haystack.len()` guard above returns None
                                     // immediately instead of looping.
-                                    s.len() + 1
+                                    haystack.len() + 1
                                 }
                             } else {
-                                m.start() + advance_one(s, m.start(), prog.bytes_mode)
+                                m.start() + advance_one(haystack, m.start(), prog.bytes_mode)
                             };
                             state.push(pc, next_seek_start)?;
                             ix = m.start();
@@ -1212,9 +1212,9 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     }
                 }
                 Insn::RejectEmptyMatchAtEOFFollowingNewline => {
-                    if ix == s.len()
+                    if ix == haystack.len()
                         && ix > 0
-                        && matches_literal(s, ix - 1, ix, b"\n")
+                        && matches_literal(haystack, ix - 1, ix, b"\n")
                         && !slash_z_matched
                         && match_attempt_start == ix
                     {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -94,7 +94,7 @@ pub(crate) type CachePoolFn = alloc::boxed::Box<
 >;
 
 use crate::error::RuntimeError;
-use crate::input::RegexInput;
+use crate::input::{Input as HaystackInput, RegexInput};
 use crate::Assertion;
 use crate::BytesMode;
 use crate::Error;
@@ -579,7 +579,7 @@ impl State {
     }
 }
 
-fn codepoint_len_at<S: RegexInput + ?Sized>(s: &S, ix: usize) -> usize {
+fn codepoint_len_at<S: HaystackInput + ?Sized>(s: &S, ix: usize) -> usize {
     codepoint_len(s.as_bytes()[ix])
 }
 
@@ -587,7 +587,7 @@ fn codepoint_len_at<S: RegexInput + ?Sized>(s: &S, ix: usize) -> usize {
 /// In `Ascii` mode, always advances 1 byte. In `Unicode`/`UnicodeBytes` mode, advances
 /// by the full codepoint length at `ix`.
 #[inline]
-fn advance_one<S: RegexInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) -> usize {
+fn advance_one<S: HaystackInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) -> usize {
     match bytes_mode {
         BytesMode::Ascii => 1,
         _ => codepoint_len_at(s, ix),
@@ -598,7 +598,7 @@ fn advance_one<S: RegexInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) 
 /// In `Ascii` mode, simply returns `ix - 1`. In `Unicode`/`UnicodeBytes` mode,
 /// skips backward over UTF-8 continuation bytes.
 #[inline]
-fn prev_ix<S: RegexInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) -> usize {
+fn prev_ix<S: HaystackInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) -> usize {
     match bytes_mode {
         BytesMode::Ascii => ix - 1,
         _ => s.prev_codepoint_ix(ix),
@@ -606,7 +606,12 @@ fn prev_ix<S: RegexInput + ?Sized>(s: &S, ix: usize, bytes_mode: BytesMode) -> u
 }
 
 #[inline]
-fn matches_literal<S: RegexInput + ?Sized>(s: &S, ix: usize, end: usize, literal: &[u8]) -> bool {
+fn matches_literal<S: HaystackInput + ?Sized>(
+    s: &S,
+    ix: usize,
+    end: usize,
+    literal: &[u8],
+) -> bool {
     // Compare as bytes because the literal might be a single byte char whereas ix
     // points to a multibyte char. Comparing with str would result in an error like
     // "byte index N is not a char boundary".
@@ -643,7 +648,7 @@ fn matches_literal_casei_unicode(text: &str, literal: &str) -> bool {
     re.find(text).is_some()
 }
 
-fn matches_literal_casei<S: RegexInput + ?Sized>(
+fn matches_literal_casei<S: HaystackInput + ?Sized>(
     s: &S,
     ix: usize,
     end: usize,
@@ -712,8 +717,7 @@ fn store_capture_groups(
 pub fn run_trace(prog: &Prog, s: &str, pos: usize) -> Result<Option<Vec<usize>>> {
     run(
         prog,
-        s,
-        pos,
+        &RegexInput::new(s).from_pos(pos),
         OPTION_TRACE,
         &HardRegexRuntimeOptions::default(),
     )
@@ -721,18 +725,28 @@ pub fn run_trace(prog: &Prog, s: &str, pos: usize) -> Result<Option<Vec<usize>>>
 
 /// Run the program with default options.
 pub fn run_default(prog: &Prog, s: &str, pos: usize) -> Result<Option<Vec<usize>>> {
-    run(prog, s, pos, 0, &HardRegexRuntimeOptions::default())
+    run(
+        prog,
+        &RegexInput::new(s).from_pos(pos),
+        0,
+        &HardRegexRuntimeOptions::default(),
+    )
 }
 
 /// Run the program with options.
 #[allow(clippy::cognitive_complexity)]
-pub(crate) fn run<S: RegexInput + ?Sized>(
+pub(crate) fn run<S: HaystackInput + ?Sized>(
     prog: &Prog,
-    s: &S,
-    pos: usize,
+    input: &RegexInput<'_, S>,
     option_flags: u32,
     options: &HardRegexRuntimeOptions,
 ) -> Result<Option<Vec<usize>>> {
+    if input.is_done() {
+        return Ok(None);
+    }
+    let s = input.haystack();
+    let pos = input.effective_start();
+    let match_range = input.get_range();
     let mut state = State::new(prog.n_saves, MAX_STACK, option_flags);
     let mut inner_slots: Vec<Option<NonMaxUsize>> = Vec::new();
     let look_matcher = LookMatcher::new();
@@ -775,6 +789,9 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                         if state.get(0) > slot1 {
                             state.save(0, slot1);
                         }
+                    }
+                    if state.get(0) < match_range.start || state.get(1) > match_range.end {
+                        break 'fail;
                     }
                     return Ok(Some(state.saves));
                 }
@@ -869,6 +886,9 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                     continue;
                 }
                 Insn::SplitUnanchored(x, y) => {
+                    if ix > match_range.end {
+                        return Ok(None);
+                    }
                     match_attempt_start = ix;
                     slash_z_matched = false;
                     state.push(y, ix)?;
@@ -1155,15 +1175,15 @@ pub(crate) fn run<S: RegexInput + ?Sized>(
                     // A sentinel value greater than s.len() is pushed onto the backtrack stack
                     // when the seek found a zero-width match at end-of-string.  On re-entry with
                     // that sentinel, there are no more positions to try.
-                    if ix > s.len() {
+                    if ix > match_range.end {
                         return Ok(None);
                     }
 
                     // TODO: ideally we would be able to use .earliest(true) as an extra optimization
                     //       as we only care about the start of the match, but unfortunately this doesn't
                     //       always return the correct start position, perhaps a bug in regex-automata
-                    let input = Input::new(s.as_bytes()).span(ix..s.len());
-                    match inner.search(&input) {
+                    let seek_input = Input::new(s.as_bytes()).span(ix..match_range.end);
+                    match inner.search(&seek_input) {
                         None => return Ok(None),
                         Some(m) => {
                             // Compute the next position to retry the seek from on backtrack:

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -810,7 +810,10 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     }
                 }
                 Insn::AnyNoCRLF => {
-                    if ix < haystack.len() && haystack.as_bytes()[ix] != b'\r' && haystack.as_bytes()[ix] != b'\n' {
+                    if ix < haystack.len()
+                        && haystack.as_bytes()[ix] != b'\r'
+                        && haystack.as_bytes()[ix] != b'\n'
+                    {
                         ix += advance_one(haystack, ix, prog.bytes_mode);
                     } else {
                         break 'fail;
@@ -861,18 +864,18 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         Assertion::LeftWordBoundary => look_matcher
                             .is_word_start_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
-                        Assertion::RightWordBoundary => {
-                            look_matcher.is_word_end_unicode(haystack.as_bytes(), ix).unwrap()
-                        }
+                        Assertion::RightWordBoundary => look_matcher
+                            .is_word_end_unicode(haystack.as_bytes(), ix)
+                            .unwrap(),
                         Assertion::LeftWordHalfBoundary => look_matcher
                             .is_word_start_half_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
                         Assertion::RightWordHalfBoundary => look_matcher
                             .is_word_end_half_unicode(haystack.as_bytes(), ix)
                             .unwrap(),
-                        Assertion::WordBoundary => {
-                            look_matcher.is_word_unicode(haystack.as_bytes(), ix).unwrap()
-                        }
+                        Assertion::WordBoundary => look_matcher
+                            .is_word_unicode(haystack.as_bytes(), ix)
+                            .unwrap(),
                         Assertion::NotWordBoundary => look_matcher
                             .is_word_unicode_negate(haystack.as_bytes(), ix)
                             .unwrap(),

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -1,4 +1,4 @@
-use fancy_regex::{Captures, CompileError, Error, Expander, Match, Result};
+use fancy_regex::{Captures, CompileError, Error, Expander, Match, RegexInput, Result};
 use matches::assert_matches;
 use std::borrow::Cow;
 use std::ops::Index;
@@ -462,6 +462,40 @@ fn captures_from_pos_looking_left() {
     assert_eq!(captures.len(), 2);
     assert_match(captures.get(0), "x", 1, 2);
     assert_match(captures.get(1), "x", 1, 2);
+}
+
+#[test]
+fn captures_input_wrap_range_keeps_anchor_context() {
+    assert!(common::assert_captures_input(r"\bat\b", "batter", 0, 1..3).is_none());
+
+    let captures = common::assert_captures_input(r"(?m)^foo$", "xx\nfoo\nzz", 0, 3..6).unwrap();
+    assert_match(captures.get(0), "foo", 3, 6);
+}
+
+#[test]
+fn captures_input_fancy_range_allows_lookaround_outside_range() {
+    let captures = common::assert_captures_input(r"(?=(foo))\1(?=bar)", "foobar", 0, 0..3).unwrap();
+    assert_match(captures.get(0), "foo", 0, 3);
+    assert_match(captures.get(1), "foo", 0, 3);
+
+    let captures = common::assert_captures_input(r"(?<=foo)(bar)", "foobar", 3, 3..6).unwrap();
+    assert_match(captures.get(0), "bar", 3, 6);
+    assert_match(captures.get(1), "bar", 3, 6);
+}
+
+#[test]
+fn captures_iter_input_respects_range_for_empty_matches() {
+    let regex = common::regex(r"(?m)(^)");
+    let text = "a\nb\n";
+    let spans: Vec<_> = regex
+        .captures_iter_input(RegexInput::new(text).range(2..4))
+        .map(|caps| {
+            let caps = caps.unwrap();
+            let m = caps.get(0).unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(spans, vec![(2, 2), (4, 4)]);
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
-use fancy_regex::{BytesMode, Captures, Regex, RegexBuilder};
+use fancy_regex::{BytesMode, Captures, Regex, RegexBuilder, RegexInput};
+use std::ops::Range;
 
 #[allow(dead_code)]
 pub fn regex(re: &str) -> Regex {
@@ -84,6 +85,36 @@ pub fn assert_find(re: &str, text: &str) -> Option<(usize, usize)> {
     assert_eq!(
         str_result, bytes_result,
         "Expected regex '{}' find results to agree between str and bytes mode for text '{}'",
+        re, text
+    );
+    str_result
+}
+
+/// Run `find_input` against `text` in both str mode and ASCII bytes mode, assert
+/// that both agree, and return the common result.
+#[cfg_attr(feature = "track_caller", track_caller)]
+#[allow(dead_code)]
+pub fn assert_find_input(
+    re: &str,
+    text: &str,
+    start: usize,
+    range: Range<usize>,
+) -> Option<(usize, usize)> {
+    let str_result = regex(re)
+        .find_input(RegexInput::new(text).from_pos(start).range(range.clone()))
+        .unwrap()
+        .map(|m| (m.start(), m.end()));
+    let bytes_result = ascii_bytes_regex(re)
+        .find_input(
+            RegexInput::new(text.as_bytes())
+                .from_pos(start)
+                .range(range),
+        )
+        .unwrap()
+        .map(|m| (m.start(), m.end()));
+    assert_eq!(
+        str_result, bytes_result,
+        "Expected regex '{}' find_input results to agree between str and bytes mode for text '{}'",
         re, text
     );
     str_result
@@ -178,6 +209,57 @@ pub fn assert_captures_from_pos<'t>(
                 re,
                 text,
                 pos
+            );
+        }
+    }
+    str_result
+}
+
+/// Run `captures_input` against `text` in both str mode and ASCII bytes mode,
+/// assert that both agree on every group span, and return the str-mode result.
+#[cfg_attr(feature = "track_caller", track_caller)]
+#[allow(dead_code)]
+pub fn assert_captures_input<'t>(
+    re: &str,
+    text: &'t str,
+    start: usize,
+    range: Range<usize>,
+) -> Option<Captures<'t, str>> {
+    let str_result = regex(re)
+        .captures_input(RegexInput::new(text).from_pos(start).range(range.clone()))
+        .expect("expected captures_input to succeed (str mode)");
+    let bytes_result = ascii_bytes_regex(re)
+        .captures_input(
+            RegexInput::new(text.as_bytes())
+                .from_pos(start)
+                .range(range),
+        )
+        .expect("expected captures_input to succeed (bytes mode)");
+    assert_eq!(
+        str_result.is_some(),
+        bytes_result.is_some(),
+        "Expected regex '{}' captures_input to agree between str and bytes modes for '{}'",
+        re,
+        text
+    );
+    if let (Some(ref s), Some(ref b)) = (&str_result, &bytes_result) {
+        assert_eq!(
+            s.len(),
+            b.len(),
+            "Expected capture group count to agree for regex '{}' on '{}'",
+            re,
+            text
+        );
+        for i in 0..s.len() {
+            let str_span = s.get(i).map(|m| (m.start(), m.end()));
+            let bytes_span = b.get(i).map(|m| (m.start(), m.end()));
+            assert_eq!(
+                str_span,
+                bytes_span,
+                "Expected capture group {} to agree between str and bytes modes for regex '{}' on '{}'",
+                i,
+                re,
+                text
             );
         }
     }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use fancy_regex::{Match, RegexBuilder};
+use fancy_regex::{Match, RegexBuilder, RegexInput};
 use matches::assert_matches;
 use std::ops::Range;
 
@@ -1081,6 +1081,57 @@ fn find_from_pos_at_end_still_runs() {
     let re = RegexBuilder::new("$").oniguruma_mode(true).build().unwrap();
     let result = re.find_from_pos("ab", 2).unwrap();
     assert!(result.is_some(), "pattern `$` must match at end-of-text");
+}
+
+#[test]
+fn find_input_wrap_range_keeps_word_boundary_context() {
+    assert_eq!(
+        common::assert_find_input(r"\bat\b", "batter", 0, 1..3),
+        None
+    );
+    assert_eq!(
+        common::assert_find_input(r"\bat\b", "batter at", 0, 7..9),
+        Some((7, 9))
+    );
+}
+
+#[test]
+fn find_input_wrap_range_handles_multiline_anchor_and_end_anchor() {
+    assert_eq!(
+        common::assert_find_input(r"(?m)^foo$", "xx\nfoo\nzz", 0, 3..6),
+        Some((3, 6))
+    );
+    assert_eq!(common::assert_find_input(r"$", "ab", 0, 2..2), Some((2, 2)));
+    assert_eq!(
+        common::assert_find_input(r"\z", "ab", 0, 2..2),
+        Some((2, 2))
+    );
+}
+
+#[test]
+fn find_input_fancy_range_allows_lookaround_outside_range() {
+    assert_eq!(
+        common::assert_find_input(r"(?=(foo))\1(?=bar)", "foobar", 0, 0..3),
+        Some((0, 3))
+    );
+    assert_eq!(
+        common::assert_find_input(r"(?<=foo)bar", "foobar", 3, 3..6),
+        Some((3, 6))
+    );
+}
+
+#[test]
+fn find_iter_input_respects_range_for_empty_matches() {
+    let re = common::regex(r"(?m)^");
+    let text = "a\nb\n";
+    let spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text).range(2..4))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(spans, vec![(2, 2), (4, 4)]);
 }
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,4 +1,4 @@
-use fancy_regex::{BytesMode, Error, RegexBuilder, RuntimeError};
+use fancy_regex::{BytesMode, Error, RegexBuilder, RegexInput, RuntimeError};
 
 mod common;
 
@@ -107,6 +107,19 @@ fn atomic_group() {
     // Look-ahead forces use of VM
     common::assert_is_match(r"^a(bc(?=d)|b)cd$", "abcd");
     common::assert_no_match(r"^a(?>bc(?=d)|b)cd$", "abcd");
+}
+
+#[test]
+fn is_match_input_respects_range_without_slicing() {
+    let re = RegexBuilder::new(r"\bat\b").build().unwrap();
+    assert!(!re
+        .is_match_input(RegexInput::new("batter").range(1..3))
+        .unwrap());
+
+    let re = RegexBuilder::new(r"(?=(foo))\1(?=bar)").build().unwrap();
+    assert!(re
+        .is_match_input(RegexInput::new("foobar").range(0..3))
+        .unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Rework RegexInput to allow searching within a range without slicing

- rename RegexInput struct to Input
- create new RegexInput struct which contains the Input struct (i.e. the haystack), a range to search within (defaulting to the full range of the haystack) and a start position (defaulting to 0 - the beginning)
- if a match attempt would start after the given range, stop searching
- if a match extends past the given range, fail the match
- delegates inside the VM are left unconstrained