### PR TITLE
Oniguruma quantifier parsing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ with the exception that 0.x versions can break between minor versions.
 ### Fixed
 - Fix bug whereby inline flags were not overriding the builder options (#247)
 - Fix bug whereby `\G` optimizations were applying where they shouldn't, giving wrong results (#256)
+- Support Oniguruma quantifier parsing rules, whereby swapped ordering causes possessiveness, `+` only causes possessiveness after `?`, `*` or `+` (#258)
 ### Upgrade guide
 If you previously stored i.e. `Captures`, you would need to change the type to `Captures<str>` to get the code to compile.
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -168,15 +168,15 @@ impl<'a> Parser<'a> {
     ) -> Result<(usize, Expr)> {
         let mut ix = self.optional_whitespace(ix)?;
         if ix < self.re.len() {
-            let (mut lo, mut hi) = match self.re.as_bytes()[ix] {
-                b'?' => (0, 1),
-                b'*' => (0, usize::MAX),
-                b'+' => (1, usize::MAX),
+            let (mut lo, mut hi, user_specified) = match self.re.as_bytes()[ix] {
+                b'?' => (0, 1, false),
+                b'*' => (0, usize::MAX, false),
+                b'+' => (1, usize::MAX, false),
                 b'{' => {
                     match self.parse_repeat(ix) {
                         Ok((next, lo, hi)) => {
                             ix = next - 1;
-                            (lo, hi)
+                            (lo, hi, true)
                         }
                         Err(_) => {
                             // Invalid repeat syntax, which results in `{` being treated as a literal
@@ -208,9 +208,14 @@ impl<'a> Parser<'a> {
             }
             greedy ^= self.flag(FLAG_SWAP_GREED);
             let mut atomic_group = false;
-            if self.flag(FLAG_ONIGURUMA_MODE) && hi < lo {
-                (lo, hi) = (hi, lo);
-                atomic_group = true;
+            if self.flag(FLAG_ONIGURUMA_MODE) {
+                if hi < lo {
+                    (lo, hi) = (hi, lo);
+                    atomic_group = true;
+                } else if !user_specified && ix < self.re.len() && self.re.as_bytes()[ix] == b'+' {
+                    ix += 1;
+                    atomic_group = true;
+                }
             } else if ix < self.re.len() && self.re.as_bytes()[ix] == b'+' {
                 ix += 1;
                 atomic_group = true;
@@ -3115,6 +3120,11 @@ mod tests {
     #[test]
     fn swapped_order_quantifier_oniguruma_mode() {
         assert_eq!(parse_oniguruma("x{3,0}").unwrap(), Expr::AtomicGroup(Box::new(Expr::Repeat { child: Box::new(make_literal("x")), lo: 0, hi: 3, greedy: true, })));
+    }
+
+    #[test]
+    fn plus_after_user_specified_quantifier_oniguruma_mode() {
+        assert_eq!(parse_oniguruma("x{2}+").unwrap(), Expr::Repeat { child: Box::new(Expr::Repeat { child: Box::new(make_literal("x")), lo: 2, hi: 2, greedy: true, }), lo: 1, hi: usize::MAX, greedy: true, });
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
     ) -> Result<(usize, Expr)> {
         let mut ix = self.optional_whitespace(ix)?;
         if ix < self.re.len() {
-            let (lo, hi) = match self.re.as_bytes()[ix] {
+            let (mut lo, mut hi) = match self.re.as_bytes()[ix] {
                 b'?' => (0, 1),
                 b'*' => (0, usize::MAX),
                 b'+' => (1, usize::MAX),
@@ -208,7 +208,10 @@ impl<'a> Parser<'a> {
             }
             greedy ^= self.flag(FLAG_SWAP_GREED);
             let mut atomic_group = false;
-            if ix < self.re.len() && self.re.as_bytes()[ix] == b'+' {
+            if self.flag(FLAG_ONIGURUMA_MODE) && hi < lo {
+                (lo, hi) = (hi, lo);
+                atomic_group = true;
+            } else if ix < self.re.len() && self.re.as_bytes()[ix] == b'+' {
                 ix += 1;
                 atomic_group = true;
             }
@@ -316,9 +319,6 @@ impl<'a> Parser<'a> {
         let ix = self.optional_whitespace(end)?; // past hi number
         if ix == self.re.len() || bytes[ix] != b'}' {
             return Err(Error::ParseError(ix, ParseError::InvalidRepeat));
-        }
-        if self.flag(FLAG_ONIGURUMA_MODE) && hi < lo {
-            return Ok((ix + 1, hi, lo));
         }
         Ok((ix + 1, lo, hi))
     }
@@ -3110,6 +3110,11 @@ mod tests {
         assert_eq!(parse_oniguruma("(?i:)*").unwrap(), Expr::Empty);
         assert_eq!(parse_oniguruma("(?s:)+").unwrap(), Expr::Empty);
         assert_eq!(parse_oniguruma("(?x: (?i:) * )").unwrap(), Expr::Empty);
+    }
+
+    #[test]
+    fn swapped_order_quantifier_oniguruma_mode() {
+        assert_eq!(parse_oniguruma("x{3,0}").unwrap(), Expr::AtomicGroup(Box::new(Expr::Repeat { child: Box::new(make_literal("x")), lo: 0, hi: 3, greedy: true, })));
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3119,12 +3119,33 @@ mod tests {
 
     #[test]
     fn swapped_order_quantifier_oniguruma_mode() {
-        assert_eq!(parse_oniguruma("x{3,0}").unwrap(), Expr::AtomicGroup(Box::new(Expr::Repeat { child: Box::new(make_literal("x")), lo: 0, hi: 3, greedy: true, })));
+        assert_eq!(
+            parse_oniguruma("x{3,0}").unwrap(),
+            Expr::AtomicGroup(Box::new(Expr::Repeat {
+                child: Box::new(make_literal("x")),
+                lo: 0,
+                hi: 3,
+                greedy: true,
+            }))
+        );
     }
 
     #[test]
     fn plus_after_user_specified_quantifier_oniguruma_mode() {
-        assert_eq!(parse_oniguruma("x{2}+").unwrap(), Expr::Repeat { child: Box::new(Expr::Repeat { child: Box::new(make_literal("x")), lo: 2, hi: 2, greedy: true, }), lo: 1, hi: usize::MAX, greedy: true, });
+        assert_eq!(
+            parse_oniguruma("x{2}+").unwrap(),
+            Expr::Repeat {
+                child: Box::new(Expr::Repeat {
+                    child: Box::new(make_literal("x")),
+                    lo: 2,
+                    hi: 2,
+                    greedy: true,
+                }),
+                lo: 1,
+                hi: usize::MAX,
+                greedy: true,
+            }
+        );
     }
 
     #[test]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1085,18 +1085,30 @@ fn find_from_pos_at_end_still_runs() {
 
 #[test]
 fn oniguruma_swapped_quantifier_order_is_possessive() {
-    let re = RegexBuilder::new("x{3,0}x").oniguruma_mode(true).build().unwrap();
+    let re = RegexBuilder::new("x{3,0}x")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
     let result = re.find_from_pos("xx", 0).unwrap();
-    assert!(result.is_none(), "swapped quantifier order in Oniguruma mode should make it possessive");
+    assert!(
+        result.is_none(),
+        "swapped quantifier order in Oniguruma mode should make it possessive"
+    );
 }
 
 #[test]
 fn oniguruma_plus_after_quantifier() {
-    let re = RegexBuilder::new("^x{2}+$").oniguruma_mode(true).build().unwrap();
+    let re = RegexBuilder::new("^x{2}+$")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
     let result = re.find_from_pos("xxxx", 0).unwrap();
     assert!(result.is_some(), "quantifier should be repeated");
 
-    let re = RegexBuilder::new("^x{0,3}+$").oniguruma_mode(true).build().unwrap();
+    let re = RegexBuilder::new("^x{0,3}+$")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
     let result = re.find_from_pos("xx", 0).unwrap();
     assert!(result.is_some(), "quantifier should be repeated");
 }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1084,6 +1084,13 @@ fn find_from_pos_at_end_still_runs() {
 }
 
 #[test]
+fn oniguruma_swapped_quantifier_order_is_possessive() {
+    let re = RegexBuilder::new("x{3,0}x").oniguruma_mode(true).build().unwrap();
+    let result = re.find_from_pos("xx", 0).unwrap();
+    assert!(result.is_none(), "swapped quantifier order in Oniguruma mode should make it possessive");
+}
+
+#[test]
 fn find_input_wrap_range_keeps_word_boundary_context() {
     assert_eq!(
         common::assert_find_input(r"\bat\b", "batter", 0, 1..3),

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1091,6 +1091,17 @@ fn oniguruma_swapped_quantifier_order_is_possessive() {
 }
 
 #[test]
+fn oniguruma_plus_after_quantifier() {
+    let re = RegexBuilder::new("^x{2}+$").oniguruma_mode(true).build().unwrap();
+    let result = re.find_from_pos("xxxx", 0).unwrap();
+    assert!(result.is_some(), "quantifier should be repeated");
+
+    let re = RegexBuilder::new("^x{0,3}+$").oniguruma_mode(true).build().unwrap();
+    let result = re.find_from_pos("xx", 0).unwrap();
+    assert!(result.is_some(), "quantifier should be repeated");
+}
+
+#[test]
 fn find_input_wrap_range_keeps_word_boundary_context() {
     assert_eq!(
         common::assert_find_input(r"\bat\b", "batter", 0, 1..3),


### PR DESCRIPTION
Support Oniguruma quantifier parsing rules, whereby swapped ordering causes possessiveness, `+` only causes possessiveness after `?`, `*` or `+`. In other cases (i.e. `a{2}+`), it is a standard repetition operator. Fixes https://github.com/fancy-regex/fancy-regex/pull/255#issuecomment-4742746550