### PR TITLE
Support Oniguruma repeated quantifiers and swapped quantifier order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1839,6 +1839,19 @@ impl Regex {
     }
 }
 
+/// `Display` adapter that prints a [`Regex`]'s internal representation via
+/// [`Regex::debug_print`]. Intended for debugging and test output only.
+#[doc(hidden)]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct DebugRegex<'a>(pub &'a Regex);
+
+impl fmt::Display for DebugRegex<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.debug_print(f)
+    }
+}
+
 fn ra_input<'a, S: input::Input + ?Sized>(input: &'a RegexInput<'a, S>) -> RaInput<'a> {
     let mut ra_input = RaInput::new(input.haystack().as_bytes()).range(input.get_range());
     ra_input.set_start(input.effective_start());

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -249,8 +249,7 @@ impl<'a> Parser<'a> {
             let mut adjacent = 0;
             loop {
                 let before = ix;
-                let (next_ix, next_repeat) =
-                    self.parse_quantifier(ix, before, repeat)?;
+                let (next_ix, next_repeat) = self.parse_quantifier(ix, before, repeat)?;
                 ix = next_ix;
                 repeat = next_repeat;
                 if ix == before {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -160,12 +160,14 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_piece(&mut self, ix: usize, depth: usize) -> Result<(usize, Expr)> {
-        let start = ix;
-        let (ix, child) = self.parse_atom(ix, depth)?;
+    fn parse_quantifier(
+        &mut self,
+        ix: usize,
+        start_ix: usize,
+        child: Expr,
+    ) -> Result<(usize, Expr)> {
         let mut ix = self.optional_whitespace(ix)?;
         if ix < self.re.len() {
-            // fail when child is empty?
             let (lo, hi) = match self.re.as_bytes()[ix] {
                 b'?' => (0, 1),
                 b'*' => (0, usize::MAX),
@@ -189,10 +191,10 @@ impl<'a> Parser<'a> {
                 // In Oniguruma mode, `(?:)` followed by a quantifier is a
                 // zero-width no-op that Oniguruma silently accepts. Skip
                 // past the quantifier and its modifiers, returning Empty.
-                // We check `ix > start` to ensure the atom actually consumed
+                // We check `ix > start_ix` to ensure the atom actually consumed
                 // input (e.g. a `(?:)` group), as opposed to a bare
                 // quantifier with no preceding atom.
-                if child == Expr::Empty && ix > start && self.flag(FLAG_ONIGURUMA_MODE) {
+                if child == Expr::Empty && ix > start_ix && self.flag(FLAG_ONIGURUMA_MODE) {
                     skip = true;
                 } else {
                     return Err(Error::ParseError(ix, ParseError::TargetNotRepeatable));
@@ -226,6 +228,42 @@ impl<'a> Parser<'a> {
             }
         }
         Ok((ix, child))
+    }
+
+    fn parse_piece(&mut self, ix: usize, depth: usize) -> Result<(usize, Expr)> {
+        let start = ix;
+        let (ix, child) = self.parse_atom(ix, depth)?;
+        let (mut ix, mut repeat) = self.parse_quantifier(ix, start, child)?;
+        if self.flag(FLAG_ONIGURUMA_MODE) {
+            // Oniguruma allows expressions like `\s{1,2}{0,1}` to mean `(?:\s{1,2})?`.
+            // Each additional adjacent quantifier wraps the previous result in
+            // another `Expr::Repeat` (and `Expr::AtomicGroup` if a possessive
+            // `+` modifier follows), increasing AST depth. We count them
+            // against the parse recursion budget AND enforce a tighter
+            // per-piece cap, because the AST depth interacts multiplicatively
+            // with subroutine-call inlining (`\g<...>`) during compile and
+            // can otherwise blow the stack on adversarial inputs like
+            // Oniguruma test #139.
+            const MAX_ADJACENT_QUANTIFIERS: usize = 4;
+            let mut depth = depth;
+            let mut adjacent = 0;
+            loop {
+                let before = ix;
+                let (next_ix, next_repeat) =
+                    self.parse_quantifier(ix, before, repeat)?;
+                ix = next_ix;
+                repeat = next_repeat;
+                if ix == before {
+                    break;
+                }
+                adjacent += 1;
+                depth += 1;
+                if adjacent > MAX_ADJACENT_QUANTIFIERS || depth >= MAX_RECURSION {
+                    return Err(Error::ParseError(ix, ParseError::RecursionExceeded));
+                }
+            }
+        }
+        Ok((ix, repeat))
     }
 
     fn is_repeatable(&self, child: &Expr) -> bool {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -280,6 +280,9 @@ impl<'a> Parser<'a> {
         if ix == self.re.len() || bytes[ix] != b'}' {
             return Err(Error::ParseError(ix, ParseError::InvalidRepeat));
         }
+        if self.flag(FLAG_ONIGURUMA_MODE) && hi < lo {
+            return Ok((ix + 1, hi, lo));
+        }
         Ok((ix + 1, lo, hi))
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+pub use fancy_regex::DebugRegex;
 use fancy_regex::{BytesMode, Captures, Regex, RegexBuilder, RegexInput};
 use std::ops::Range;
 
@@ -307,13 +309,4 @@ pub fn assert_captures<'t>(re: &str, text: &'t str) -> Option<Captures<'t, str>>
         }
     }
     str_result
-}
-
-use std::fmt;
-#[allow(dead_code)]
-pub struct DebugRegex<'a>(pub &'a Regex);
-impl fmt::Display for DebugRegex<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.debug_print(f)
-    }
 }

--- a/tests/oniguruma/test_utf8.c
+++ b/tests/oniguruma/test_utf8.c
@@ -1191,18 +1191,6 @@ extern int main(int argc, char* argv[])
   x2("(?(?{....})123|456)", "123", 0, 3);
   x2("(?(*FAIL)123|456)", "456", 0, 3);
 
-  x2("\\g'0'++{,0}",   "abcdefgh", 0, 0);
-  x2("\\g'0'++{,0}?",  "abcdefgh", 0, 0);
-  x2("\\g'0'++{,0}b",  "abcdefgh", 1, 2);
-  x2("\\g'0'++{,0}?def", "abcdefgh", 3, 6);
-  n("a{2,3}?",  "a");
-  n("a{3,2}a", "aaa");
-  x2("a{3,2}b", "aaab", 0, 4);
-  x2("a{3,2}b", "aaaab", 1, 5);
-  x2("a{3,2}b", "aab", 0, 3);
-  x2("a{3,2}?", "", 0, 0);     /* == (?:a{3,2})?*/
-  x2("a{2,3}+a", "aaa", 0, 3); /* == (?:a{2,3})+*/
-
   n("   \xfd", ""); /* https://bugs.php.net/bug.php?id=77370 */
   /* can't use \xfc00.. because compiler error: hex escape sequence out of range */
   n("()0\\xfc00000\\xfc00000\\xfc00000\xfc", ""); /* https://bugs.php.net/bug.php?id=77371 */

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -448,16 +448,7 @@
   // Compile failed: CompileError(LeftRecursiveSubroutineCall("group 0"))
   x2("\\g'0'++{,0}?def", "abcdefgh", 3, 6);
 
-  // Compile failed: CompileError(InnerError(BuildError { kind: Syntax { pid: PatternID(0), err: Parse(Error { kind: RepetitionCountInvalid, pattern: "a{3,2}b", span: Span(Position(o: 1, l: 1, c: 2), Position(o: 6, l: 1, c: 7)) }) } }))
-  x2("a{3,2}b", "aaab", 0, 4);
-
-  // Compile failed: CompileError(InnerError(BuildError { kind: Syntax { pid: PatternID(0), err: Parse(Error { kind: RepetitionCountInvalid, pattern: "a{3,2}b", span: Span(Position(o: 1, l: 1, c: 2), Position(o: 6, l: 1, c: 7)) }) } }))
-  x2("a{3,2}b", "aaaab", 1, 5);
-
-  // Compile failed: CompileError(InnerError(BuildError { kind: Syntax { pid: PatternID(0), err: Parse(Error { kind: RepetitionCountInvalid, pattern: "a{3,2}b", span: Span(Position(o: 1, l: 1, c: 2), Position(o: 6, l: 1, c: 7)) }) } }))
-  x2("a{3,2}b", "aab", 0, 3);
-
-  // Compile failed: CompileError(InnerError(BuildError { kind: Syntax { pid: PatternID(0), err: Parse(Error { kind: RepetitionCountInvalid, pattern: "a{3,2}?", span: Span(Position(o: 1, l: 1, c: 2), Position(o: 7, l: 1, c: 8)) }) } }))
+  // No match found
   x2("a{3,2}?", "", 0, 0);
 
   // No match found

--- a/tests/oniguruma/test_utf8_ignore.c
+++ b/tests/oniguruma/test_utf8_ignore.c
@@ -64,20 +64,8 @@
   // Match found at start 1 and end 2 (expected 0 and 2)
   x2("a(?i)b|c", "aC", 0, 2);
 
-  // No match found
-  x2("(?:ab)?{2}", "", 0, 0);
-
-  // No match found
-  x2("(?:ab)?{2}", "ababa", 0, 4);
-
-  // No match found
-  x2("(?:ab)*{0}", "ababa", 0, 0);
-
   // Match found at start 0 and end 2 (expected 0 and 5)
   x2("(?:ab){,}", "ab{,}", 0, 5);
-
-  // No match found
-  x2("(?:abc)+?{2}", "abcabcabc", 0, 6);
 
   // No match found
   x3("((?m:a.c))", "a\nc", 0, 3, 1);
@@ -219,20 +207,8 @@
   // No match found
   x2("(?m:.め)", "ま\nめ", 3, 7);
 
-  // No match found
-  x2("(?:あい)?{2}", "", 0, 0);
-
-  // No match found
-  x2("(?:鬼車)?{2}", "鬼車鬼車鬼", 0, 12);
-
-  // No match found
-  x2("(?:鬼車)*{0}", "鬼車鬼車鬼", 0, 0);
-
   // Match found at start 0 and end 6 (expected 0 and 9)
   x2("(?:鬼車){,}", "鬼車{,}", 0, 9);
-
-  // No match found
-  x2("(?:かきく)+?{2}", "かきくかきくかきく", 0, 18);
 
   // No match found
   x3("((?m:あ.う))", "あ\nう", 0, 7, 1);
@@ -423,7 +399,7 @@
   // Compile failed: ParseError(2, InvalidHex)
   x2("\\x1", "\x01", 0, 1);
 
-  // Compile failed: ParseError(10, TargetNotRepeatable)
+  // Compile failed: ParseError(88, RecursionExceeded)
   x2("((?()0+)+++(((0\\g<0>)0)|())++++((?(1)(0\\g<0>))++++++0*())++++((?(1)(0\\g<1>)+)++++++++++*())++++((?(1)((0)\\g<0>)+)++())+0++*+++(((0\\g<0>))*())++++((?(1)(0\\g<0>)+)++++++++++*|)++++*+++((?(1)((0)\\g<0>)+)+++++++++())++*|)++++((?()0))|", "abcde", 0, 0);
 
   // Compile failed: ParseError(9, TargetNotRepeatable)


### PR DESCRIPTION
Oniguruma allows expressions like `\s{1,2}{0,1}` to mean `(?:\s{1,2})?`.
Each additional adjacent quantifier wraps the previous result in another `Expr::Repeat` (and `Expr::AtomicGroup` if a possessive `+` modifier follows), increasing AST depth.
We count them against the parse recursion budget AND restrict how many consecutive quantifiers we parse in a row, because the AST depth interacts multiplicatively with subroutine-call inlining (`\g<...>`) during compilation and can otherwise blow the stack on adversarial inputs like Oniguruma test # 139.