### PR TITLE
Improvements to graph output and playground analysis for casei

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ with the exception that 0.x versions can break between minor versions.
 ## [Unreleased]
 ### Added
 ### Changed
-- Add VM instruction for case insensitive literals when in Unicode mode, to keep the build cost bounded (#268)
+- Add VM instruction for case insensitive literals when in Unicode mode, to keep the build cost bounded (#268) and ensured the toy example graph output remains readable instead of being super verbose (#269)
 ### Fixed
+- The playground didn't show when a literal or backreference was being matched case insensitively in the analysis tree view (#269)
 
 ## [0.19.0] - 2026-07-28
 ### Added

--- a/examples/toy.rs
+++ b/examples/toy.rs
@@ -270,6 +270,40 @@ digraph G {
     }
 
     #[test]
+    fn test_meta_char_class_graph() {
+        assert_graph(
+            r"(?i)hello(?<!\w)",
+            "\
+digraph G {
+  0 [label=\"0: SplitUnanchored(3, 1)\"];
+  0 -> 3;
+  0 -> 1;
+  1 [label=\"1: Any\"];
+  1 -> 2;
+  2 [label=\"2: Jmp(0)\"];
+  2 -> 0;
+  3 [label=\"3: Save(0)\"];
+  3 -> 4;
+  4 [label=\"4: LitCasei(CaseiLiteral { chars: [[('H', 'H'), ('h', 'h')], [('E', 'E'), ('e', 'e')], [('L', 'L'), ('l', 'l')], [('L', 'L'), ('l', 'l')], [('O', 'O'), ('o', 'o')]] })\"];
+  4 -> 5;
+  5 [label=\"5: Split(6, 9)\"];
+  5 -> 6;
+  5 -> 9;
+  6 [label=\"6: GoBack(1)\"];
+  6 -> 7;
+  7 [label=\"7: CharClass(Codepoint \\\\w)\"];
+  7 -> 8;
+  8 [label=\"8: FailNegativeLookAround\"];
+  8 -> 9;
+  9 [label=\"9: Save(1)\"];
+  9 -> 10;
+ 10 [label=\"10: End\"];
+}
+",
+        );
+    }
+
+    #[test]
     fn test_simple_analysis() {
         assert_analysis_succeeds("a+bc?");
     }

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -242,6 +242,8 @@ pub struct AnalysisTreeNode {
     pub children: Vec<AnalysisTreeNode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<GroupInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub casei: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -287,6 +289,13 @@ fn info_to_tree_node<'a>(
     info: &fancy_regex::internal::Info<'a>,
     group_names: &std::collections::HashMap<usize, String>,
 ) -> AnalysisTreeNode {
+    let casei = match info.expr {
+        Expr::Literal { casei, .. } => Some(casei),
+        Expr::Backref { casei, .. } => Some(casei),
+        Expr::BackrefWithRelativeRecursionLevel { casei, .. } => Some(casei),
+        _ => None,
+    };
+
     let (kind, summary, group_info) = match info.expr {
         Expr::Empty => ("Empty".to_string(), None, None),
         Expr::Any { newline, crlf } => {
@@ -333,7 +342,15 @@ fn info_to_tree_node<'a>(
         Expr::GeneralNewline { .. } => {
             ("GeneralNewline".to_string(), Some("\\R".to_string()), None)
         }
-        Expr::Literal { val, .. } => ("Literal".to_string(), Some(format!("{:?}", val)), None),
+        Expr::Literal { val, .. } => {
+            let mut summary = format!("{:?}", val);
+            if let Some(ci) = casei {
+                if *ci {
+                    summary.push_str(" (case-insensitive)");
+                }
+            }
+            ("Literal".to_string(), Some(summary), None)
+        }
         Expr::Concat(v) => ("Concat".to_string(), Some(format!("({})", v.len())), None),
         Expr::Alt(v) => ("Alt".to_string(), Some(format!("({})", v.len())), None),
         Expr::Group(_) => {
@@ -389,25 +406,34 @@ fn info_to_tree_node<'a>(
                 None,
             )
         }
-        Expr::Backref { group, .. } => {
-            let summary = if let Some(name) = group_names.get(group) {
-                Some(format!("({})", name))
+        Expr::Backref {
+            group,
+            casei: br_casei,
+        } => {
+            let mut summary = if let Some(name) = group_names.get(group) {
+                format!("({})", name)
             } else {
-                Some(format!("{}", group))
+                format!("{}", group)
             };
-            ("Backref".to_string(), summary, None)
+            if *br_casei {
+                summary.push_str(" (case-insensitive)");
+            }
+            ("Backref".to_string(), Some(summary), None)
         }
         Expr::BackrefWithRelativeRecursionLevel {
             group,
             relative_level,
-            ..
+            casei: br_casei,
         } => {
-            let summary = if let Some(name) = group_names.get(group) {
-                Some(format!("({}) level={}", name, relative_level))
+            let mut summary = if let Some(name) = group_names.get(group) {
+                format!("({}) level={}", name, relative_level)
             } else {
-                Some(format!("{} level={}", group, relative_level))
+                format!("{} level={}", group, relative_level)
             };
-            ("Backref".to_string(), summary, None)
+            if *br_casei {
+                summary.push_str(" (case-insensitive)");
+            }
+            ("Backref".to_string(), Some(summary), None)
         }
         Expr::AtomicGroup(_) => ("AtomicGroup".to_string(), None, None),
         Expr::KeepOut => ("KeepOut".to_string(), None, None),
@@ -466,6 +492,7 @@ fn info_to_tree_node<'a>(
         const_size: info.const_size,
         children,
         group: group_info,
+        casei: casei.copied(),
     }
 }
 
@@ -516,7 +543,12 @@ mod tests {
     /// Parse a pattern, analyze it, and convert to an AnalysisTreeNode.
     /// Builds a group names lookup from the parse tree's named_groups (for patterns with named captures).
     fn parse_and_analyze(pattern: &str) -> AnalysisTreeNode {
-        let tree = fancy_regex::Expr::parse_tree(pattern).unwrap();
+        parse_and_analyze_with_flags(pattern, 0)
+    }
+
+    /// Parse a pattern with flags, analyze it, and convert to an AnalysisTreeNode.
+    fn parse_and_analyze_with_flags(pattern: &str, flags: u32) -> AnalysisTreeNode {
+        let tree = fancy_regex::Expr::parse_tree_with_flags(pattern, flags).unwrap();
         let group_names = build_group_names_lookup(&tree.named_groups);
         let info =
             fancy_regex::internal::analyze(&tree, fancy_regex::internal::AnalyzeContext::default())
@@ -577,6 +609,84 @@ mod tests {
         assert_eq!(node.children[0].kind, "Literal");
         assert_eq!(node.children[0].summary.as_deref(), Some("\"t\""));
         assert_eq!(node.children[4].summary.as_deref(), Some("\"\\\\\""));
+    }
+
+    #[test]
+    fn test_info_to_tree_node_literal_case_insensitive() {
+        use fancy_regex::internal::FLAG_CASEI;
+
+        // Single literal with case-insensitive flag
+        let node = parse_and_analyze_with_flags("a", FLAG_CASEI);
+        assert_eq!(node.kind, "Literal");
+        assert_eq!(node.summary.as_deref(), Some("\"a\" (case-insensitive)"));
+        assert_eq!(node.casei, Some(true));
+
+        // Single literal without flag
+        let node = parse_and_analyze_with_flags("a", 0);
+        assert_eq!(node.kind, "Literal");
+        assert_eq!(node.summary.as_deref(), Some("\"a\""));
+        assert_eq!(node.casei, Some(false));
+
+        // Mixed case-insensitive and case-sensitive in concat
+        let node = parse_and_analyze_with_flags("abc", FLAG_CASEI);
+        assert_eq!(node.kind, "Concat");
+        assert_eq!(node.children.len(), 3);
+        for child in &node.children {
+            assert_eq!(child.kind, "Literal");
+            assert_eq!(child.casei, Some(true));
+            assert!(child
+                .summary
+                .as_deref()
+                .unwrap()
+                .contains("(case-insensitive)"));
+        }
+
+        // Non-literal node should have casei: null
+        let node = parse_and_analyze_with_flags(r"\w", FLAG_CASEI);
+        assert_eq!(node.kind, "Delegate");
+        assert_eq!(node.casei, None);
+    }
+
+    #[test]
+    fn test_info_to_tree_node_backref_case_insensitive() {
+        use fancy_regex::internal::FLAG_CASEI;
+
+        let node = parse_and_analyze_with_flags(r"(\w+)\1", FLAG_CASEI);
+        assert_eq!(node.kind, "Concat");
+        let backref = node
+            .children
+            .iter()
+            .find(|n| n.kind == "Backref")
+            .expect("Should find Backref node");
+        assert_eq!(backref.casei, Some(true));
+        assert!(
+            backref
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .contains("(case-insensitive)"),
+            "Backref summary should indicate case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_info_to_tree_node_backref_case_sensitive() {
+        let node = parse_and_analyze(r"(\w+)\1");
+        assert_eq!(node.kind, "Concat");
+        let backref = node
+            .children
+            .iter()
+            .find(|n| n.kind == "Backref")
+            .expect("Should find Backref node");
+        assert_eq!(backref.casei, Some(false));
+        assert!(
+            !backref
+                .summary
+                .as_deref()
+                .unwrap_or("")
+                .contains("(case-insensitive)"),
+            "Backref summary should NOT indicate case-insensitive when case-sensitive"
+        );
     }
 
     #[test]

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -87,13 +87,12 @@ impl<'a> Info<'a> {
 
     /// `None` if this is not a literal; `Some(casei)` if it is, where `casei`
     /// says whether any character is case-insensitive.
-    pub(crate) fn literal_casei(&self) -> Option<bool> {
+    pub(crate) fn is_literal_get_casei(&self) -> Option<bool> {
         match *self.expr {
             Expr::Literal { casei, .. } => Some(casei),
-            Expr::Concat(_) => self
-                .children
-                .iter()
-                .try_fold(false, |any, child| child.literal_casei().map(|c| any || c)),
+            Expr::Concat(_) => self.children.iter().try_fold(false, |any, child| {
+                child.is_literal_get_casei().map(|c| any || c)
+            }),
             _ => None,
         }
     }
@@ -1368,21 +1367,21 @@ mod tests {
     fn is_literal() {
         let tree = Expr::parse_tree("abc").unwrap();
         let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        assert_eq!(info.literal_casei(), Some(false));
+        assert_eq!(info.is_literal_get_casei(), Some(false));
     }
 
     #[test]
     fn is_literal_casei() {
         let tree = Expr::parse_tree("(?i)abc").unwrap();
         let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        assert_eq!(info.literal_casei(), Some(true));
+        assert_eq!(info.is_literal_get_casei(), Some(true));
     }
 
     #[test]
     fn is_literal_with_repeat() {
         let tree = Expr::parse_tree("abc*").unwrap();
         let info = analyze(&tree, AnalyzeContext::default()).unwrap();
-        assert_eq!(info.literal_casei(), None);
+        assert_eq!(info.is_literal_get_casei(), None);
     }
 
     #[test]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1091,6 +1091,15 @@ pub(crate) fn options_to_rabuilder(options: &CompileOptions, usage: DelegateUsag
     builder
 }
 
+/// Strip the `(?i:` prefix and `)` suffix that `Expr::to_str` wraps around
+/// case-insensitive delegate expressions. This keeps the stored `CharClassMatcher`
+/// name readable (e.g. `\w` instead of `(?i:\w)`).
+fn strip_delegate_flags(s: &str) -> &str {
+    s.strip_prefix("(?i:")
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or(s)
+}
+
 /// Try to compile a delegated fragment to a native [`CharClassMatcher`] instead
 /// of a regex-automata engine.
 ///
@@ -1116,12 +1125,16 @@ fn try_char_class_matcher(re: &str, options: &CompileOptions) -> Option<CharClas
         .parse(re)
         .ok()?;
 
-    char_class_matcher_from_hir(&hir, options)
+    char_class_matcher_from_hir(&hir, options, Some(strip_delegate_flags(re).to_string()))
 }
 
 /// Build a [`CharClassMatcher`] from an `Hir` that is a single character class,
 /// or `None` if it isn't one (or can't be matched natively in this bytes mode).
-fn char_class_matcher_from_hir(hir: &Hir, options: &CompileOptions) -> Option<CharClassMatcher> {
+fn char_class_matcher_from_hir(
+    hir: &Hir,
+    options: &CompileOptions,
+    name: Option<String>,
+) -> Option<CharClassMatcher> {
     use regex_syntax::hir::{Class, HirKind};
 
     match hir.kind() {
@@ -1134,11 +1147,11 @@ fn char_class_matcher_from_hir(hir: &Hir, options: &CompileOptions) -> Option<Ch
                 return None;
             }
             let ranges = cu.ranges().iter().map(|r| (r.start(), r.end())).collect();
-            Some(CharClassMatcher::Codepoint(ranges))
+            Some(CharClassMatcher::Codepoint { ranges, name })
         }
         HirKind::Class(Class::Bytes(cb)) => {
             let ranges = cb.ranges().iter().map(|r| (r.start(), r.end())).collect();
-            Some(CharClassMatcher::Byte(ranges))
+            Some(CharClassMatcher::Byte { ranges, name })
         }
         _ => None,
     }
@@ -1374,7 +1387,11 @@ impl DelegateBuilder {
         if self.capture_groups.map_or(false, |r| r.start() == r.end()) {
             let matcher = match &self.hirs {
                 // A single fragment whose Hir is a class; no parse needed.
-                Some(hirs) if hirs.len() == 1 => char_class_matcher_from_hir(&hirs[0], options),
+                Some(hirs) if hirs.len() == 1 => char_class_matcher_from_hir(
+                    &hirs[0],
+                    options,
+                    Some(strip_delegate_flags(&self.re).to_string()),
+                ),
                 // Multiple fragments can't be a single class.
                 Some(_) => None,
                 // Translation bailed; fall back to parsing the string.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -835,7 +835,7 @@ impl<'a> Compiler<'a> {
         // scale with the number of branches.
         if let Some(any_casei) = infos
             .iter()
-            .try_fold(false, |any, e| e.literal_casei().map(|c| any || c))
+            .try_fold(false, |any, e| e.is_literal_get_casei().map(|c| any || c))
         {
             if !any_casei {
                 let mut val = String::new();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -75,6 +75,7 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt;
 use regex_automata::meta::Regex;
 use regex_automata::util::look::LookMatcher;
 use regex_automata::util::pool::Pool;
@@ -157,14 +158,43 @@ impl CaptureGroupRange {
 /// The ranges are taken verbatim from the `regex-syntax` `Hir` for the class
 /// (sorted, non-overlapping, and already case-folded / Unicode-expanded), so the
 /// matched set is identical to what the delegated engine would accept.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum CharClassMatcher {
     /// Match one Unicode scalar value against inclusive `char` ranges. Used in
     /// Unicode bytes mode, where the haystack is valid UTF-8.
-    Codepoint(Box<[(char, char)]>),
+    Codepoint {
+        ranges: Box<[(char, char)]>,
+        name: Option<String>,
+    },
     /// Match one byte against inclusive byte ranges. Used in ASCII bytes mode
     /// (and for ASCII-only `(?-u:...)` classes).
-    Byte(Box<[(u8, u8)]>),
+    Byte {
+        ranges: Box<[(u8, u8)]>,
+        name: Option<String>,
+    },
+}
+
+impl fmt::Debug for CharClassMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref name) = match self {
+            CharClassMatcher::Codepoint { name, .. } => name,
+            CharClassMatcher::Byte { name, .. } => name,
+        } {
+            match self {
+                CharClassMatcher::Codepoint { .. } => write!(f, "Codepoint {}", name),
+                CharClassMatcher::Byte { .. } => write!(f, "Byte {}", name),
+            }
+        } else {
+            match self {
+                CharClassMatcher::Codepoint { ranges, .. } => {
+                    f.debug_tuple("Codepoint").field(ranges).finish()
+                }
+                CharClassMatcher::Byte { ranges, .. } => {
+                    f.debug_tuple("Byte").field(ranges).finish()
+                }
+            }
+        }
+    }
 }
 
 impl CharClassMatcher {
@@ -178,14 +208,14 @@ impl CharClassMatcher {
             return None;
         }
         match self {
-            CharClassMatcher::Byte(ranges) => {
+            CharClassMatcher::Byte { ranges, .. } => {
                 if range_contains(ranges, bytes[ix]) {
                     Some(1)
                 } else {
                     None
                 }
             }
-            CharClassMatcher::Codepoint(ranges) => {
+            CharClassMatcher::Codepoint { ranges, .. } => {
                 let len = codepoint_len(bytes[ix]);
                 let end = ix + len;
                 if end > bytes.len() {


### PR DESCRIPTION
- improve readability of graph output in the toy example for char classes
- show in the playground's analysis tree when a node (backref or literal) is being matched case insensitively