### PR TITLE
Reduce catastrophic backtracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ See the @CONTRIBUTING.md guide for details.
 2. Maintain existing code structure and organization unless asked to reorganize
 3. Write unit tests for new functionality
 4. Document public APIs and complex logic. Suggest changes to the Markdown documents when appropriate
+5. If you can avoid unnecessary cloning by doing a mem swap, please do. Performance is a feature.
 
 ## Tests
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -24,7 +24,9 @@ extern crate criterion;
 use criterion::Criterion;
 use std::time::Duration;
 
-use fancy_regex::internal::{analyze, compile, run_default, AnalyzeContext, CompileOptions};
+use fancy_regex::internal::{
+    analyze, compile, optimize, run_default, AnalyzeContext, CompileOptions,
+};
 use fancy_regex::seek_pattern_is_useful;
 use fancy_regex::Expr;
 use fancy_regex::Regex as FancyRegex;
@@ -459,6 +461,57 @@ criterion_group!(
     is_match_fancy,
 );
 
+/// Shared logic for the optimized-vs-unoptimized concat-repeat benchmarks.
+///
+/// Compiles `(\w)(?:\s*\w?\s*)+\1` with or without calling `optimize()` on
+/// the parsed tree. The backreference makes the whole pattern hard, so the
+/// VM executes the ambiguous `(?:\s*\w?\s*)+` middle section. With
+/// optimization, that section is rewritten to the unambiguous `\s*(?:\w\s*)*`,
+/// reducing the number of backtracking paths the VM must explore.
+fn bench_concat_repeat_optimization(c: &mut Criterion, name: &str, with_optimize: bool) {
+    let pattern = r"(\w)(?:\s*\w?\s*)+\1";
+    let mut tree = Expr::parse_tree(pattern).unwrap();
+    if with_optimize {
+        optimize(&mut tree);
+    }
+    let a = analyze(
+        &tree,
+        AnalyzeContext {
+            explicit_capture_group_0: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let p = compile(
+        &a,
+        CompileOptions {
+            contains_subroutines: tree.contains_subroutines,
+            ..CompileOptions::default()
+        },
+    )
+    .unwrap();
+    // Haystack: 20 repetitions of "x " then a final "x" — the whole string
+    // matches because the captured 'x' equals the final \1.
+    let mut haystack = "x ".repeat(20);
+    haystack.push('x');
+    c.bench_function(name, |b| b.iter(|| run_default(&p, &haystack, 0).unwrap()));
+}
+
+fn run_concat_repeat_optimized(c: &mut Criterion) {
+    bench_concat_repeat_optimization(c, "run_concat_repeat_optimized", true);
+}
+
+fn run_concat_repeat_unoptimized(c: &mut Criterion) {
+    bench_concat_repeat_optimization(c, "run_concat_repeat_unoptimized", false);
+}
+
+criterion_group!(
+    name = optimize_benches;
+    config = Criterion::default();
+    targets = run_concat_repeat_optimized,
+    run_concat_repeat_unoptimized,
+);
+
 #[cfg(feature = "variable-lookbehinds")]
 criterion_main!(
     benches,
@@ -467,7 +520,8 @@ criterion_main!(
     continue_from_end_of_prev_match_benches,
     seek_benches,
     seek_worst_case_benches,
-    api_benches
+    api_benches,
+    optimize_benches
 );
 
 #[cfg(not(feature = "variable-lookbehinds"))]
@@ -477,5 +531,6 @@ criterion_main!(
     continue_from_end_of_prev_match_benches,
     seek_benches,
     seek_worst_case_benches,
-    api_benches
+    api_benches,
+    optimize_benches
 );

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -226,26 +226,52 @@ fn build_concat_repeat_triplet(left: Expr, middle: Expr, right: Expr) -> (Expr, 
         unreachable!("check_concat_repeat_triplet guarantees right is a Repeat");
     };
 
-    let prefix = Expr::Repeat {
-        child: left_inner,
-        lo: left_lo.min(right_lo),
-        hi: usize::MAX,
-        greedy: true,
-    };
     let mandatory_middle = Expr::Repeat {
         child: middle_inner,
         lo: 1,
         hi: middle_hi,
         greedy: middle_greedy,
     };
-    let tail = Expr::Concat(vec![mandatory_middle, right]);
-    let optional_tail = Expr::Repeat {
-        child: Box::new(tail),
-        lo: 0,
-        hi: 1,
-        greedy: true,
-    };
-    (prefix, optional_tail)
+
+    if left_lo < right_lo {
+        // The right repeat is the less permissive (higher lo) side — keep it as a mandatory
+        // suffix. Make the left repeat and middle optional as a prefix instead, so that the
+        // rewritten expression is no more permissive than the original.
+        // E.g. `\w*\.?\w+` → `(?:\w*\.{1})?\w+`
+        let left_repeat = Expr::Repeat {
+            child: left_inner,
+            lo: left_lo,
+            hi: usize::MAX,
+            greedy: true,
+        };
+        let head = Expr::Concat(vec![left_repeat, mandatory_middle]);
+        let optional_head = Expr::Repeat {
+            child: Box::new(head),
+            lo: 0,
+            hi: 1,
+            greedy: true,
+        };
+        (optional_head, right)
+    } else {
+        // The left repeat is the less permissive (higher or equal lo) side — keep it as a
+        // mandatory prefix. Make the middle and right repeat optional as a suffix.
+        // E.g. `\w+\.?\w+` → `\w+(?:\.{1}\w+)?`
+        // E.g. `\w+\.?\w*` → `\w+(?:\.{1}\w*)?`
+        let prefix = Expr::Repeat {
+            child: left_inner,
+            lo: left_lo,
+            hi: usize::MAX,
+            greedy: true,
+        };
+        let tail = Expr::Concat(vec![mandatory_middle, right]);
+        let optional_tail = Expr::Repeat {
+            child: Box::new(tail),
+            lo: 0,
+            hi: 1,
+            greedy: true,
+        };
+        (prefix, optional_tail)
+    }
 }
 
 fn check_repeated_concat(child: &Expr, outer_lo: usize) -> bool {
@@ -643,24 +669,27 @@ mod tests {
 
     #[test]
     fn ambiguous_concat_repeats_simplified_with_bounded_middle() {
+        // left=\w* (lo=0) < right=\w+ (lo=1): right is mandatory suffix, left+middle become optional prefix
         assert_eq!(
             optimized_pattern(r"foo\w*\s{0,5}\w+"),
-            r"foo\w*(?:\s{1,5}\w+)?"
+            r"foo(?:\w*\s{1,5})?\w+"
         );
     }
 
     #[test]
     fn ambiguous_concat_repeats_simplified_with_nongreedy_middle() {
+        // left=\w* (lo=0) < right=\w+ (lo=1): same as above with non-greedy middle
         assert_eq!(
             optimized_pattern(r"foo\w*\s{0,5}?\w+"),
-            r"foo\w*(?:\s{1,5}?\w+)?"
+            r"foo(?:\w*\s{1,5}?)?\w+"
         );
     }
 
     #[test]
     fn ambiguous_concat_repeats_simplified_with_plus_and_star() {
-        assert_eq!(optimized_pattern(r"\s+\w{0,1}\s*"), r"\s*(?:\w{1}\s*)?");
-        assert_eq!(optimized_pattern(r"^\s+\w{0,1}\s*$"), r"^\s*(?:\w{1}\s*)?$");
+        // left=\s+ (lo=1) >= right=\s* (lo=0): left is mandatory prefix, right+middle become optional suffix
+        assert_eq!(optimized_pattern(r"\s+\w{0,1}\s*"), r"\s+(?:\w{1}\s*)?");
+        assert_eq!(optimized_pattern(r"^\s+\w{0,1}\s*$"), r"^\s+(?:\w{1}\s*)?$");
     }
 
     #[test]
@@ -674,5 +703,20 @@ mod tests {
             optimized_pattern(r"(?:\s*\w?\s*)*"),
             r"(?:\s*(?:\w{1}\s*)*)?"
         );
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_star_optional_plus_uses_suffix() {
+        // left=\w* (lo=0) < right=\w+ (lo=1): the more restrictive side becomes the mandatory
+        // suffix to avoid making the rewritten expression more permissive than the original.
+        // \w*\.?\w+ cannot match an empty string (requires at least one word char from \w+),
+        // so the rewritten form must also require at least one word char.
+        assert_eq!(optimized_pattern(r"\w*\.?\w+"), r"(?:\w*\.{1})?\w+");
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_plus_optional_star_uses_prefix() {
+        // left=\w+ (lo=1) >= right=\w* (lo=0): left is the mandatory prefix
+        assert_eq!(optimized_pattern(r"\w+\.?\w*"), r"\w+(?:\.{1}\w*)?");
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -27,6 +27,7 @@ use crate::LookAround;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec;
+use alloc::vec::Vec;
 use core::mem;
 
 /// Rewrite the expression tree to help the VM compile an efficient program.
@@ -48,181 +49,6 @@ pub fn optimize(tree: &mut ExprTree) -> bool {
 fn optimize_nested_repeats(expr: &mut Expr) {
     for child in expr.children_iter_mut() {
         optimize_nested_repeats(child);
-    }
-
-    fn optimize_ambiguous_concat_repeats(expr: &mut Expr) {
-        for child in expr.children_iter_mut() {
-            optimize_ambiguous_concat_repeats(child);
-        }
-
-        if let Expr::Concat(children) = expr {
-            rewrite_concat_repeat_windows(children);
-        }
-
-        if let Expr::Repeat {
-            child,
-            lo,
-            hi,
-            greedy,
-        } = expr
-        {
-            if *greedy && *hi == usize::MAX {
-                if let Some(replacement) = rewrite_repeated_concat(child.as_ref(), *lo) {
-                    *expr = replacement;
-                }
-            }
-        }
-    }
-
-    fn rewrite_concat_repeat_windows(children: &mut Vec<Expr>) {
-        let mut ix = 0;
-        while ix + 2 < children.len() {
-            let replacement = rewrite_concat_repeat_triplet(
-                &children[ix],
-                &children[ix + 1],
-                &children[ix + 2],
-            );
-            if let Some((prefix, optional_tail)) = replacement {
-                children.splice(ix..ix + 3, [prefix, optional_tail]);
-                ix += 2;
-            } else {
-                ix += 1;
-            }
-        }
-    }
-
-    fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Option<(Expr, Expr)> {
-        let Expr::Repeat {
-            child: left_inner,
-            lo: left_lo,
-            hi: left_hi,
-            greedy: left_greedy,
-        } = left
-        else {
-            return None;
-        };
-        let Expr::Repeat {
-            child: right_inner,
-            lo: right_lo,
-            hi: right_hi,
-            greedy: right_greedy,
-        } = right
-        else {
-            return None;
-        };
-        let Expr::Repeat {
-            child: middle_inner,
-            lo: middle_lo,
-            hi: middle_hi,
-            greedy: middle_greedy,
-        } = middle
-        else {
-            return None;
-        };
-
-        if !*left_greedy || !*right_greedy || *left_hi != usize::MAX || *right_hi != usize::MAX {
-            return None;
-        }
-        if !matches!((*left_lo, *right_lo), (0, 0) | (0, 1) | (1, 0) | (1, 1)) {
-            return None;
-        }
-        if *middle_lo != 0 || *middle_hi == 0 || left_inner.as_ref() != right_inner.as_ref() {
-            return None;
-        }
-
-        let prefix = Expr::Repeat {
-            child: Box::new(left_inner.as_ref().clone()),
-            lo: (*left_lo).min(*right_lo),
-            hi: usize::MAX,
-            greedy: true,
-        };
-        let mandatory_middle = Expr::Repeat {
-            child: Box::new(middle_inner.as_ref().clone()),
-            lo: 1,
-            hi: *middle_hi,
-            greedy: *middle_greedy,
-        };
-        let tail = Expr::Concat(vec![mandatory_middle, right.clone()]);
-        let optional_tail = Expr::Repeat {
-            child: Box::new(tail),
-            lo: 0,
-            hi: 1,
-            greedy: true,
-        };
-        Some((prefix, optional_tail))
-    }
-
-    fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
-        let Expr::Concat(children) = child else {
-            return None;
-        };
-        let [prefix, optional_tail] = children.as_slice() else {
-            return None;
-        };
-        let Expr::Repeat {
-            child: tail_inner,
-            lo: tail_lo,
-            hi: tail_hi,
-            greedy: tail_greedy,
-        } = optional_tail
-        else {
-            return None;
-        };
-        if !*tail_greedy || *tail_lo != 0 || *tail_hi != 1 {
-            return None;
-        }
-        let Expr::Concat(tail_children) = tail_inner.as_ref() else {
-            return None;
-        };
-        let [middle_required, right] = tail_children.as_slice() else {
-            return None;
-        };
-        let Expr::Repeat {
-            child: prefix_inner,
-            lo: prefix_lo,
-            hi: prefix_hi,
-            greedy: prefix_greedy,
-        } = prefix
-        else {
-            return None;
-        };
-        let Expr::Repeat {
-            child: right_inner,
-            lo: right_lo,
-            hi: right_hi,
-            greedy: right_greedy,
-        } = right
-        else {
-            return None;
-        };
-
-        if !*prefix_greedy
-            || !*right_greedy
-            || *prefix_hi != usize::MAX
-            || *right_hi != usize::MAX
-            || !matches!((*prefix_lo, *right_lo), (0, 0) | (0, 1) | (1, 0) | (1, 1))
-            || prefix_inner.as_ref() != right_inner.as_ref()
-        {
-            return None;
-        }
-
-        let repeated_tail = Expr::Repeat {
-            child: Box::new(Expr::Concat(vec![middle_required.clone(), right.clone()])),
-            lo: 0,
-            hi: usize::MAX,
-            greedy: true,
-        };
-        let core = Expr::Concat(vec![prefix.clone(), repeated_tail]);
-        match outer_lo {
-            1 => Some(core),
-            0 => Some(Expr::Repeat {
-                child: Box::new(core),
-                lo: 0,
-                hi: 1,
-                greedy: true,
-            }),
-            _ => None,
-        }
     }
 
     let replacement = if let Expr::Repeat {
@@ -290,6 +116,186 @@ fn optimize_nested_repeats(expr: &mut Expr) {
     if let Some(replacement) = replacement {
         *expr = replacement;
     }
+}
+
+fn optimize_ambiguous_concat_repeats(expr: &mut Expr) {
+    for child in expr.children_iter_mut() {
+        optimize_ambiguous_concat_repeats(child);
+    }
+
+    if let Expr::Concat(children) = expr {
+        rewrite_concat_repeat_windows(children);
+    }
+
+    if let Expr::Repeat {
+        child,
+        lo,
+        hi,
+        greedy,
+    } = expr
+    {
+        if *greedy && *hi == usize::MAX {
+            if let Some(replacement) = rewrite_repeated_concat(child.as_ref(), *lo) {
+                *expr = replacement;
+            }
+        }
+    }
+}
+
+fn rewrite_concat_repeat_windows(children: &mut Vec<Expr>) {
+    let mut ix = 0;
+    while ix + 2 < children.len() {
+        let replacement =
+            rewrite_concat_repeat_triplet(&children[ix], &children[ix + 1], &children[ix + 2]);
+        if let Some((prefix, optional_tail)) = replacement {
+            children.splice(ix..ix + 3, [prefix, optional_tail]);
+            ix += 2;
+        } else {
+            ix += 1;
+        }
+    }
+}
+
+fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Option<(Expr, Expr)> {
+    let Expr::Repeat {
+        child: left_inner,
+        lo: left_lo,
+        hi: left_hi,
+        greedy: left_greedy,
+    } = left
+    else {
+        return None;
+    };
+    let Expr::Repeat {
+        child: right_inner,
+        lo: right_lo,
+        hi: right_hi,
+        greedy: right_greedy,
+    } = right
+    else {
+        return None;
+    };
+    let Expr::Repeat {
+        child: middle_inner,
+        lo: middle_lo,
+        hi: middle_hi,
+        greedy: middle_greedy,
+    } = middle
+    else {
+        return None;
+    };
+
+    if !is_unbounded_simple_repeat(*left_lo, *left_hi, *left_greedy)
+        || !is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
+    {
+        return None;
+    }
+    if !compatible_edge_repeat_bounds(*left_lo, *right_lo) {
+        return None;
+    }
+    if *middle_lo != 0 || *middle_hi == 0 || left_inner.as_ref() != right_inner.as_ref() {
+        return None;
+    }
+
+    let prefix = Expr::Repeat {
+        child: Box::new(left_inner.as_ref().clone()),
+        lo: (*left_lo).min(*right_lo),
+        hi: usize::MAX,
+        greedy: true,
+    };
+    let mandatory_middle = Expr::Repeat {
+        child: Box::new(middle_inner.as_ref().clone()),
+        lo: 1,
+        hi: *middle_hi,
+        greedy: *middle_greedy,
+    };
+    let tail = Expr::Concat(vec![mandatory_middle, right.clone()]);
+    let optional_tail = Expr::Repeat {
+        child: Box::new(tail),
+        lo: 0,
+        hi: 1,
+        greedy: true,
+    };
+    Some((prefix, optional_tail))
+}
+
+fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
+    let Expr::Concat(children) = child else {
+        return None;
+    };
+    let [prefix, tail_repeat] = children.as_slice() else {
+        return None;
+    };
+    let Expr::Repeat {
+        child: tail_inner,
+        lo: tail_lo,
+        hi: tail_hi,
+        greedy: tail_greedy,
+    } = tail_repeat
+    else {
+        return None;
+    };
+    if !*tail_greedy || *tail_lo != 0 || *tail_hi != 1 {
+        return None;
+    }
+    let Expr::Concat(tail_children) = tail_inner.as_ref() else {
+        return None;
+    };
+    let [middle_part, right] = tail_children.as_slice() else {
+        return None;
+    };
+    let Expr::Repeat {
+        child: prefix_inner,
+        lo: prefix_lo,
+        hi: prefix_hi,
+        greedy: prefix_greedy,
+    } = prefix
+    else {
+        return None;
+    };
+    let Expr::Repeat {
+        child: right_inner,
+        lo: right_lo,
+        hi: right_hi,
+        greedy: right_greedy,
+    } = right
+    else {
+        return None;
+    };
+
+    if !is_unbounded_simple_repeat(*prefix_lo, *prefix_hi, *prefix_greedy)
+        || !is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
+        || !compatible_edge_repeat_bounds(*prefix_lo, *right_lo)
+        || prefix_inner.as_ref() != right_inner.as_ref()
+    {
+        return None;
+    }
+
+    let repeated_tail = Expr::Repeat {
+        child: Box::new(Expr::Concat(vec![middle_part.clone(), right.clone()])),
+        lo: 0,
+        hi: usize::MAX,
+        greedy: true,
+    };
+    let core = Expr::Concat(vec![prefix.clone(), repeated_tail]);
+    match outer_lo {
+        1 => Some(core),
+        0 => Some(Expr::Repeat {
+            child: Box::new(core),
+            lo: 0,
+            hi: 1,
+            greedy: true,
+        }),
+        _ => None,
+    }
+}
+
+fn is_unbounded_simple_repeat(lo: usize, hi: usize, greedy: bool) -> bool {
+    greedy && hi == usize::MAX && matches!(lo, 0 | 1)
+}
+
+fn compatible_edge_repeat_bounds(left_lo: usize, right_lo: usize) -> bool {
+    matches!((left_lo, right_lo), (0, 0) | (0, 1) | (1, 0) | (1, 1))
 }
 
 fn compose_repeat(child: Box<Expr>, result_kind: QuantifierKind) -> Expr {
@@ -581,7 +587,7 @@ mod tests {
 
     #[test]
     fn ambiguous_concat_repeats_simplified_basic() {
-        assert_eq!(optimized_pattern(r"\b\s*\w?\s*"), r"\b\s*(?:\w\s*)?");
+        assert_eq!(optimized_pattern(r"\s*\w?\s*"), r"\s*(?:\w{1}\s*)?");
     }
 
     #[test]
@@ -595,23 +601,26 @@ mod tests {
     #[test]
     fn ambiguous_concat_repeats_simplified_with_nongreedy_middle() {
         assert_eq!(
-            optimized_pattern(r"foo\w*\s{0,5}?\w+\b"),
-            r"foo\w*(?:\s{1,5}?\w+)?\b"
+            optimized_pattern(r"foo\w*\s{0,5}?\w+"),
+            r"foo\w*(?:\s{1,5}?\w+)?"
         );
     }
 
     #[test]
     fn ambiguous_concat_repeats_simplified_with_plus_and_star() {
-        assert_eq!(optimized_pattern(r"\b\s+\w{0,1}\s*\b"), r"\b\s*(?:\w\s*)?\b");
+        assert_eq!(optimized_pattern(r"\s+\w{0,1}\s*"), r"\s*(?:\w{1}\s*)?");
     }
 
     #[test]
     fn ambiguous_concat_repeats_inside_plus_simplified() {
-        assert_eq!(optimized_pattern(r"(?:\s*\w?\s*)+"), r"\s*(?:\w\s*)*");
+        assert_eq!(optimized_pattern(r"(?:\s*\w?\s*)+"), r"\s*(?:\w{1}\s*)*");
     }
 
     #[test]
     fn ambiguous_concat_repeats_inside_star_simplified() {
-        assert_eq!(optimized_pattern(r"(?:\s*\w?\s*)*"), r"(?:\s*(?:\w\s*)*)?");
+        assert_eq!(
+            optimized_pattern(r"(?:\s*\w?\s*)*"),
+            r"(?:\s*(?:\w{1}\s*)*)?"
+        );
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -24,6 +24,7 @@ use crate::parse::ExprTree;
 use crate::Expr;
 use crate::LookAround;
 
+use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec;
 use core::mem;
@@ -32,10 +33,152 @@ use core::mem;
 /// Returns a boolean to say whether the new tree explicitly contains capture group 0.
 pub fn optimize(tree: &mut ExprTree) -> bool {
     // self recursion prevents us from moving the trailing lookahead out of group 0
-    if !tree.self_recursive {
+    let requires_capture_group_fixup = if !tree.self_recursive {
         optimize_trailing_lookahead(tree)
     } else {
         false
+    };
+
+    optimize_nested_repeats(&mut tree.expr);
+
+    requires_capture_group_fixup
+}
+
+fn optimize_nested_repeats(expr: &mut Expr) {
+    for child in expr.children_iter_mut() {
+        optimize_nested_repeats(child);
+    }
+
+    let replacement = if let Expr::Repeat {
+        child,
+        lo: outer_lo,
+        hi: outer_hi,
+        greedy: outer_greedy,
+    } = expr
+    {
+        if let Expr::Repeat {
+            child: inner_child,
+            lo: inner_lo,
+            hi: inner_hi,
+            greedy: inner_greedy,
+        } = child.as_ref()
+        {
+            if let Some(result_kind) = can_simplify(
+                *outer_lo,
+                *outer_hi,
+                *outer_greedy,
+                *inner_lo,
+                *inner_hi,
+                *inner_greedy,
+            ) {
+                Some(compose_repeat(
+                    Box::new(inner_child.as_ref().clone()),
+                    result_kind,
+                ))
+            } else {
+                None
+            }
+        } else if let Expr::Group(group) = child.as_mut() {
+            if let Expr::Repeat {
+                child: inner_child,
+                lo: inner_lo,
+                hi: inner_hi,
+                greedy: inner_greedy,
+            } = group.as_ref()
+            {
+                if let Some(result_kind) = can_simplify(
+                    *outer_lo,
+                    *outer_hi,
+                    *outer_greedy,
+                    *inner_lo,
+                    *inner_hi,
+                    *inner_greedy,
+                ) {
+                    Some(Expr::Group(Arc::new(compose_repeat(
+                        Box::new(inner_child.as_ref().clone()),
+                        result_kind,
+                    ))))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(replacement) = replacement {
+        *expr = replacement;
+    }
+}
+
+fn compose_repeat(child: Box<Expr>, result_kind: QuantifierKind) -> Expr {
+    let (lo, hi) = result_kind.bounds();
+    Expr::Repeat {
+        child,
+        lo,
+        hi,
+        greedy: true,
+    }
+}
+
+fn can_simplify(
+    outer_lo: usize,
+    outer_hi: usize,
+    outer_greedy: bool,
+    inner_lo: usize,
+    inner_hi: usize,
+    inner_greedy: bool,
+) -> Option<QuantifierKind> {
+    if !outer_greedy || !inner_greedy {
+        return None;
+    }
+
+    let outer = quantifier_kind(outer_lo, outer_hi)?;
+    let inner = quantifier_kind(inner_lo, inner_hi)?;
+
+    match (inner, outer) {
+        (QuantifierKind::OneOrMore, QuantifierKind::OneOrMore) => Some(QuantifierKind::OneOrMore),
+        (QuantifierKind::ZeroOrMore, QuantifierKind::OneOrMore) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::Optional, QuantifierKind::OneOrMore) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::OneOrMore, QuantifierKind::ZeroOrMore) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::ZeroOrMore, QuantifierKind::ZeroOrMore) => {
+            Some(QuantifierKind::ZeroOrMore)
+        }
+        (QuantifierKind::Optional, QuantifierKind::ZeroOrMore) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::OneOrMore, QuantifierKind::Optional) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::ZeroOrMore, QuantifierKind::Optional) => Some(QuantifierKind::ZeroOrMore),
+        (QuantifierKind::Optional, QuantifierKind::Optional) => Some(QuantifierKind::Optional),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QuantifierKind {
+    Optional,
+    ZeroOrMore,
+    OneOrMore,
+}
+
+impl QuantifierKind {
+    fn bounds(self) -> (usize, usize) {
+        match self {
+            QuantifierKind::Optional => (0, 1),
+            QuantifierKind::ZeroOrMore => (0, usize::MAX),
+            QuantifierKind::OneOrMore => (1, usize::MAX),
+        }
+    }
+}
+
+fn quantifier_kind(lo: usize, hi: usize) -> Option<QuantifierKind> {
+    match (lo, hi) {
+        (0, 1) => Some(QuantifierKind::Optional),
+        (0, usize::MAX) => Some(QuantifierKind::ZeroOrMore),
+        (1, usize::MAX) => Some(QuantifierKind::OneOrMore),
+        _ => None,
     }
 }
 
@@ -89,6 +232,22 @@ mod tests {
     use crate::parse::make_literal;
     use crate::Expr;
     use alloc::string::String;
+
+    fn optimized_pattern(pattern: &str) -> String {
+        optimized_pattern_with_flags(pattern, crate::parse_flags::FLAG_UNICODE)
+    }
+
+    fn optimized_pattern_with_flags(pattern: &str, flags: u32) -> String {
+        let mut tree = Expr::parse_tree_with_flags(pattern, flags).unwrap();
+        optimize(&mut tree);
+        let mut s = String::new();
+        tree.expr.to_str(&mut s, 0);
+        s
+    }
+
+    fn oniguruma_flags() -> u32 {
+        crate::parse_flags::FLAG_ONIGURUMA_MODE | crate::parse_flags::FLAG_UNICODE
+    }
 
     #[test]
     fn trailing_positive_lookahead_optimized() {
@@ -180,5 +339,67 @@ mod tests {
         let requires_capture_group_fixup = optimize(&mut optimized_tree);
         assert_eq!(requires_capture_group_fixup, false);
         assert_eq!(&optimized_tree.expr, &tree.expr);
+    }
+
+    #[test]
+    fn nested_plus_plus_simplified() {
+        assert_eq!(optimized_pattern(r"(x+){1,}"), "(x+)");
+    }
+
+    #[test]
+    fn nested_star_plus_simplified() {
+        assert_eq!(optimized_pattern(r"(x*){1,}"), "(x*)");
+    }
+
+    #[test]
+    fn nested_optional_plus_simplified() {
+        assert_eq!(optimized_pattern(r"(x?){1,}"), "(x*)");
+    }
+
+    #[test]
+    fn nested_optional_optional_simplified() {
+        assert_eq!(optimized_pattern(r"(x?){0,1}"), "(x?)");
+    }
+
+    #[test]
+    fn nested_repeats_in_children_simplified() {
+        assert_eq!(optimized_pattern(r"(x+){1,}(y*){0,}"), "(x+)(y*)");
+    }
+
+    #[test]
+    fn capture_group_preserved_when_nested_repeat_simplified() {
+        assert_eq!(optimized_pattern(r"(x+){1,}"), "(x+)");
+    }
+
+    #[test]
+    fn non_greedy_nested_repeats_left_alone() {
+        assert_eq!(optimized_pattern(r"(x+?){1,}"), "(x+?)+");
+        assert_eq!(optimized_pattern(r"(x+){0,1}?"), "(x+)??");
+    }
+
+    #[test]
+    fn bounded_quantifier_left_alone() {
+        let max = usize::MAX;
+        assert_eq!(
+            super::can_simplify(1, max, true, 1, max, true),
+            Some(super::QuantifierKind::OneOrMore)
+        );
+        assert_eq!(super::can_simplify(2, max, true, 1, max, true), None);
+    }
+
+    #[test]
+    fn nested_repeat_does_not_affect_capture_group_fixup_return() {
+        let mut tree = Expr::parse_tree(r"(x+){1,}").unwrap();
+        let requires_capture_group_fixup = optimize(&mut tree);
+        assert_eq!(requires_capture_group_fixup, false);
+        assert_eq!(optimized_pattern(r"(x+){1,}"), "(x+)");
+    }
+
+    #[test]
+    fn nested_repeats_from_oniguruma_adjacent_quantifiers_simplified() {
+        assert_eq!(
+            optimized_pattern_with_flags(r"(x+){1,}{0,}", oniguruma_flags()),
+            "(x*)"
+        );
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -660,6 +660,7 @@ mod tests {
     #[test]
     fn ambiguous_concat_repeats_simplified_with_plus_and_star() {
         assert_eq!(optimized_pattern(r"\s+\w{0,1}\s*"), r"\s*(?:\w{1}\s*)?");
+        assert_eq!(optimized_pattern(r"^\s+\w{0,1}\s*$"), r"^\s*(?:\w{1}\s*)?$");
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -40,6 +40,7 @@ pub fn optimize(tree: &mut ExprTree) -> bool {
     };
 
     optimize_nested_repeats(&mut tree.expr);
+    optimize_ambiguous_concat_repeats(&mut tree.expr);
 
     requires_capture_group_fixup
 }
@@ -47,6 +48,181 @@ pub fn optimize(tree: &mut ExprTree) -> bool {
 fn optimize_nested_repeats(expr: &mut Expr) {
     for child in expr.children_iter_mut() {
         optimize_nested_repeats(child);
+    }
+
+    fn optimize_ambiguous_concat_repeats(expr: &mut Expr) {
+        for child in expr.children_iter_mut() {
+            optimize_ambiguous_concat_repeats(child);
+        }
+
+        if let Expr::Concat(children) = expr {
+            rewrite_concat_repeat_windows(children);
+        }
+
+        if let Expr::Repeat {
+            child,
+            lo,
+            hi,
+            greedy,
+        } = expr
+        {
+            if *greedy && *hi == usize::MAX {
+                if let Some(replacement) = rewrite_repeated_concat(child.as_ref(), *lo) {
+                    *expr = replacement;
+                }
+            }
+        }
+    }
+
+    fn rewrite_concat_repeat_windows(children: &mut Vec<Expr>) {
+        let mut ix = 0;
+        while ix + 2 < children.len() {
+            let replacement = rewrite_concat_repeat_triplet(
+                &children[ix],
+                &children[ix + 1],
+                &children[ix + 2],
+            );
+            if let Some((prefix, optional_tail)) = replacement {
+                children.splice(ix..ix + 3, [prefix, optional_tail]);
+                ix += 2;
+            } else {
+                ix += 1;
+            }
+        }
+    }
+
+    fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Option<(Expr, Expr)> {
+        let Expr::Repeat {
+            child: left_inner,
+            lo: left_lo,
+            hi: left_hi,
+            greedy: left_greedy,
+        } = left
+        else {
+            return None;
+        };
+        let Expr::Repeat {
+            child: right_inner,
+            lo: right_lo,
+            hi: right_hi,
+            greedy: right_greedy,
+        } = right
+        else {
+            return None;
+        };
+        let Expr::Repeat {
+            child: middle_inner,
+            lo: middle_lo,
+            hi: middle_hi,
+            greedy: middle_greedy,
+        } = middle
+        else {
+            return None;
+        };
+
+        if !*left_greedy || !*right_greedy || *left_hi != usize::MAX || *right_hi != usize::MAX {
+            return None;
+        }
+        if !matches!((*left_lo, *right_lo), (0, 0) | (0, 1) | (1, 0) | (1, 1)) {
+            return None;
+        }
+        if *middle_lo != 0 || *middle_hi == 0 || left_inner.as_ref() != right_inner.as_ref() {
+            return None;
+        }
+
+        let prefix = Expr::Repeat {
+            child: Box::new(left_inner.as_ref().clone()),
+            lo: (*left_lo).min(*right_lo),
+            hi: usize::MAX,
+            greedy: true,
+        };
+        let mandatory_middle = Expr::Repeat {
+            child: Box::new(middle_inner.as_ref().clone()),
+            lo: 1,
+            hi: *middle_hi,
+            greedy: *middle_greedy,
+        };
+        let tail = Expr::Concat(vec![mandatory_middle, right.clone()]);
+        let optional_tail = Expr::Repeat {
+            child: Box::new(tail),
+            lo: 0,
+            hi: 1,
+            greedy: true,
+        };
+        Some((prefix, optional_tail))
+    }
+
+    fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
+        let Expr::Concat(children) = child else {
+            return None;
+        };
+        let [prefix, optional_tail] = children.as_slice() else {
+            return None;
+        };
+        let Expr::Repeat {
+            child: tail_inner,
+            lo: tail_lo,
+            hi: tail_hi,
+            greedy: tail_greedy,
+        } = optional_tail
+        else {
+            return None;
+        };
+        if !*tail_greedy || *tail_lo != 0 || *tail_hi != 1 {
+            return None;
+        }
+        let Expr::Concat(tail_children) = tail_inner.as_ref() else {
+            return None;
+        };
+        let [middle_required, right] = tail_children.as_slice() else {
+            return None;
+        };
+        let Expr::Repeat {
+            child: prefix_inner,
+            lo: prefix_lo,
+            hi: prefix_hi,
+            greedy: prefix_greedy,
+        } = prefix
+        else {
+            return None;
+        };
+        let Expr::Repeat {
+            child: right_inner,
+            lo: right_lo,
+            hi: right_hi,
+            greedy: right_greedy,
+        } = right
+        else {
+            return None;
+        };
+
+        if !*prefix_greedy
+            || !*right_greedy
+            || *prefix_hi != usize::MAX
+            || *right_hi != usize::MAX
+            || !matches!((*prefix_lo, *right_lo), (0, 0) | (0, 1) | (1, 0) | (1, 1))
+            || prefix_inner.as_ref() != right_inner.as_ref()
+        {
+            return None;
+        }
+
+        let repeated_tail = Expr::Repeat {
+            child: Box::new(Expr::Concat(vec![middle_required.clone(), right.clone()])),
+            lo: 0,
+            hi: usize::MAX,
+            greedy: true,
+        };
+        let core = Expr::Concat(vec![prefix.clone(), repeated_tail]);
+        match outer_lo {
+            1 => Some(core),
+            0 => Some(Expr::Repeat {
+                child: Box::new(core),
+                lo: 0,
+                hi: 1,
+                greedy: true,
+            }),
+            _ => None,
+        }
     }
 
     let replacement = if let Expr::Repeat {
@@ -401,5 +577,41 @@ mod tests {
             optimized_pattern_with_flags(r"(x+){1,}{0,}", oniguruma_flags()),
             "(x*)"
         );
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_simplified_basic() {
+        assert_eq!(optimized_pattern(r"\b\s*\w?\s*"), r"\b\s*(?:\w\s*)?");
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_simplified_with_bounded_middle() {
+        assert_eq!(
+            optimized_pattern(r"foo\w*\s{0,5}\w+"),
+            r"foo\w*(?:\s{1,5}\w+)?"
+        );
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_simplified_with_nongreedy_middle() {
+        assert_eq!(
+            optimized_pattern(r"foo\w*\s{0,5}?\w+\b"),
+            r"foo\w*(?:\s{1,5}?\w+)?\b"
+        );
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_simplified_with_plus_and_star() {
+        assert_eq!(optimized_pattern(r"\b\s+\w{0,1}\s*\b"), r"\b\s*(?:\w\s*)?\b");
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_inside_plus_simplified() {
+        assert_eq!(optimized_pattern(r"(?:\s*\w?\s*)+"), r"\s*(?:\w\s*)*");
+    }
+
+    #[test]
+    fn ambiguous_concat_repeats_inside_star_simplified() {
+        assert_eq!(optimized_pattern(r"(?:\s*\w?\s*)*"), r"(?:\s*(?:\w\s*)*)?");
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -127,17 +127,22 @@ fn optimize_ambiguous_concat_repeats(expr: &mut Expr) {
         rewrite_concat_repeat_windows(children);
     }
 
-    if let Expr::Repeat {
+    let should_rewrite = if let Expr::Repeat {
         child,
         lo,
         hi,
         greedy,
-    } = expr
+    } = &*expr
     {
-        if *greedy && *hi == usize::MAX {
-            if let Some(replacement) = rewrite_repeated_concat(child.as_ref(), *lo) {
-                *expr = replacement;
-            }
+        *greedy && *hi == usize::MAX && check_repeated_concat(child.as_ref(), *lo)
+    } else {
+        false
+    };
+
+    if should_rewrite {
+        let owned = mem::replace(expr, Expr::Empty);
+        if let Expr::Repeat { child, lo, .. } = owned {
+            *expr = build_repeated_concat(*child, lo);
         }
     }
 }
@@ -145,9 +150,14 @@ fn optimize_ambiguous_concat_repeats(expr: &mut Expr) {
 fn rewrite_concat_repeat_windows(children: &mut Vec<Expr>) {
     let mut ix = 0;
     while ix + 2 < children.len() {
-        let replacement =
-            rewrite_concat_repeat_triplet(&children[ix], &children[ix + 1], &children[ix + 2]);
-        if let Some((prefix, optional_tail)) = replacement {
+        if check_concat_repeat_triplet(&children[ix], &children[ix + 1], &children[ix + 2]) {
+            let mut left = Expr::Empty;
+            let mut middle = Expr::Empty;
+            let mut right = Expr::Empty;
+            mem::swap(&mut left, &mut children[ix]);
+            mem::swap(&mut middle, &mut children[ix + 1]);
+            mem::swap(&mut right, &mut children[ix + 2]);
+            let (prefix, optional_tail) = build_concat_repeat_triplet(left, middle, right);
             children.splice(ix..ix + 3, [prefix, optional_tail]);
             ix += 2;
         } else {
@@ -156,7 +166,7 @@ fn rewrite_concat_repeat_windows(children: &mut Vec<Expr>) {
     }
 }
 
-fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Option<(Expr, Expr)> {
+fn check_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> bool {
     let Expr::Repeat {
         child: left_inner,
         lo: left_lo,
@@ -164,7 +174,7 @@ fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Op
         greedy: left_greedy,
     } = left
     else {
-        return None;
+        return false;
     };
     let Expr::Repeat {
         child: right_inner,
@@ -173,58 +183,80 @@ fn rewrite_concat_repeat_triplet(left: &Expr, middle: &Expr, right: &Expr) -> Op
         greedy: right_greedy,
     } = right
     else {
-        return None;
+        return false;
+    };
+    let Expr::Repeat {
+        lo: middle_lo,
+        hi: middle_hi,
+        ..
+    } = middle
+    else {
+        return false;
+    };
+
+    is_unbounded_simple_repeat(*left_lo, *left_hi, *left_greedy)
+        && is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
+        && compatible_edge_repeat_bounds(*left_lo, *right_lo)
+        && *middle_lo == 0
+        && *middle_hi != 0
+        && left_inner.as_ref() == right_inner.as_ref()
+}
+
+fn build_concat_repeat_triplet(left: Expr, middle: Expr, right: Expr) -> (Expr, Expr) {
+    let Expr::Repeat {
+        child: left_inner,
+        lo: left_lo,
+        ..
+    } = left
+    else {
+        unreachable!("check_concat_repeat_triplet guarantees left is a Repeat");
     };
     let Expr::Repeat {
         child: middle_inner,
-        lo: middle_lo,
         hi: middle_hi,
         greedy: middle_greedy,
+        ..
     } = middle
     else {
-        return None;
+        unreachable!("check_concat_repeat_triplet guarantees middle is a Repeat");
+    };
+    let right_lo = if let Expr::Repeat { lo, .. } = &right {
+        *lo
+    } else {
+        unreachable!("check_concat_repeat_triplet guarantees right is a Repeat");
     };
 
-    if !is_unbounded_simple_repeat(*left_lo, *left_hi, *left_greedy)
-        || !is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
-    {
-        return None;
-    }
-    if !compatible_edge_repeat_bounds(*left_lo, *right_lo) {
-        return None;
-    }
-    if *middle_lo != 0 || *middle_hi == 0 || left_inner.as_ref() != right_inner.as_ref() {
-        return None;
-    }
-
     let prefix = Expr::Repeat {
-        child: Box::new(left_inner.as_ref().clone()),
-        lo: (*left_lo).min(*right_lo),
+        child: left_inner,
+        lo: left_lo.min(right_lo),
         hi: usize::MAX,
         greedy: true,
     };
     let mandatory_middle = Expr::Repeat {
-        child: Box::new(middle_inner.as_ref().clone()),
+        child: middle_inner,
         lo: 1,
-        hi: *middle_hi,
-        greedy: *middle_greedy,
+        hi: middle_hi,
+        greedy: middle_greedy,
     };
-    let tail = Expr::Concat(vec![mandatory_middle, right.clone()]);
+    let tail = Expr::Concat(vec![mandatory_middle, right]);
     let optional_tail = Expr::Repeat {
         child: Box::new(tail),
         lo: 0,
         hi: 1,
         greedy: true,
     };
-    Some((prefix, optional_tail))
+    (prefix, optional_tail)
 }
 
-fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
+fn check_repeated_concat(child: &Expr, outer_lo: usize) -> bool {
+    if outer_lo != 0 && outer_lo != 1 {
+        return false;
+    }
     let Expr::Concat(children) = child else {
-        return None;
+        return false;
     };
     let [prefix, tail_repeat] = children.as_slice() else {
-        return None;
+        return false;
     };
     let Expr::Repeat {
         child: tail_inner,
@@ -233,16 +265,16 @@ fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
         greedy: tail_greedy,
     } = tail_repeat
     else {
-        return None;
+        return false;
     };
     if !*tail_greedy || *tail_lo != 0 || *tail_hi != 1 {
-        return None;
+        return false;
     }
     let Expr::Concat(tail_children) = tail_inner.as_ref() else {
-        return None;
+        return false;
     };
-    let [middle_part, right] = tail_children.as_slice() else {
-        return None;
+    let [_, right] = tail_children.as_slice() else {
+        return false;
     };
     let Expr::Repeat {
         child: prefix_inner,
@@ -251,7 +283,7 @@ fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
         greedy: prefix_greedy,
     } = prefix
     else {
-        return None;
+        return false;
     };
     let Expr::Repeat {
         child: right_inner,
@@ -260,33 +292,52 @@ fn rewrite_repeated_concat(child: &Expr, outer_lo: usize) -> Option<Expr> {
         greedy: right_greedy,
     } = right
     else {
-        return None;
+        return false;
     };
 
-    if !is_unbounded_simple_repeat(*prefix_lo, *prefix_hi, *prefix_greedy)
-        || !is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
-        || !compatible_edge_repeat_bounds(*prefix_lo, *right_lo)
-        || prefix_inner.as_ref() != right_inner.as_ref()
-    {
-        return None;
-    }
+    is_unbounded_simple_repeat(*prefix_lo, *prefix_hi, *prefix_greedy)
+        && is_unbounded_simple_repeat(*right_lo, *right_hi, *right_greedy)
+        && compatible_edge_repeat_bounds(*prefix_lo, *right_lo)
+        && prefix_inner.as_ref() == right_inner.as_ref()
+}
+
+fn build_repeated_concat(child: Expr, outer_lo: usize) -> Expr {
+    let Expr::Concat(mut children) = child else {
+        unreachable!("check_repeated_concat guarantees child is a Concat");
+    };
+    // children = [prefix_repeat, tail_repeat]
+    let tail_repeat = children.pop().unwrap();
+    let prefix = children.pop().unwrap();
+
+    let Expr::Repeat {
+        child: tail_inner, ..
+    } = tail_repeat
+    else {
+        unreachable!("check_repeated_concat guarantees tail is a Repeat");
+    };
+    let Expr::Concat(mut tail_children) = *tail_inner else {
+        unreachable!("check_repeated_concat guarantees tail inner is a Concat");
+    };
+    // tail_children = [middle_part, right_repeat]
+    let right = tail_children.pop().unwrap();
+    let middle_part = tail_children.pop().unwrap();
 
     let repeated_tail = Expr::Repeat {
-        child: Box::new(Expr::Concat(vec![middle_part.clone(), right.clone()])),
+        child: Box::new(Expr::Concat(vec![middle_part, right])),
         lo: 0,
         hi: usize::MAX,
         greedy: true,
     };
-    let core = Expr::Concat(vec![prefix.clone(), repeated_tail]);
+    let core = Expr::Concat(vec![prefix, repeated_tail]);
     match outer_lo {
-        1 => Some(core),
-        0 => Some(Expr::Repeat {
+        1 => core,
+        0 => Expr::Repeat {
             child: Box::new(core),
             lo: 0,
             hi: 1,
             greedy: true,
-        }),
-        _ => None,
+        },
+        _ => unreachable!("check_repeated_concat guarantees outer_lo is 0 or 1"),
     }
 }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -255,7 +255,7 @@ fn check_repeated_concat(child: &Expr, outer_lo: usize) -> bool {
     let Expr::Concat(children) = child else {
         return false;
     };
-    let [prefix, tail_repeat] = children.as_slice() else {
+    let [prefix, optional_tail] = children.as_slice() else {
         return false;
     };
     let Expr::Repeat {
@@ -263,7 +263,7 @@ fn check_repeated_concat(child: &Expr, outer_lo: usize) -> bool {
         lo: tail_lo,
         hi: tail_hi,
         greedy: tail_greedy,
-    } = tail_repeat
+    } = optional_tail
     else {
         return false;
     };
@@ -273,7 +273,7 @@ fn check_repeated_concat(child: &Expr, outer_lo: usize) -> bool {
     let Expr::Concat(tail_children) = tail_inner.as_ref() else {
         return false;
     };
-    let [_, right] = tail_children.as_slice() else {
+    let [_middle_part, right] = tail_children.as_slice() else {
         return false;
     };
     let Expr::Repeat {
@@ -305,13 +305,13 @@ fn build_repeated_concat(child: Expr, outer_lo: usize) -> Expr {
     let Expr::Concat(mut children) = child else {
         unreachable!("check_repeated_concat guarantees child is a Concat");
     };
-    // children = [prefix_repeat, tail_repeat]
-    let tail_repeat = children.pop().unwrap();
+    // children = [prefix_repeat, optional_tail]
+    let optional_tail = children.pop().unwrap();
     let prefix = children.pop().unwrap();
 
     let Expr::Repeat {
         child: tail_inner, ..
-    } = tail_repeat
+    } = optional_tail
     else {
         unreachable!("check_repeated_concat guarantees tail is a Repeat");
     };

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -25,6 +25,18 @@ fn captures_fancy() {
 }
 
 #[test]
+fn nested_repeats_preserve_capture_numbering() {
+    let re = RegexBuilder::new(r"(x+){1,}(y)$")
+        .oniguruma_mode(true)
+        .build()
+        .unwrap();
+    let captures = re.captures("xxxy").unwrap().unwrap();
+    assert_eq!(captures.len(), 3);
+    assert_match(captures.get(1), "xxx", 0, 3);
+    assert_match(captures.get(2), "y", 3, 4);
+}
+
+#[test]
 fn captures_fancy_named() {
     let captures = common::assert_captures(r"\s*(?<name>\w+)(?=\.)", "foo bar.").unwrap();
     assert_eq!(captures.len(), 2);

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -86,6 +86,32 @@ fn alternation_with_empty_arm() {
 }
 
 #[test]
+fn nested_repeats_match_same_language() {
+    fn assert_oniguruma_is_match(pattern: &str, text: &str) {
+        let re = RegexBuilder::new(pattern)
+            .oniguruma_mode(true)
+            .build()
+            .unwrap();
+        assert!(re.is_match(text).unwrap());
+    }
+
+    fn assert_oniguruma_no_match(pattern: &str, text: &str) {
+        let re = RegexBuilder::new(pattern)
+            .oniguruma_mode(true)
+            .build()
+            .unwrap();
+        assert!(!re.is_match(text).unwrap());
+    }
+
+    assert_oniguruma_is_match(r"^(x+){1,}$", "xxx");
+    assert_oniguruma_no_match(r"^(x+){1,}$", "xxy");
+    assert_oniguruma_is_match(r"^(x*){1,}$", "");
+    assert_oniguruma_is_match(r"^(x*){1,}$", "xxx");
+    assert_oniguruma_is_match(r"^(x?){1,}$", "");
+    assert_oniguruma_is_match(r"^(x?){1,}$", "xxx");
+}
+
+#[test]
 fn case_insensitive_character_class() {
     common::assert_is_match(r"^(?i)[a-z]+$", "aB");
 }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1034,3 +1034,29 @@ fn native_char_class_matches_multibyte_unicode() {
     let re = fancy_regex::Regex::new(r"(?<=a)[^\d]").unwrap();
     assert!(re.is_match("aé").unwrap());
 }
+
+#[test]
+fn ambiguous_concat_repeat_optimization_not_more_permissive() {
+    // \w*\.?\w+ requires at least one word character (from \w+).
+    // After optimization to (?:\w*\.{1})?\w+, it must not match an empty string.
+    common::assert_is_match(r"\w*\.?\w+", "a");
+    common::assert_is_match(r"\w*\.?\w+", "ab");
+    common::assert_is_match(r"\w*\.?\w+", "a.b");
+    common::assert_no_match(r"^\w*\.?\w+$", "");
+    common::assert_no_match(r"^\w*\.?\w+$", ".");
+
+    // \w+\.?\w* requires at least one word character (from \w+).
+    // After optimization to \w+(?:\.{1}\w*)?, it must not match an empty string.
+    common::assert_is_match(r"\w+\.?\w*", "a");
+    common::assert_is_match(r"\w+\.?\w*", "ab");
+    common::assert_is_match(r"\w+\.?\w*", "a.b");
+    common::assert_no_match(r"^\w+\.?\w*$", "");
+    common::assert_no_match(r"^\w+\.?\w*$", ".");
+
+    // \s+\w?\s* requires at least one whitespace character (from \s+).
+    // After optimization to \s+(?:\w{1}\s*)?, it must not match an empty string.
+    common::assert_is_match(r"\s+\w?\s*", " ");
+    common::assert_is_match(r"\s+\w?\s*", " a ");
+    common::assert_no_match(r"^\s+\w?\s*$", "");
+    common::assert_no_match(r"^\s+\w?\s*$", "a");
+}


### PR DESCRIPTION
In the optimization pass, rewrite patterns of the form `Repeat(X) -> Repeat(lo=0, ...) -> Repeat(X)` into a leading `Repeat(X)`  followed by an optional tail where the middle repeat is made mandatory (lo raised from 0 to 1) and followed by the trailing `Repeat(X)`. This keeps semantics identical but removes the possibility of catastrophic backtracking.

In addition, it does a second rewrite for enclosing quantifiers (`+` and `*` specifically) around the transformed `Concat`, so patterns like:

- `(?:\s*\w?\s*)+` become `\s*(?:\w{1}\s*)*`
- `(?:\s*\w?\s*)*` become `(?:\s*(?:\w{1}\s*)*)?`

As a separate but semi-related optimization, unnecessarily repeated patterns also merge the quantifiers for the same goal. Example: `(?:x+)*` is identical to `x*`

Full disclaimer: I got Copilot to do most of the work, and iterated with followup prompts, and manually fixed a few things and then fixed up the original commits. The ideas and examples were mine, the implementation was done by the AI.