### PR TITLE
Make anchored search possible for callers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ See the @CONTRIBUTING.md guide for details.
 1. Follow Rust best practices and idiomatic patterns - avoid writing unsafe code
 2. Maintain existing code structure and organization unless asked to reorganize
 3. Write unit tests for new functionality
-5. Document public APIs and complex logic. Suggest changes to the Markdown documents when appropriate
+4. Document public APIs and complex logic. Suggest changes to the Markdown documents when appropriate
 
 ## Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the exception that 0.x versions can break between minor versions.
 - Add `BytesMode` and the `RegexInput` trait so the matching and capture APIs can operate on strings or bytes, and allows to opt out of unicode handling if desired (#248)
   - Also allows searching within a range without slicing (#253)
   - Assertions can be overridden at runtime, if the regex builder `allow_input_assertion_overrides` option was used (#254)
+  - Search can be performed in anchored mode, searching only at the start position specified (#263)
 - Add experimental seek optimization to only invoke the VM at candidate positions where a match could occur (#246)
 - Add `RegexBuilder::disallow_empty_match_at_eof_after_newline` to reject empty matches at the end of the haystack following a trailing newline, to match Oniguruma behavior (#247)
 - Add `RegexSet` API for efficiently matching multiple patterns against the same text (#255)

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,6 +26,7 @@ pub struct RegexInput<'h, S: Input + ?Sized> {
     haystack: &'h S,
     start: usize,
     range: Range<usize>,
+    anchored: bool,
     start_text: Option<bool>,
     end_text: Option<bool>,
     continue_from_previous_match_end: Option<bool>,
@@ -39,6 +40,7 @@ impl<'h, S: Input + ?Sized> Clone for RegexInput<'h, S> {
             haystack: self.haystack,
             start: self.start,
             range: self.range.clone(),
+            anchored: self.anchored,
             start_text: self.start_text,
             end_text: self.end_text,
             continue_from_previous_match_end: self.continue_from_previous_match_end,
@@ -53,6 +55,7 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
             haystack,
             start: 0,
             range: 0..haystack.len(),
+            anchored: false,
             start_text: None,
             end_text: None,
             continue_from_previous_match_end: None,
@@ -126,6 +129,17 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
         self
     }
 
+    /// Return a copy of this input with an override for whether matching should
+    /// be anchored at the start position.
+    ///
+    /// When `true`, the regex will only match at the exact start position,
+    /// without scanning forward through the haystack. This is more efficient
+    /// when you already know where a potential match must occur.
+    pub fn anchored(mut self, yes: bool) -> Self {
+        self.anchored = yes;
+        self
+    }
+
     pub(crate) fn effective_start(&self) -> usize {
         self.start.max(self.range.start)
     }
@@ -148,6 +162,10 @@ impl<'h, S: Input + ?Sized> RegexInput<'h, S> {
 
     pub(crate) fn continue_from_previous_match_end_override(&self) -> Option<bool> {
         self.continue_from_previous_match_end
+    }
+
+    pub(crate) fn is_anchored(&self) -> bool {
+        self.anchored
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,7 @@ use crate::compile::{compile, CompileOptions};
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::parse_flags::*;
-use crate::vm::{
-    Prog, OPTION_ANCHORED, OPTION_FIND_NOT_EMPTY, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH,
-};
+use crate::vm::{Prog, OPTION_FIND_NOT_EMPTY, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH};
 
 pub use crate::bytes::MatchBytes;
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
@@ -1386,7 +1384,7 @@ impl Regex {
                 ..
             } => {
                 let mut delegated_input = ra_input(input);
-                if option_flags & OPTION_ANCHORED != 0 {
+                if input.is_anchored() {
                     delegated_input = delegated_input.anchored(RaAnchored::Yes);
                 }
                 let result = if !*explicit_capture_group_0 {
@@ -1578,7 +1576,7 @@ impl Regex {
                 let explicit = *explicit_capture_group_0;
                 let mut locations = inner.create_captures();
                 let mut delegated_input = ra_input(input);
-                if option_flags & OPTION_ANCHORED != 0 {
+                if input.is_anchored() {
                     delegated_input = delegated_input.anchored(RaAnchored::Yes);
                 }
                 inner.captures(delegated_input, &mut locations);
@@ -3195,22 +3193,29 @@ mod tests {
     #[test]
     fn find_input_raw_honors_anchored_flag_for_wrapped_regex() {
         let regex = Regex::new("abc").unwrap();
+
+        // Unanchored search finds match at position 1
         let input = RegexInput::new("zabc");
-
-        assert_eq!(Some((1, 4)), regex.find_input_raw(&input, 0).unwrap());
-        assert_eq!(
-            None,
-            regex
-                .find_input_raw(&input, super::OPTION_ANCHORED)
-                .unwrap()
-        );
-
-        let anchored_at_match = input.clone().from_pos(1);
         assert_eq!(
             Some((1, 4)),
             regex
-                .find_input_raw(&anchored_at_match, super::OPTION_ANCHORED)
+                .find_input(input)
                 .unwrap()
+                .map(|m| (m.start(), m.end()))
+        );
+
+        // Anchored at position 0 returns None (abc doesn't match at pos 0)
+        let anchored_at_start = RegexInput::new("zabc").anchored(true);
+        assert!(regex.find_input(anchored_at_start).unwrap().is_none());
+
+        // Anchored at position 1 finds match
+        let anchored_at_match = RegexInput::new("zabc").from_pos(1).anchored(true);
+        assert_eq!(
+            regex
+                .find_input(anchored_at_match)
+                .unwrap()
+                .map(|m| (m.start(), m.end())),
+            Some((1, 4))
         );
     }
 }

--- a/src/regexset.rs
+++ b/src/regexset.rs
@@ -131,7 +131,7 @@ use regex_automata::PatternID;
 use regex_automata::PatternSet;
 
 use crate::compile::options_to_rabuilder;
-use crate::vm::{OPTION_ANCHORED, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH};
+use crate::vm::OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH;
 use crate::CompileError;
 use crate::Error;
 use crate::RegexOptions;
@@ -448,10 +448,14 @@ impl RegexSet {
         let mut seen_pattern_indices = PatternSet::new(self.regexes.len());
 
         while search_start <= match_range.end {
-            let Some(candidate) = self
-                .earliest_match_finder
-                .search(&RaInput::new(haystack.as_bytes()).range(search_start..match_range.end))
-            else {
+            let ra_input = RaInput::new(haystack.as_bytes())
+                .range(search_start..match_range.end)
+                .anchored(if input.is_anchored() {
+                    Anchored::Yes
+                } else {
+                    Anchored::No
+                });
+            let Some(candidate) = self.earliest_match_finder.search(&ra_input) else {
                 return Ok(None);
             };
             let match_start = candidate.start();
@@ -520,9 +524,9 @@ impl RegexSet {
         input: &RegexInput<'t, S>,
         match_start: usize,
     ) -> Result<Option<RegexSetMatch<'t, S>>> {
-        let candidate_input = input.clone().from_pos(match_start);
+        let candidate_input = input.clone().from_pos(match_start).anchored(true);
         let regex = &self.regexes[pattern_index];
-        let mut option_flags = OPTION_ANCHORED;
+        let mut option_flags = 0;
         if input.start() < match_start {
             option_flags |= OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH;
         }
@@ -766,6 +770,33 @@ mod tests {
             .find_input(RegexInput::new("a").from_pos(2))
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn find_input_returns_none_when_input_is_anchored_and_match_not_at_start_position() {
+        let set = RegexSet::new(&[r"b"]).unwrap();
+
+        assert!(set
+            .find_input(RegexInput::new("ab").from_pos(0).anchored(true))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn find_input_returns_match_when_input_is_anchored_and_match_at_start_position() {
+        let set = RegexSet::new(&[r"b"]).unwrap();
+
+        let mut matches = set
+            .find_input(RegexInput::new("ab").from_pos(1).anchored(true))
+            .unwrap()
+            .unwrap();
+
+        let only = matches.next().unwrap().unwrap();
+        assert_eq!(0, only.pattern());
+        assert_eq!(1, only.start());
+        assert_eq!(2, only.end());
+        assert_eq!("b", only.as_str());
+        assert!(matches.next().is_none());
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -115,13 +115,6 @@ pub(crate) const OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH: u32 = 1 << 1;
 /// \K is ignored as part of this check - so empty matches can still be reported if the engine
 /// consumed characters and then \K was used afterwards.
 pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
-/// When this option is set, the VM will only attempt to match at the start position given by the
-/// input (`effective_start`), without scanning forward.  `SplitUnanchored` and `Seek` preamble
-/// instructions are treated as no-ops that simply advance to the real pattern body; no backtrack
-/// branch is pushed for retrying at later positions.  This is used by [`RegexSet`] verification,
-/// where the many-DFA has already identified candidate start positions and the VM only needs to
-/// confirm (or deny) a match anchored at that exact position.
-pub(crate) const OPTION_ANCHORED: u32 = 1 << 3;
 
 // TODO: make configurable
 const MAX_STACK: usize = 1_000_000;
@@ -928,7 +921,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                     match_attempt_start = ix;
                     slash_z_matched = false;
 
-                    if option_flags & OPTION_ANCHORED != 0 {
+                    if input.is_anchored() {
                         // Anchored mode: only try at the current position; do not push a
                         // backtrack branch for advancing to the next position.
                     } else {
@@ -1211,8 +1204,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         // If \G is at the start of the pattern, and we are performing a non-anchored
                         // search, then we can fail early instead of checking at each position in the
                         // haystack because \G will never match at any other position
-                        if at_start && state.stack.len() == 1 && option_flags & OPTION_ANCHORED == 0
-                        {
+                        if at_start && state.stack.len() == 1 && !input.is_anchored() {
                             // The only item on the stack is from the SplitUnanchored (or Seek)
                             // instruction for non-anchored search.
                             // We can safely return None immediately.
@@ -1229,7 +1221,7 @@ pub(crate) fn run<S: HaystackInput + ?Sized>(
                         return Ok(None);
                     }
 
-                    if option_flags & OPTION_ANCHORED != 0 {
+                    if input.is_anchored() {
                         // Anchored mode: the idea is that since the many-DFA from the regex-set has
                         // already confirmed a candidate match starting at this position, there is no
                         // need to verify the seek pattern matches here. We also don't push any backtracking


### PR DESCRIPTION
Update `RegexInput` to allow anchored search - previously this functionality was only available internally. Arguably it is more correct to have it part of the input (mirroring regex-automata API) as opposed to having it as a runtime VM flag which is also referred to when searching easy/wrapped patterns, so this change has a couple of benefits.

Re: https://github.com/fancy-regex/fancy-regex/issues/162#issuecomment-4879664957