### PR TITLE
Add runtime assertion overrides on RegexInput

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -209,6 +209,7 @@ pub fn analyze_regex(pattern: &str, flags: JsValue) -> Result<String, String> {
                     explicit_capture_group_0: requires_capture_group_fixup,
                     find_not_empty: flags.find_not_empty,
                     disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
+                    allow_input_assertion_overrides: false,
                 },
             ) {
                 Ok(info) => Ok(format!("{:#?}", info)),
@@ -483,6 +484,7 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
                     explicit_capture_group_0: requires_capture_group_fixup,
                     find_not_empty: flags.find_not_empty,
                     disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
+                    allow_input_assertion_overrides: false,
                 },
             ) {
                 Ok(info) => {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -133,6 +133,9 @@ struct Analyzer<'a> {
     /// When true, nodes that could produce empty matches (min size 0 and not const size)
     /// are promoted to hard so the VM can ensure the whole match at EOF isn't empty.
     disallow_empty_match_at_eof_after_newline: bool,
+    /// When true, assertions with runtime input suppression overrides are promoted to hard
+    /// so they run on the VM.
+    allow_input_assertion_overrides: bool,
 }
 
 impl<'a> Analyzer<'a> {
@@ -152,7 +155,13 @@ impl<'a> Analyzer<'a> {
         let mut const_size = false;
         let mut hard = false;
         match *expr {
-            Expr::Assertion(assertion) if assertion.is_hard() => {
+            Expr::Assertion(assertion) if assertion.is_always_hard() => {
+                const_size = true;
+                hard = true;
+            }
+            Expr::Assertion(Assertion::StartText | Assertion::EndText)
+                if self.allow_input_assertion_overrides =>
+            {
                 const_size = true;
                 hard = true;
             }
@@ -796,6 +805,9 @@ pub struct AnalyzeContext {
     pub find_not_empty: bool,
     /// To match Oniguruma behavior where only \z can match at EOF if preceeded by a newline character
     pub disallow_empty_match_at_eof_after_newline: bool,
+    /// When true, treat assertions that support runtime input suppression overrides (`\A`, `\z`)
+    /// as hard so that they execute on the VM.
+    pub allow_input_assertion_overrides: bool,
 }
 
 /// Analyze the parsed expression to determine whether it requires fancy features.
@@ -803,6 +815,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
     let explicit_capture_group_0 = ctx.explicit_capture_group_0;
     let find_not_empty = ctx.find_not_empty;
     let disallow_empty_match_at_eof_after_newline = ctx.disallow_empty_match_at_eof_after_newline;
+    let allow_input_assertion_overrides = ctx.allow_input_assertion_overrides;
 
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
     if tree.numbered_groups_ignored
@@ -836,6 +849,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
         analyzing_groups: BitSet::new(),
         find_not_empty,
         disallow_empty_match_at_eof_after_newline,
+        allow_input_assertion_overrides,
     };
 
     let mut analyzed = analyzer.visit(&tree.expr, 0, false, 0)?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,6 +26,9 @@ pub struct RegexInput<'h, S: Input + ?Sized> {
     haystack: &'h S,
     start: usize,
     range: Range<usize>,
+    start_text: Option<bool>,
+    end_text: Option<bool>,
+    continue_from_previous_match_end: Option<bool>,
 }
 
 impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
@@ -35,6 +38,9 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
             haystack,
             start: 0,
             range: 0..haystack.len(),
+            start_text: None,
+            end_text: None,
+            continue_from_previous_match_end: None,
         }
     }
 
@@ -75,6 +81,36 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
         self
     }
 
+    /// Return a copy of this input with an override for whether `^`/`\A`
+    /// should match.
+    ///
+    /// This override is suppression-only: `false` suppresses the assertion, while
+    /// `true` clears the override and preserves default behavior.
+    pub fn start_text(mut self, yes: bool) -> Self {
+        self.start_text = if yes { None } else { Some(false) };
+        self
+    }
+
+    /// Return a copy of this input with an override for whether `$`/`\z`
+    /// should match.
+    ///
+    /// This override is suppression-only: `false` suppresses the assertion, while
+    /// `true` clears the override and preserves default behavior.
+    pub fn end_text(mut self, yes: bool) -> Self {
+        self.end_text = if yes { None } else { Some(false) };
+        self
+    }
+
+    /// Return a copy of this input with an override for whether `\G` should
+    /// match.
+    ///
+    /// This override is suppression-only: `false` suppresses the assertion, while
+    /// `true` clears the override and preserves default behavior.
+    pub fn continue_from_previous_match_end(mut self, yes: bool) -> Self {
+        self.continue_from_previous_match_end = if yes { None } else { Some(false) };
+        self
+    }
+
     pub(crate) fn effective_start(&self) -> usize {
         self.start.max(self.range.start)
     }
@@ -85,6 +121,18 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
 
     pub(crate) fn set_start(&mut self, start: usize) {
         self.start = start;
+    }
+
+    pub(crate) fn start_text_override(&self) -> Option<bool> {
+        self.start_text
+    }
+
+    pub(crate) fn end_text_override(&self) -> Option<bool> {
+        self.end_text
+    }
+
+    pub(crate) fn continue_from_previous_match_end_override(&self) -> Option<bool> {
+        self.continue_from_previous_match_end
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,7 @@ struct HardRegexRuntimeOptions {
     backtrack_limit: usize,
     find_not_empty: bool,
     disallow_empty_match_at_eof_after_newline: bool,
+    allow_input_assertion_overrides: bool,
 }
 
 impl RegexOptions {
@@ -605,6 +606,7 @@ impl Default for HardRegexRuntimeOptions {
             backtrack_limit: 1_000_000,
             find_not_empty: false,
             disallow_empty_match_at_eof_after_newline: false,
+            allow_input_assertion_overrides: false,
         }
     }
 }
@@ -917,6 +919,20 @@ impl RegexOptionsBuilder {
             .disallow_empty_match_at_eof_after_newline = yes;
         self
     }
+
+    /// Allow [`RegexInput`] assertion suppression overrides at runtime.
+    ///
+    /// When enabled, patterns containing `\A` and `\z` are treated as hard and compiled to the VM
+    /// so that [`RegexInput::start_text`] and [`RegexInput::end_text`] can suppress those
+    /// assertions.
+    ///
+    /// When disabled (the default), those runtime overrides are ignored.
+    pub fn allow_input_assertion_overrides(&mut self, yes: bool) -> &mut Self {
+        self.options
+            .hard_regex_runtime_options
+            .allow_input_assertion_overrides = yes;
+        self
+    }
 }
 
 impl RegexBuilder {
@@ -1044,6 +1060,12 @@ impl RegexBuilder {
         self.options.disallow_empty_match_at_eof_after_newline(yes);
         self
     }
+
+    /// See [`RegexOptionsBuilder::allow_input_assertion_overrides`]
+    pub fn allow_input_assertion_overrides(&mut self, yes: bool) -> &mut Self {
+        self.options.allow_input_assertion_overrides(yes);
+        self
+    }
 }
 
 impl fmt::Debug for Regex {
@@ -1084,6 +1106,9 @@ impl Regex {
         let disallow_empty_match_at_eof_after_newline = options
             .hard_regex_runtime_options
             .disallow_empty_match_at_eof_after_newline;
+        let allow_input_assertion_overrides = options
+            .hard_regex_runtime_options
+            .allow_input_assertion_overrides;
 
         let requires_capture_group_fixup = if find_not_empty {
             // if the find_not_empty flag is set, we skip optimizations
@@ -1102,6 +1127,7 @@ impl Regex {
                 explicit_capture_group_0: requires_capture_group_fixup,
                 find_not_empty,
                 disallow_empty_match_at_eof_after_newline,
+                allow_input_assertion_overrides,
             },
         )?;
 
@@ -2353,17 +2379,18 @@ pub enum Assertion {
 }
 
 impl Assertion {
-    pub(crate) fn is_hard(&self) -> bool {
+    pub(crate) fn is_always_hard(&self) -> bool {
         use Assertion::*;
         matches!(
             self,
-            // these will make regex-automata use PikeVM
+            // these will make regex-automata use PikeVM and are not compabible with certain regex-automata features we use
             LeftWordBoundary
                 | LeftWordHalfBoundary
                 | RightWordBoundary
                 | RightWordHalfBoundary
                 | WordBoundary
                 | NotWordBoundary
+                // `\Z` needs custom trailing-newline handling.
                 | EndTextIgnoreTrailingNewlines { .. }
         )
     }
@@ -2727,7 +2754,7 @@ mod tests {
     use alloc::{format, vec};
 
     use crate::parse::{make_group, make_literal};
-    use crate::{Absent, Expr, Regex, RegexImpl};
+    use crate::{Absent, Expr, Regex, RegexBuilder, RegexImpl};
 
     //use detect_possible_backref;
 
@@ -2865,6 +2892,27 @@ mod tests {
         );
         assert_eq!(s, regex.as_str());
         assert_eq!(s, format!("{:?}", regex));
+    }
+
+    #[test]
+    fn start_end_text_assertions_can_stay_wrap_without_override_opt_in() {
+        let regex = Regex::new(r"\Afoo\z").unwrap();
+        assert!(
+            matches!(regex.inner, RegexImpl::Wrap { .. }),
+            r"\A...\z should stay on the wrap path unless input assertion overrides are enabled"
+        );
+    }
+
+    #[test]
+    fn start_end_text_assertions_become_fancy_with_override_opt_in() {
+        let regex = RegexBuilder::new(r"\Afoo\z")
+            .allow_input_assertion_overrides(true)
+            .build()
+            .unwrap();
+        assert!(
+            matches!(regex.inner, RegexImpl::Fancy { .. }),
+            r"\A...\z should use the VM when input assertion overrides are enabled"
+        );
     }
 
     /*

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -828,9 +828,19 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                 }
                 Insn::Assertion(assertion) => {
                     if !match assertion {
-                        Assertion::StartText => look_matcher.is_start(haystack.as_bytes(), ix),
+                        Assertion::StartText => input
+                            .start_text_override()
+                            .and_then(|value| {
+                                options.allow_input_assertion_overrides.then_some(value)
+                            })
+                            .unwrap_or_else(|| look_matcher.is_start(haystack.as_bytes(), ix)),
                         Assertion::EndText => {
-                            let matched = look_matcher.is_end(haystack.as_bytes(), ix);
+                            let matched = input
+                                .end_text_override()
+                                .and_then(|value| {
+                                    options.allow_input_assertion_overrides.then_some(value)
+                                })
+                                .unwrap_or_else(|| look_matcher.is_end(haystack.as_bytes(), ix));
                             slash_z_matched |= matched;
                             matched
                         }
@@ -1161,7 +1171,11 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     }
                 }
                 Insn::ContinueFromPreviousMatchEnd { at_start } => {
-                    if ix > pos || option_flags & OPTION_SKIPPED_EMPTY_MATCH != 0 {
+                    let at_previous_match_end = input
+                        .continue_from_previous_match_end_override()
+                        .and_then(|value| options.allow_input_assertion_overrides.then_some(value))
+                        .unwrap_or(ix == pos && option_flags & OPTION_SKIPPED_EMPTY_MATCH == 0);
+                    if !at_previous_match_end {
                         // If \G is at the start of the pattern, we can fail early
                         // instead of checking at each position in the haystack
                         // because \G will never match at any other position

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -1,4 +1,6 @@
-use fancy_regex::{Captures, CompileError, Error, Expander, Match, RegexInput, Result};
+use fancy_regex::{
+    BytesMode, Captures, CompileError, Error, Expander, Match, RegexBuilder, RegexInput, Result,
+};
 use matches::assert_matches;
 use std::borrow::Cow;
 use std::ops::Index;
@@ -481,6 +483,49 @@ fn captures_input_fancy_range_allows_lookaround_outside_range() {
     let captures = common::assert_captures_input(r"(?<=foo)(bar)", "foobar", 3, 3..6).unwrap();
     assert_match(captures.get(0), "bar", 3, 6);
     assert_match(captures.get(1), "bar", 3, 6);
+}
+
+#[test]
+fn captures_input_text_boundary_overrides() {
+    let re = RegexBuilder::new(r"\A(foo)\z")
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    let re_bytes = RegexBuilder::new(r"\A(foo)\z")
+        .bytes_mode(BytesMode::Ascii)
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    let caps = re
+        .captures_input(RegexInput::new("foo").start_text(false).end_text(false))
+        .unwrap();
+    assert!(caps.is_none());
+    let caps = re_bytes
+        .captures_input(
+            RegexInput::new("foo".as_bytes())
+                .start_text(false)
+                .end_text(false),
+        )
+        .unwrap();
+    assert!(caps.is_none());
+
+    let caps = re
+        .captures_input(RegexInput::new("foo").start_text(true).end_text(true))
+        .unwrap()
+        .unwrap();
+    assert_match(caps.get(0), "foo", 0, 3);
+    assert_match(caps.get(1), "foo", 0, 3);
+
+    let caps = re_bytes
+        .captures_input(
+            RegexInput::new("foo".as_bytes())
+                .start_text(true)
+                .end_text(true),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(caps.get(0).map(|m| (m.start(), m.end())), Some((0, 3)));
+    assert_eq!(caps.get(1).map(|m| (m.start(), m.end())), Some((0, 3)));
 }
 
 #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use fancy_regex::{Match, RegexBuilder, RegexInput};
+use fancy_regex::{BytesMode, Match, RegexBuilder, RegexInput};
 use matches::assert_matches;
 use std::ops::Range;
 
@@ -1132,6 +1132,117 @@ fn find_iter_input_respects_range_for_empty_matches() {
         })
         .collect();
     assert_eq!(spans, vec![(2, 2), (4, 4)]);
+}
+
+#[test]
+fn find_input_text_boundary_overrides() {
+    let re = RegexBuilder::new(r"\Afoo\z")
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    let re_bytes = RegexBuilder::new(r"\Afoo\z")
+        .bytes_mode(BytesMode::Ascii)
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    assert_eq!(
+        re.find_input(RegexInput::new("foo").start_text(false).end_text(false))
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        None
+    );
+    assert_eq!(
+        re_bytes
+            .find_input(
+                RegexInput::new("foo".as_bytes())
+                    .start_text(false)
+                    .end_text(false)
+            )
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        None
+    );
+    assert_eq!(
+        re.find_input(RegexInput::new("foo").start_text(true).end_text(true))
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((0, 3))
+    );
+    assert_eq!(
+        re_bytes
+            .find_input(
+                RegexInput::new("foo".as_bytes())
+                    .start_text(true)
+                    .end_text(true)
+            )
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((0, 3))
+    );
+}
+
+#[test]
+fn find_iter_input_continue_from_previous_match_end_override() {
+    let re = RegexBuilder::new(r"\G")
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    let re_bytes = RegexBuilder::new(r"\G")
+        .bytes_mode(BytesMode::Ascii)
+        .allow_input_assertion_overrides(true)
+        .build()
+        .unwrap();
+    let text = "ab";
+    let default_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(default_spans, vec![(0, 0)]);
+    let default_spans_bytes: Vec<_> = re_bytes
+        .find_iter_input(RegexInput::new(text.as_bytes()))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(default_spans_bytes, default_spans);
+
+    let forced_false_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text).continue_from_previous_match_end(false))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(forced_false_spans, vec![]);
+    let forced_false_spans_bytes: Vec<_> = re_bytes
+        .find_iter_input(RegexInput::new(text.as_bytes()).continue_from_previous_match_end(false))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(forced_false_spans_bytes, forced_false_spans);
+
+    let forced_true_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text).continue_from_previous_match_end(true))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(forced_true_spans, default_spans);
+    let forced_true_spans_bytes: Vec<_> = re_bytes
+        .find_iter_input(RegexInput::new(text.as_bytes()).continue_from_previous_match_end(true))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(forced_true_spans_bytes, forced_true_spans);
 }
 
 fn find(re: &str, text: &str) -> Option<(usize, usize)> {

--- a/tests/regex_options.rs
+++ b/tests/regex_options.rs
@@ -1,4 +1,4 @@
-use fancy_regex::{CompileError, Error, ParseError, Regex, RegexBuilder};
+use fancy_regex::{CompileError, Error, ParseError, Regex, RegexBuilder, RegexInput};
 
 mod common;
 
@@ -618,4 +618,59 @@ fn disallow_empty_match_at_eof_after_newline_still_allows_slash_z() {
         find_all_matches(&create_regex(r"$\z", false), haystack),
         [4]
     );
+}
+
+#[test]
+fn input_assertion_overrides_are_ignored_by_default() {
+    let re = build_regex(&RegexBuilder::new(r"\Afoo\z"));
+    assert_eq!(
+        re.find_input(RegexInput::new("foo").start_text(false).end_text(false))
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        Some((0, 3))
+    );
+}
+
+#[test]
+fn input_assertion_overrides_require_builder_opt_in() {
+    let re = build_regex(RegexBuilder::new(r"\Afoo\z").allow_input_assertion_overrides(true));
+    assert_eq!(
+        re.find_input(RegexInput::new("foo").start_text(false).end_text(false))
+            .unwrap()
+            .map(|m| (m.start(), m.end())),
+        None
+    );
+}
+
+#[test]
+fn continue_from_previous_match_end_override_is_suppression_only() {
+    let re = build_regex(RegexBuilder::new(r"\G").allow_input_assertion_overrides(true));
+    let text = "ab";
+
+    let default_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(default_spans, vec![(0, 0)]);
+
+    let suppressed_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text).continue_from_previous_match_end(false))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert!(suppressed_spans.is_empty());
+
+    let cleared_override_spans: Vec<_> = re
+        .find_iter_input(RegexInput::new(text).continue_from_previous_match_end(true))
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(cleared_override_spans, default_spans);
 }


### PR DESCRIPTION
to allow `^` / `\A` and `$` / `\z` to be treated as non-matching even though they might normally match. Useful for syntax highlighting scenarios when matching against one line at a time - the `(?m:^|$)` will still match at the beginning/end of the line, but now there is a way for the syntax grammar to know when it is at BOF or EOF.