### PR TITLE
Add VM instruction for case insensitive literals when in Unicode mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Added
+### Changed
+- Add VM instruction for case insensitive literals when in Unicode mode, to keep the build cost bounded (#268)
+### Fixed
+
 ## [0.19.0] - 2026-07-28
 ### Added
 - Add `BytesMode` and the `RegexInput` trait so the matching and capture APIs can operate on strings or bytes, and allows to opt out of unicode handling if desired (#248)
@@ -282,7 +288,7 @@ If you previously stored i.e. `Captures`, you would need to change the type to `
 ### Added
 - Initial release
 
-
+[Unreleased]: https://github.com/fancy-regex/fancy-regex/compare/0.19.0...HEAD
 [0.19.0]: https://github.com/fancy-regex/fancy-regex/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/fancy-regex/fancy-regex/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/fancy-regex/fancy-regex/compare/0.16.2...0.17.0

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -72,14 +72,6 @@ impl<'a> Info<'a> {
         self.capture_groups.end()
     }
 
-    pub(crate) fn is_literal(&self) -> bool {
-        match *self.expr {
-            Expr::Literal { casei, .. } => !casei,
-            Expr::Concat(_) => self.children.iter().all(|child| child.is_literal()),
-            _ => false,
-        }
-    }
-
     pub(crate) fn push_literal(&self, buf: &mut String) {
         match *self.expr {
             // could be more paranoid about checking casei
@@ -90,6 +82,32 @@ impl<'a> Info<'a> {
                 }
             }
             _ => panic!("push_literal called on non-literal"),
+        }
+    }
+
+    /// `None` if this is not a literal; `Some(casei)` if it is, where `casei`
+    /// says whether any character is case-insensitive.
+    pub(crate) fn literal_casei(&self) -> Option<bool> {
+        match *self.expr {
+            Expr::Literal { casei, .. } => Some(casei),
+            Expr::Concat(_) => self
+                .children
+                .iter()
+                .try_fold(false, |any, child| child.literal_casei().map(|c| any || c)),
+            _ => None,
+        }
+    }
+
+    /// Pushes each character of the literal along with its case-insensitivity.
+    pub(crate) fn push_literal_chars(&self, buf: &mut Vec<(char, bool)>) {
+        match *self.expr {
+            Expr::Literal { ref val, casei } => buf.extend(val.chars().map(|c| (c, casei))),
+            Expr::Concat(_) => {
+                for child in &self.children {
+                    child.push_literal_chars(buf);
+                }
+            }
+            _ => panic!("push_literal_chars called on non-literal"),
         }
     }
 }
@@ -1350,14 +1368,21 @@ mod tests {
     fn is_literal() {
         let tree = Expr::parse_tree("abc").unwrap();
         let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        assert_eq!(info.is_literal(), true);
+        assert_eq!(info.literal_casei(), Some(false));
+    }
+
+    #[test]
+    fn is_literal_casei() {
+        let tree = Expr::parse_tree("(?i)abc").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.literal_casei(), Some(true));
     }
 
     #[test]
     fn is_literal_with_repeat() {
         let tree = Expr::parse_tree("abc*").unwrap();
         let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        assert_eq!(info.is_literal(), false);
+        assert_eq!(info.literal_casei(), None);
     }
 
     #[test]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -44,7 +44,7 @@ use crate::seek::build_seek_pattern;
 use crate::to_hir::{expr_to_hir, HirCtx};
 #[cfg(feature = "variable-lookbehinds")]
 use crate::vm::{CachePoolFn, ReverseBackwardsDelegate};
-use crate::vm::{CaptureGroupRange, CharClassMatcher, Delegate, Insn, Prog, Seek};
+use crate::vm::{CaptureGroupRange, CaseiLiteral, CharClassMatcher, Delegate, Insn, Prog, Seek};
 use crate::LookAround::*;
 use crate::{
     Absent, BacktrackingControlVerb, BytesMode, CompileError, Error, Expr, LookAround, Result,
@@ -826,15 +826,33 @@ impl<'a> Compiler<'a> {
         if infos.is_empty() {
             return Ok(());
         }
-        // TODO: might want to do something similar for case insensitive literals
-        // (have is_literal return an additional bool for casei)
-        if infos.iter().all(|e| e.is_literal()) {
-            let mut val = String::new();
-            for info in infos {
-                info.push_literal(&mut val);
+        // A batch that is entirely literal compiles to a native literal
+        // instruction instead of a delegated engine. Case-sensitive literals
+        // become a plain byte-compare `Lit`; batches containing
+        // case-insensitive characters become a `LitCasei` (Unicode mode only —
+        // see `try_casei_literal`). This keeps each literal branch of an
+        // alternation off a per-branch delegated engine, so build cost does not
+        // scale with the number of branches.
+        if let Some(any_casei) = infos
+            .iter()
+            .try_fold(false, |any, e| e.literal_casei().map(|c| any || c))
+        {
+            if !any_casei {
+                let mut val = String::new();
+                for info in infos {
+                    info.push_literal(&mut val);
+                }
+                self.b.add(Insn::Lit(val));
+                return Ok(());
             }
-            self.b.add(Insn::Lit(val));
-            return Ok(());
+            let mut chars = Vec::new();
+            for info in infos {
+                info.push_literal_chars(&mut chars);
+            }
+            if let Some(lit) = self.try_casei_literal(&chars) {
+                self.b.add(Insn::LitCasei(lit));
+                return Ok(());
+            }
         }
 
         let mut delegate_builder = DelegateBuilder::new(&self.options);
@@ -850,20 +868,40 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_delegate(&mut self, info: &Info) -> Result<()> {
-        if info.is_literal() {
-            let mut val = String::new();
-            info.push_literal(&mut val);
-            self.b.add(Insn::Lit(val));
-        } else {
-            let mut builder = DelegateBuilder::new(&self.options);
-            builder.push(info);
-            // Skip emitting a delegate for an empty regex (e.g. DefineGroup),
-            // as it would just match the empty string and is a no-op.
-            if !builder.is_empty() {
-                self.b.add(builder.build(&self.options)?);
-            }
+        self.compile_delegates(core::slice::from_ref(info))
+    }
+
+    /// Builds a [`CaseiLiteral`] from `(char, casei)` pairs: each
+    /// case-insensitive character contributes its Unicode simple case-fold
+    /// class (what a delegated `(?i)` literal matches), each case-sensitive
+    /// one a singleton. `None` when the fold semantics wouldn't match a
+    /// delegated engine's — non-Unicode syntax folds ASCII-only, and non-UTF-8
+    /// haystacks can't be decoded per codepoint — so the caller falls back to
+    /// a delegate.
+    fn try_casei_literal(&self, chars: &[(char, bool)]) -> Option<CaseiLiteral> {
+        use regex_syntax::hir::{ClassUnicode, ClassUnicodeRange};
+
+        if !self.options.unicode || !matches!(self.options.bytes_mode, BytesMode::Unicode) {
+            return None;
         }
-        Ok(())
+        let mut out = Vec::with_capacity(chars.len());
+        for &(c, casei) in chars {
+            let ranges: Box<[(char, char)]> = if casei {
+                let mut class = ClassUnicode::new([ClassUnicodeRange::new(c, c)]);
+                // Errs when regex-syntax was built without its case-folding
+                // tables; the delegate fallback handles it the old way.
+                class.try_case_fold_simple().ok()?;
+                class
+                    .ranges()
+                    .iter()
+                    .map(|r| (r.start(), r.end()))
+                    .collect()
+            } else {
+                Box::new([(c, c)])
+            };
+            out.push(ranges);
+        }
+        Some(CaseiLiteral::new(out.into()))
     }
 
     fn compile_general_newline(&mut self, unicode: bool) -> Result<()> {
@@ -1393,6 +1431,39 @@ mod tests {
                 other.err()
             ),
         }
+    }
+
+    #[test]
+    fn casei_literal_compiles_to_native_insn() {
+        // A case-insensitive literal inside a hard pattern becomes a single
+        // native LitCasei instruction, not a delegated engine.
+        let prog = compile_prog_forced_hard("(?i)abc");
+        assert_eq!(prog.len(), 2, "prog: {:?}", prog);
+        assert_matches!(prog[0], LitCasei(_));
+        assert_matches!(prog[1], End);
+    }
+
+    #[test]
+    fn casei_alternation_branches_compile_to_native_insns() {
+        // A hard element in one branch forces the alternation to compile
+        // branch by branch on the VM (a fully-easy alternation would be
+        // delegated whole). The literal branches must become native LitCasei
+        // instructions instead of one delegated engine each.
+        let prog = compile_prog_forced_hard("(?i)(abort|absent|z(?<=q)z)");
+        let count = prog
+            .iter()
+            .filter(|insn| matches!(insn, LitCasei(_)))
+            .count();
+        assert!(
+            count >= 2,
+            "literal branches should compile to LitCasei: {:?}",
+            prog
+        );
+        assert!(
+            prog.iter().all(|insn| !matches!(insn, Insn::Delegate(_))),
+            "no branch should need a forward delegate: {:?}",
+            prog
+        );
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -239,7 +239,7 @@ impl CaseiLiteral {
     fn match_len<S: HaystackInput + ?Sized>(&self, s: &S, ix: usize) -> Option<usize> {
         let bytes = s.as_bytes();
         let mut pos = ix;
-        for ranges in &self.chars {
+        for ranges in self.chars.iter() {
             if pos >= bytes.len() {
                 return None;
             }
@@ -254,7 +254,7 @@ impl CaseiLiteral {
                 .ok()?
                 .chars()
                 .next()?;
-            if !range_contains(ranges, c) {
+            if !range_contains(ranges.as_ref(), c) {
                 return None;
             }
             pos = end;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -204,6 +204,65 @@ impl CharClassMatcher {
     }
 }
 
+/// A case-insensitive literal, matched natively by the VM instead of being
+/// delegated to a `meta::Regex` engine.
+///
+/// A case-insensitive alternation branch such as `(?i)abort` is a run of
+/// literal characters; delegating each branch to its own engine makes build
+/// cost scale with the number of branches. Like [`CharClassMatcher`],
+/// membership can be tested directly: one sorted range set per original
+/// character, holding its Unicode simple case-fold class (a singleton for
+/// case-sensitive characters). The fold classes come from `regex-syntax`, so
+/// the matched set is identical to what the delegated `(?i)` engine would
+/// accept — including width-changing variants such as `k` ↔ U+212A KELVIN
+/// SIGN, which is why matching advances codepoint by codepoint instead of
+/// assuming the literal's own byte length.
+///
+/// Only built in Unicode bytes mode (the haystack is valid UTF-8).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CaseiLiteral {
+    chars: Box<[FoldRanges]>,
+}
+
+/// The characters matching one literal character, as sorted inclusive ranges
+/// (its simple case-fold class, or a singleton when case-sensitive).
+pub(crate) type FoldRanges = Box<[(char, char)]>;
+
+impl CaseiLiteral {
+    pub(crate) fn new(chars: Box<[FoldRanges]>) -> Self {
+        CaseiLiteral { chars }
+    }
+
+    /// If the literal matches at `ix`, returns the matched byte length (which
+    /// can differ from the literal's own length under folding). `None` on no
+    /// match or end of input.
+    fn match_len<S: HaystackInput + ?Sized>(&self, s: &S, ix: usize) -> Option<usize> {
+        let bytes = s.as_bytes();
+        let mut pos = ix;
+        for ranges in &self.chars {
+            if pos >= bytes.len() {
+                return None;
+            }
+            let len = codepoint_len(bytes[pos]);
+            let end = pos + len;
+            if end > bytes.len() {
+                return None;
+            }
+            // The haystack is valid UTF-8 in Unicode mode, so this decodes the
+            // codepoint; the `?` is a safety net for an unexpected boundary.
+            let c = core::str::from_utf8(&bytes[pos..end])
+                .ok()?
+                .chars()
+                .next()?;
+            if !range_contains(ranges, c) {
+                return None;
+            }
+            pos = end;
+        }
+        Some(pos - ix)
+    }
+}
+
 /// Binary-searches `ranges` (sorted, non-overlapping, inclusive) for `needle`.
 #[inline]
 fn range_contains<T: Ord + Copy>(ranges: &[(T, T)], needle: T) -> bool {
@@ -329,6 +388,9 @@ pub enum Insn {
     Assertion(Assertion),
     /// Match the literal string at the current index
     Lit(String), // should be cow?
+    /// Match a case-insensitive literal at the current index, without
+    /// delegating to a regex-automata engine.
+    LitCasei(CaseiLiteral),
     /// Match a single character class (e.g. `\d`, `[a-z]`) at the current index,
     /// without delegating to a regex-automata engine.
     CharClass(CharClassMatcher),
@@ -999,6 +1061,10 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                     }
                     ix = ix_end
                 }
+                Insn::LitCasei(ref lit) => match lit.match_len(haystack, ix) {
+                    Some(len) => ix += len,
+                    None => break 'fail,
+                },
                 Insn::CharClass(ref matcher) => match matcher.match_len(haystack, ix) {
                     Some(len) => ix += len,
                     None => break 'fail,

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1060,3 +1060,42 @@ fn ambiguous_concat_repeat_optimization_not_more_permissive() {
     common::assert_no_match(r"^\s+\w?\s*$", "");
     common::assert_no_match(r"^\s+\w?\s*$", "a");
 }
+
+#[test]
+fn casei_literal_in_hard_pattern() {
+    // Lookbehind forces these onto the VM, where casei literals are matched
+    // by the native LitCasei instruction. Semantics must equal a delegated
+    // (?i) literal: Unicode simple case folding.
+    common::assert_is_match(r"(?<=x)(?i)kelvin", "xKELVIN");
+    common::assert_is_match(r"(?<=x)(?i)KELVIN", "xkelvin");
+    common::assert_no_match(r"(?<=x)(?i)kelvin", "xKELVIM");
+
+    // Mixed casei and case-sensitive chars in one literal batch
+    common::assert_is_match(r"(?<=x)(?i:ab)cd", "xABcd");
+    common::assert_no_match(r"(?<=x)(?i:ab)cd", "xABCD");
+
+    // Unicode folding applies in str mode only (the shared both-modes helpers
+    // also run in ASCII bytes mode, where (?i) folds ASCII only).
+    let is_match =
+        |re: &str, text: &str| fancy_regex::Regex::new(re).unwrap().is_match(text).unwrap();
+
+    // Cyrillic folding
+    assert!(is_match(r"(?<=x)(?i)привет", "xПРИВЕТ"));
+    assert!(is_match(r"(?<=x)(?i)ПРИВЕТ", "xпривет"));
+
+    // Width-changing fold variants: U+212A KELVIN SIGN (3 bytes) matches
+    // literal `k` (1 byte), and U+017F LATIN SMALL LETTER LONG S matches `s`.
+    assert!(is_match(r"(?<=x)(?i)k", "x\u{212A}"));
+    assert!(is_match(r"(?<=x)(?i)s", "x\u{17F}"));
+}
+
+#[test]
+fn casei_keyword_alternation_in_hard_pattern() {
+    let haystack = "if ABSENT then";
+    let m = fancy_regex::Regex::new(r"\b(?i)(abort|absent|zzz)\b")
+        .unwrap()
+        .find(haystack)
+        .unwrap()
+        .unwrap();
+    assert_eq!(&haystack[m.start()..m.end()], "ABSENT");
+}


### PR DESCRIPTION
Avoids building regex-automata meta engine for each case insensitive literal - keeps the build cost down when handling many hard alternations

https://github.com/fancy-regex/fancy-regex/issues/162#issuecomment-5180016958
