### PR TITLE
In Oniguruma parsing mode, reject StartLine matches at EOF following a trailing newline

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -313,8 +313,12 @@ fn info_to_tree_node<'a>(
                 EndTextIgnoreTrailingNewlines { crlf: false } => {
                     ("EndTextIgnoreTrailingNewlines", None)
                 }
-                StartLine { crlf: true, .. } => ("StartLine", Some("(crlf)".to_string())),
-                StartLine { crlf: false, .. } => ("StartLine", None),
+                StartLine { crlf: true } => ("StartLine", Some("(crlf)".to_string())),
+                StartLine { crlf: false } => ("StartLine", None),
+                StartLineOniguruma { crlf: true } => {
+                    ("StartLineOniguruma", Some("(crlf)".to_string()))
+                }
+                StartLineOniguruma { crlf: false } => ("StartLineOniguruma", None),
                 EndLine { crlf: true } => ("EndLine", Some("(crlf)".to_string())),
                 EndLine { crlf: false } => ("EndLine", None),
                 LeftWordBoundary => ("LeftWordBoundary", None),

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -313,8 +313,8 @@ fn info_to_tree_node<'a>(
                 EndTextIgnoreTrailingNewlines { crlf: false } => {
                     ("EndTextIgnoreTrailingNewlines", None)
                 }
-                StartLine { crlf: true } => ("StartLine", Some("(crlf)".to_string())),
-                StartLine { crlf: false } => ("StartLine", None),
+                StartLine { crlf: true, .. } => ("StartLine", Some("(crlf)".to_string())),
+                StartLine { crlf: false, .. } => ("StartLine", None),
                 EndLine { crlf: true } => ("EndLine", Some("(crlf)".to_string())),
                 EndLine { crlf: false } => ("EndLine", None),
                 LeftWordBoundary => ("LeftWordBoundary", None),

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -136,6 +136,13 @@ struct Analyzer<'a> {
     /// When true, assertions with runtime input suppression overrides are promoted to hard
     /// so they run on the VM.
     allow_input_assertion_overrides: bool,
+    /// Oniguruma's `^` (StartLine with `reject_after_trailing_newline_at_eof`) only rejects
+    /// the empty match at the absolute end of the haystack when it anchors the match itself;
+    /// when used as a sub-assertion inside a lookaround it behaves as a plain line start.
+    /// Treating it as the (delegatable) plain line start inside lookarounds also
+    /// keeps variable-length lookbehinds that contain `^` compilable instead of
+    /// forcing the whole body onto the backtracking VM.
+    in_lookaround: bool,
 }
 
 impl<'a> Analyzer<'a> {
@@ -155,6 +162,13 @@ impl<'a> Analyzer<'a> {
         let mut const_size = false;
         let mut hard = false;
         match *expr {
+            Expr::Assertion(Assertion::StartLine {
+                reject_after_trailing_newline_at_eof: true,
+                ..
+            }) if !self.in_lookaround => {
+                const_size = true;
+                hard = true;
+            }
             Expr::Assertion(assertion) if assertion.is_always_hard() => {
                 const_size = true;
                 hard = true;
@@ -248,9 +262,12 @@ impl<'a> Analyzer<'a> {
                 children.push(child_info);
             }
             Expr::LookAround(ref child, _) => {
+                let was_in_lookaround = self.in_lookaround;
+                self.in_lookaround = true;
                 // NOTE: min_pos_in_group might seem weird for lookbehinds
                 let child_info =
                     self.visit(child, min_pos_in_group, inside_zero_rep, enclosing_group)?;
+                self.in_lookaround = was_in_lookaround;
                 // min_size = 0
                 const_size = true;
                 hard = true;
@@ -850,6 +867,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
         find_not_empty,
         disallow_empty_match_at_eof_after_newline,
         allow_input_assertion_overrides,
+        in_lookaround: false,
     };
 
     let mut analyzed = analyzer.visit(&tree.expr, 0, false, 0)?;

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -136,12 +136,9 @@ struct Analyzer<'a> {
     /// When true, assertions with runtime input suppression overrides are promoted to hard
     /// so they run on the VM.
     allow_input_assertion_overrides: bool,
-    /// Oniguruma's `^` (StartLine with `reject_after_trailing_newline_at_eof`) only rejects
-    /// the empty match at the absolute end of the haystack when it anchors the match itself;
-    /// when used as a sub-assertion inside a lookaround it behaves as a plain line start.
-    /// Treating it as the (delegatable) plain line start inside lookarounds also
-    /// keeps variable-length lookbehinds that contain `^` compilable instead of
-    /// forcing the whole body onto the backtracking VM.
+    /// Oniguruma's `^` rejects the empty match at the absolute end of the haystack after a trailing
+    /// newline when it anchors the match itself. When used as a sub-assertion inside a lookaround,
+    /// it behaves as a plain line start. So we need to track when we are analyzing inside a lookaround.
     in_lookaround: bool,
 }
 
@@ -162,14 +159,11 @@ impl<'a> Analyzer<'a> {
         let mut const_size = false;
         let mut hard = false;
         match *expr {
-            Expr::Assertion(Assertion::StartLine {
-                reject_after_trailing_newline_at_eof: true,
-                ..
-            }) if !self.in_lookaround => {
+            Expr::Assertion(assertion) if assertion.is_always_hard() => {
                 const_size = true;
                 hard = true;
             }
-            Expr::Assertion(assertion) if assertion.is_always_hard() => {
+            Expr::Assertion(Assertion::StartLineOniguruma { .. }) if !self.in_lookaround => {
                 const_size = true;
                 hard = true;
             }
@@ -1471,6 +1465,40 @@ mod tests {
     fn not_anchored_for_startline_assertions() {
         let tree = Expr::parse_tree(r"(?m)^(\w+)\1").unwrap();
         assert_eq!(can_compile_as_anchored(&tree.expr), false);
+    }
+
+    #[test]
+    fn start_line_analysis() {
+        use crate::parse_flags::FLAG_ONIGURUMA_MODE;
+        use crate::Assertion;
+
+        let tree = Expr::parse_tree(r"(?m)^").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).expect("can analyze start line");
+        assert_eq!(info.min_size, 0);
+        assert!(info.const_size);
+        assert!(!info.hard);
+        assert_matches!(info.expr, Expr::Assertion(Assertion::StartLine { .. }));
+
+        let tree = Expr::parse_tree_with_flags(r"(?m)^", FLAG_ONIGURUMA_MODE).unwrap();
+        let info =
+            analyze(&tree, AnalyzeContext::default()).expect("can analyze Oniguruma start line");
+        assert_eq!(info.min_size, 0);
+        assert!(info.hard);
+        assert_matches!(
+            info.expr,
+            Expr::Assertion(Assertion::StartLineOniguruma { .. })
+        );
+
+        let tree = Expr::parse_tree_with_flags(r"(?m)(?=^)", FLAG_ONIGURUMA_MODE).unwrap();
+        let info = analyze(&tree, AnalyzeContext::default())
+            .expect("can analyze Oniguruma start line inside lookaround");
+        assert_eq!(info.min_size, 0);
+        assert!(info.hard);
+        assert_matches!(
+            info.children[0].expr,
+            Expr::Assertion(Assertion::StartLineOniguruma { .. })
+        );
+        assert!(!info.children[0].hard);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2415,6 +2415,8 @@ pub enum Assertion {
         /// If true, this assertion matches at the starting position of the input text, or at the position immediately
         /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
+        /// Whether to reject matches after a trailing newline at EOF
+        reject_after_trailing_newline_at_eof: bool,
     },
     /// End of a line
     EndLine {
@@ -2451,6 +2453,7 @@ impl Assertion {
                 | NotWordBoundary
                 // `\Z` needs custom trailing-newline handling.
                 | EndTextIgnoreTrailingNewlines { .. }
+                | StartLine { reject_after_trailing_newline_at_eof: true, .. }
         )
     }
 }
@@ -2665,9 +2668,15 @@ impl Expr {
             }
             Expr::Assertion(Assertion::StartText) => buf.push('^'),
             Expr::Assertion(Assertion::EndText) => buf.push('$'),
-            Expr::Assertion(Assertion::StartLine { crlf: false }) => buf.push_str("(?m:^)"),
+            Expr::Assertion(Assertion::StartLine {
+                crlf: false,
+                reject_after_trailing_newline_at_eof: _,
+            }) => buf.push_str("(?m:^)"),
             Expr::Assertion(Assertion::EndLine { crlf: false }) => buf.push_str("(?m:$)"),
-            Expr::Assertion(Assertion::StartLine { crlf: true }) => buf.push_str("(?Rm:^)"),
+            Expr::Assertion(Assertion::StartLine {
+                crlf: true,
+                reject_after_trailing_newline_at_eof: _,
+            }) => buf.push_str("(?Rm:^)"),
             Expr::Assertion(Assertion::EndLine { crlf: true }) => buf.push_str("(?Rm:$)"),
             Expr::Concat(ref children) => {
                 if precedence > 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,6 +859,30 @@ impl RegexOptionsBuilder {
     /// `fancy-regex` would normally reject patterns like `(?:)+` because the `+` has nothing
     /// to target. In Oniguruma mode, the empty repeat is silently dropped at parse time.
     ///
+    /// # Swapped order quantifiers
+    ///
+    /// `fancy-regex` would normally treat `x{0,3}` as a syntax error because the minimum is
+    /// greater than the maximum. In Oniguruma mode, the limits are swapped (behaving as
+    /// `x{3,0}`) and the resulting repeat is treated as atomic (possessive), matching
+    /// Oniguruma's behavior.
+    ///
+    /// # Adjacent quantifiers
+    ///
+    /// `fancy-regex` would normally reject adjacent quantifiers like `a{3}{2}`, treating the
+    /// second as having nothing to target. In Oniguruma mode, each quantifier wraps the
+    /// previous result (e.g. `a{3}{2}` becomes `(?:a{3}){2}`).
+    ///
+    /// Outside Oniguruma mode, `+` after `{...}` is a possessive modifier (e.g. `x{2}+` is
+    /// possessive). In Oniguruma mode, `+` after a user-specified `{...}` repeat is treated
+    /// as another repeat modifier — `x{2}+` is equivalent to `(?:x{2})+`.
+    ///
+    /// # Start of line (`^`) in multiline mode
+    ///
+    /// In multiline mode (`(?m)`), `^` normally matches at the start of the input and after
+    /// any newline. In Oniguruma mode, it additionally rejects a match at the absolute end of
+    /// the input when it is preceded by a trailing newline.
+    /// Inside lookarounds, `^` behaves as a plain line start without the end-of-input rejection.
+    ///
     /// ## Example
     ///
     /// ```
@@ -2415,8 +2439,15 @@ pub enum Assertion {
         /// If true, this assertion matches at the starting position of the input text, or at the position immediately
         /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
         crlf: bool,
-        /// Whether to reject matches after a trailing newline at EOF
-        reject_after_trailing_newline_at_eof: bool,
+    },
+    /// Start of a line in Oniguruma mode.
+    /// Behaves like [`StartLine`], but additionally rejects matches at the end of the input
+    /// when it is preceded by a newline.
+    StartLineOniguruma {
+        /// CRLF mode.
+        /// If true, this assertion matches at the starting position of the input text, or at the position immediately
+        /// following either a `\r` or `\n` character, but never after a `\r` when a `\n` follows.
+        crlf: bool,
     },
     /// End of a line
     EndLine {
@@ -2667,15 +2698,14 @@ impl Expr {
             }
             Expr::Assertion(Assertion::StartText) => buf.push('^'),
             Expr::Assertion(Assertion::EndText) => buf.push('$'),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: false,
-                reject_after_trailing_newline_at_eof: _,
-            }) => buf.push_str("(?m:^)"),
+            Expr::Assertion(
+                Assertion::StartLine { crlf: false }
+                | Assertion::StartLineOniguruma { crlf: false },
+            ) => buf.push_str("(?m:^)"),
             Expr::Assertion(Assertion::EndLine { crlf: false }) => buf.push_str("(?m:$)"),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: true,
-                reject_after_trailing_newline_at_eof: _,
-            }) => buf.push_str("(?Rm:^)"),
+            Expr::Assertion(
+                Assertion::StartLine { crlf: true } | Assertion::StartLineOniguruma { crlf: true },
+            ) => buf.push_str("(?Rm:^)"),
             Expr::Assertion(Assertion::EndLine { crlf: true }) => buf.push_str("(?Rm:$)"),
             Expr::Concat(ref children) => {
                 if precedence > 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2441,7 +2441,7 @@ pub enum Assertion {
         crlf: bool,
     },
     /// Start of a line in Oniguruma mode.
-    /// Behaves like [`StartLine`], but additionally rejects matches at the end of the input
+    /// Behaves like [`Assertion::StartLine`], but additionally rejects matches at the end of the input
     /// when it is preceded by a newline.
     StartLineOniguruma {
         /// CRLF mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2453,7 +2453,6 @@ impl Assertion {
                 | NotWordBoundary
                 // `\Z` needs custom trailing-newline handling.
                 | EndTextIgnoreTrailingNewlines { .. }
-                | StartLine { reject_after_trailing_newline_at_eof: true, .. }
         )
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -344,10 +344,15 @@ impl<'a> Parser<'a> {
             b'^' => Ok((
                 ix + 1,
                 if self.flag(FLAG_MULTI) {
-                    Expr::Assertion(Assertion::StartLine {
-                        crlf: self.flag(FLAG_CRLF),
-                        reject_after_trailing_newline_at_eof: self.flag(FLAG_ONIGURUMA_MODE),
-                    })
+                    if self.flag(FLAG_ONIGURUMA_MODE) {
+                        Expr::Assertion(Assertion::StartLineOniguruma {
+                            crlf: self.flag(FLAG_CRLF),
+                        })
+                    } else {
+                        Expr::Assertion(Assertion::StartLine {
+                            crlf: self.flag(FLAG_CRLF),
+                        })
+                    }
                 } else {
                     Expr::Assertion(Assertion::StartText)
                 },
@@ -2375,10 +2380,7 @@ mod tests {
         assert_eq!(
             p(r"(?m)^?"),
             Expr::Repeat {
-                child: Box::new(Expr::Assertion(Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: false
-                })),
+                child: Box::new(Expr::Assertion(Assertion::StartLine { crlf: false })),
                 lo: 0,
                 hi: 1,
                 greedy: true
@@ -2726,10 +2728,7 @@ mod tests {
         assert_eq!(p("^"), Expr::Assertion(Assertion::StartText));
         assert_eq!(
             p("(?m:^)"),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: false,
-                reject_after_trailing_newline_at_eof: false
-            })
+            Expr::Assertion(Assertion::StartLine { crlf: false })
         );
         assert_eq!(p("$"), Expr::Assertion(Assertion::EndText));
         assert_eq!(
@@ -2742,17 +2741,11 @@ mod tests {
     fn flag_crlf() {
         assert_eq!(
             p("(?mR:^)"),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: true,
-                reject_after_trailing_newline_at_eof: false
-            })
+            Expr::Assertion(Assertion::StartLine { crlf: true })
         );
         assert_eq!(
             p("(?Rm:^)"),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: true,
-                reject_after_trailing_newline_at_eof: false
-            })
+            Expr::Assertion(Assertion::StartLine { crlf: true })
         );
         assert_eq!(
             p("(?mR:$)"),
@@ -2761,10 +2754,7 @@ mod tests {
         // Negating R reverts to LF-only
         assert_eq!(
             p("(?mR)(?-R:^)"),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: false,
-                reject_after_trailing_newline_at_eof: false
-            })
+            Expr::Assertion(Assertion::StartLine { crlf: false })
         );
     }
 
@@ -3095,13 +3085,14 @@ mod tests {
     }
 
     #[test]
-    fn start_line_in_oniguruma_mode_will_reject_after_trailing_newline_at_eof() {
+    fn start_line_in_oniguruma_mode() {
+        assert_eq!(
+            parse_oniguruma("(?R:^)").unwrap(),
+            Expr::Assertion(Assertion::StartLineOniguruma { crlf: true })
+        );
         assert_eq!(
             parse_oniguruma("^").unwrap(),
-            Expr::Assertion(Assertion::StartLine {
-                crlf: false,
-                reject_after_trailing_newline_at_eof: true
-            })
+            Expr::Assertion(Assertion::StartLineOniguruma { crlf: false })
         );
     }
 
@@ -3789,10 +3780,7 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: false
-                }),
+                Expr::Assertion(Assertion::StartLine { crlf: false }),
                 make_literal("h"),
                 make_literal("e"),
                 make_literal("l"),
@@ -3813,10 +3801,7 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: false
-                }),
+                Expr::Assertion(Assertion::StartLine { crlf: false }),
                 make_literal("h"),
                 make_literal("e"),
                 make_literal("l"),
@@ -3911,10 +3896,7 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: false
-                }),
+                Expr::Assertion(Assertion::StartLine { crlf: false }),
                 make_literal_case_insensitive("h", true),
                 make_literal_case_insensitive("e", true),
                 make_literal_case_insensitive("l", true),
@@ -3936,10 +3918,7 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: false
-                }),
+                Expr::Assertion(Assertion::StartLine { crlf: false }),
                 make_literal_case_insensitive("h", true),
                 make_literal_case_insensitive("e", true),
                 make_literal_case_insensitive("l", true),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -346,6 +346,7 @@ impl<'a> Parser<'a> {
                 if self.flag(FLAG_MULTI) {
                     Expr::Assertion(Assertion::StartLine {
                         crlf: self.flag(FLAG_CRLF),
+                        reject_after_trailing_newline_at_eof: self.flag(FLAG_ONIGURUMA_MODE),
                     })
                 } else {
                     Expr::Assertion(Assertion::StartText)
@@ -1810,6 +1811,7 @@ mod tests {
     fn parse_oniguruma(s: &str) -> crate::Result<Expr> {
         let mut options = RegexOptions::default();
         options.oniguruma_mode = true;
+        options.syntaxc = options.syntaxc.multi_line(true);
         Expr::parse_tree_with_flags(s, options.compute_flags()).map(|tree| tree.expr)
     }
 
@@ -2373,7 +2375,10 @@ mod tests {
         assert_eq!(
             p(r"(?m)^?"),
             Expr::Repeat {
-                child: Box::new(Expr::Assertion(Assertion::StartLine { crlf: false })),
+                child: Box::new(Expr::Assertion(Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: false
+                })),
                 lo: 0,
                 hi: 1,
                 greedy: true
@@ -2721,7 +2726,10 @@ mod tests {
         assert_eq!(p("^"), Expr::Assertion(Assertion::StartText));
         assert_eq!(
             p("(?m:^)"),
-            Expr::Assertion(Assertion::StartLine { crlf: false })
+            Expr::Assertion(Assertion::StartLine {
+                crlf: false,
+                reject_after_trailing_newline_at_eof: false
+            })
         );
         assert_eq!(p("$"), Expr::Assertion(Assertion::EndText));
         assert_eq!(
@@ -2734,11 +2742,17 @@ mod tests {
     fn flag_crlf() {
         assert_eq!(
             p("(?mR:^)"),
-            Expr::Assertion(Assertion::StartLine { crlf: true })
+            Expr::Assertion(Assertion::StartLine {
+                crlf: true,
+                reject_after_trailing_newline_at_eof: false
+            })
         );
         assert_eq!(
             p("(?Rm:^)"),
-            Expr::Assertion(Assertion::StartLine { crlf: true })
+            Expr::Assertion(Assertion::StartLine {
+                crlf: true,
+                reject_after_trailing_newline_at_eof: false
+            })
         );
         assert_eq!(
             p("(?mR:$)"),
@@ -2747,7 +2761,10 @@ mod tests {
         // Negating R reverts to LF-only
         assert_eq!(
             p("(?mR)(?-R:^)"),
-            Expr::Assertion(Assertion::StartLine { crlf: false })
+            Expr::Assertion(Assertion::StartLine {
+                crlf: false,
+                reject_after_trailing_newline_at_eof: false
+            })
         );
     }
 
@@ -3075,6 +3092,17 @@ mod tests {
         assert_eq!(parse_oniguruma("(?:)++").unwrap(), Expr::Empty);
         // Both non-greedy and possessive
         assert_eq!(parse_oniguruma("(?:)*?+").unwrap(), Expr::Empty);
+    }
+
+    #[test]
+    fn start_line_in_oniguruma_mode_will_reject_after_trailing_newline_at_eof() {
+        assert_eq!(
+            parse_oniguruma("^").unwrap(),
+            Expr::Assertion(Assertion::StartLine {
+                crlf: false,
+                reject_after_trailing_newline_at_eof: true
+            })
+        );
     }
 
     #[test]
@@ -3761,7 +3789,10 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine { crlf: false }),
+                Expr::Assertion(Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: false
+                }),
                 make_literal("h"),
                 make_literal("e"),
                 make_literal("l"),
@@ -3773,7 +3804,7 @@ mod tests {
     }
 
     #[test]
-    fn pparse_with_multiline_option() {
+    fn parse_with_multiline_option() {
         let options = get_options(|x| x.multi_line(true));
 
         let tree = Expr::parse_tree_with_flags("^hello$", options.compute_flags());
@@ -3782,7 +3813,10 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine { crlf: false }),
+                Expr::Assertion(Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: false
+                }),
                 make_literal("h"),
                 make_literal("e"),
                 make_literal("l"),
@@ -3877,7 +3911,10 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine { crlf: false }),
+                Expr::Assertion(Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: false
+                }),
                 make_literal_case_insensitive("h", true),
                 make_literal_case_insensitive("e", true),
                 make_literal_case_insensitive("l", true),
@@ -3899,7 +3936,10 @@ mod tests {
         assert_eq!(
             expr,
             Expr::Concat(vec![
-                Expr::Assertion(Assertion::StartLine { crlf: false }),
+                Expr::Assertion(Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: false
+                }),
                 make_literal_case_insensitive("h", true),
                 make_literal_case_insensitive("e", true),
                 make_literal_case_insensitive("l", true),

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -180,8 +180,14 @@ pub(crate) fn build_seek_pattern_impl<'a>(
                 // Emit them faithfully.
                 Assertion::StartText => buf.push('^'),
                 Assertion::EndText => buf.push('$'),
-                Assertion::StartLine { crlf: false } => buf.push_str("(?m:^)"),
-                Assertion::StartLine { crlf: true } => buf.push_str("(?Rm:^)"),
+                Assertion::StartLine {
+                    crlf: false,
+                    reject_after_trailing_newline_at_eof: _,
+                } => buf.push_str("(?m:^)"),
+                Assertion::StartLine {
+                    crlf: true,
+                    reject_after_trailing_newline_at_eof: _,
+                } => buf.push_str("(?Rm:^)"),
                 Assertion::EndLine { crlf: false } => buf.push_str("(?m:$)"),
                 Assertion::EndLine { crlf: true } => buf.push_str("(?Rm:$)"),
             }

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -50,6 +50,7 @@ pub(crate) fn expr_contains_positional_anchor(expr: &Expr) -> bool {
             | Assertion::EndText
             | Assertion::EndTextIgnoreTrailingNewlines { .. }
             | Assertion::StartLine { .. }
+            | Assertion::StartLineOniguruma { .. }
             | Assertion::EndLine { .. },
         ) => true,
         _ => expr.children_iter().any(expr_contains_positional_anchor),
@@ -124,6 +125,7 @@ pub(crate) fn build_seek_pattern_impl<'a>(
             Assertion::StartText
             | Assertion::EndText
             | Assertion::StartLine { .. }
+            | Assertion::StartLineOniguruma { .. }
             | Assertion::EndLine { .. },
         ) = info.expr
         {
@@ -180,14 +182,10 @@ pub(crate) fn build_seek_pattern_impl<'a>(
                 // Emit them faithfully.
                 Assertion::StartText => buf.push('^'),
                 Assertion::EndText => buf.push('$'),
-                Assertion::StartLine {
-                    crlf: false,
-                    reject_after_trailing_newline_at_eof: _,
-                } => buf.push_str("(?m:^)"),
-                Assertion::StartLine {
-                    crlf: true,
-                    reject_after_trailing_newline_at_eof: _,
-                } => buf.push_str("(?Rm:^)"),
+                Assertion::StartLine { crlf: false }
+                | Assertion::StartLineOniguruma { crlf: false } => buf.push_str("(?m:^)"),
+                Assertion::StartLine { crlf: true }
+                | Assertion::StartLineOniguruma { crlf: true } => buf.push_str("(?Rm:^)"),
                 Assertion::EndLine { crlf: false } => buf.push_str("(?m:$)"),
                 Assertion::EndLine { crlf: true } => buf.push_str("(?Rm:$)"),
             }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -874,11 +874,27 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                             slash_z_matched |= matched;
                             matched
                         }
-                        Assertion::StartLine { crlf: false } => {
+                        Assertion::StartLine {
+                            crlf: false,
+                            reject_after_trailing_newline_at_eof: false,
+                        } => look_matcher.is_start_lf(haystack.as_bytes(), ix),
+                        Assertion::StartLine {
+                            crlf: true,
+                            reject_after_trailing_newline_at_eof: false,
+                        } => look_matcher.is_start_crlf(haystack.as_bytes(), ix),
+                        Assertion::StartLine {
+                            crlf: false,
+                            reject_after_trailing_newline_at_eof: true,
+                        } => {
                             look_matcher.is_start_lf(haystack.as_bytes(), ix)
+                                && !(ix > 0 && ix == haystack.len())
                         }
-                        Assertion::StartLine { crlf: true } => {
+                        Assertion::StartLine {
+                            crlf: true,
+                            reject_after_trailing_newline_at_eof: true,
+                        } => {
                             look_matcher.is_start_crlf(haystack.as_bytes(), ix)
+                                && !(ix > 0 && ix == haystack.len())
                         }
                         Assertion::EndLine { crlf: false } => {
                             look_matcher.is_end_lf(haystack.as_bytes(), ix)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -874,25 +874,17 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                             slash_z_matched |= matched;
                             matched
                         }
-                        Assertion::StartLine {
-                            crlf: false,
-                            reject_after_trailing_newline_at_eof: false,
-                        } => look_matcher.is_start_lf(haystack.as_bytes(), ix),
-                        Assertion::StartLine {
-                            crlf: true,
-                            reject_after_trailing_newline_at_eof: false,
-                        } => look_matcher.is_start_crlf(haystack.as_bytes(), ix),
-                        Assertion::StartLine {
-                            crlf: false,
-                            reject_after_trailing_newline_at_eof: true,
-                        } => {
+                        Assertion::StartLine { crlf: false } => {
+                            look_matcher.is_start_lf(haystack.as_bytes(), ix)
+                        }
+                        Assertion::StartLine { crlf: true } => {
+                            look_matcher.is_start_crlf(haystack.as_bytes(), ix)
+                        }
+                        Assertion::StartLineOniguruma { crlf: false } => {
                             look_matcher.is_start_lf(haystack.as_bytes(), ix)
                                 && !(ix > 0 && ix == haystack.len())
                         }
-                        Assertion::StartLine {
-                            crlf: true,
-                            reject_after_trailing_newline_at_eof: true,
-                        } => {
+                        Assertion::StartLineOniguruma { crlf: true } => {
                             look_matcher.is_start_crlf(haystack.as_bytes(), ix)
                                 && !(ix > 0 && ix == haystack.len())
                         }

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1114,6 +1114,20 @@ fn oniguruma_plus_after_quantifier() {
 }
 
 #[test]
+fn find_from_pos_startline_rejected_after_trailing_newline_at_eof() {
+    let re = RegexBuilder::new("^")
+        .oniguruma_mode(true)
+        .multi_line(true)
+        .build()
+        .unwrap();
+    let result = re.find_from_pos("ab\n", 3).unwrap();
+    assert!(
+        result.is_none(),
+        "pattern `^` must not match at end-of-text after a trailing newline"
+    );
+}
+
+#[test]
 fn find_input_wrap_range_keeps_word_boundary_context() {
     assert_eq!(
         common::assert_find_input(r"\bat\b", "batter", 0, 1..3),


### PR DESCRIPTION
I think this should be used instead of `disallow_empty_match_at_eof_after_newline`, judging from https://github.com/fancy-regex/fancy-regex/issues/162#issuecomment-4804691364, although we might need to keep some of that behavior, not sure... CC @Keats 