### PR TITLE
small tweak to emit escaped literals like \n in seek patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2433,10 +2433,18 @@ fn is_special(c: char) -> bool {
 
 pub(crate) fn push_quoted(buf: &mut String, s: &str) {
     for c in s.chars() {
-        if is_special(c) {
-            buf.push('\\');
+        match c {
+            '\\' => buf.push_str("\\\\"),
+            '\n' => buf.push_str("\\n"),
+            '\t' => buf.push_str("\\t"),
+            '\r' => buf.push_str("\\r"),
+            _ => {
+                if is_special(c) {
+                    buf.push('\\');
+                }
+                buf.push(c);
+            }
         }
-        buf.push(c);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2432,6 +2432,32 @@ fn is_special(c: char) -> bool {
 }
 
 pub(crate) fn push_quoted(buf: &mut String, s: &str) {
+    if !s.bytes().any(|b| {
+        b == b'\\'
+            || b == b'\n'
+            || b == b'\t'
+            || b == b'\r'
+            || matches!(
+                b,
+                b'.' | b'+'
+                    | b'*'
+                    | b'?'
+                    | b'('
+                    | b')'
+                    | b'|'
+                    | b'['
+                    | b']'
+                    | b'{'
+                    | b'}'
+                    | b'^'
+                    | b'$'
+                    | b'#'
+            )
+    }) {
+        buf.push_str(s);
+        return;
+    }
+
     for c in s.chars() {
         match c {
             '\\' => buf.push_str("\\\\"),
@@ -2936,6 +2962,15 @@ mod tests {
     }
 
     #[test]
+    fn to_str_literal_special_chars() {
+        assert_eq!(to_str(make_literal("\n")), "\\n");
+        assert_eq!(to_str(make_literal("\t")), "\\t");
+        assert_eq!(to_str(make_literal("\r")), "\\r");
+        assert_eq!(to_str(make_literal("\\")), "\\\\");
+        assert_eq!(to_str(make_literal(".")), "\\.");
+    }
+
+    #[test]
     fn as_str_debug() {
         let s = r"(a+)b\1";
         let regex = Regex::new(s).unwrap();
@@ -2996,6 +3031,23 @@ mod tests {
 
         // Check that multibyte characters are handled correctly.
         assert_eq!(crate::escape("fø*ø").into_owned(), "fø\\*ø");
+    }
+
+    #[test]
+    fn push_quoted_special_chars() {
+        fn pq(s: &str) -> String {
+            let mut buf = String::new();
+            crate::push_quoted(&mut buf, s);
+            buf
+        }
+        assert_eq!(pq("\n"), "\\n");
+        assert_eq!(pq("\t"), "\\t");
+        assert_eq!(pq("\r"), "\\r");
+        assert_eq!(pq("\\"), "\\\\");
+        assert_eq!(pq("."), "\\.");
+        assert_eq!(pq("hello"), "hello");
+        assert_eq!(pq("a.b"), "a\\.b");
+        assert_eq!(pq("fø*ø"), "fø\\*ø");
     }
 
     #[test]

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -667,7 +667,7 @@ mod tests {
     fn seek_pattern_subroutine_call_inlined_and_anchors_are_preserved() {
         assert_eq!(
             get_seek_pattern(r"((?m:^)[A-Z][a-z0-9]*)\n\g<1>"),
-            "(?:(?m:^)[A-Z][a-z0-9]*)\n(?:(?m:^)[A-Z][a-z0-9]*)"
+            "(?:(?m:^)[A-Z][a-z0-9]*)\\n(?:(?m:^)[A-Z][a-z0-9]*)"
         );
     }
 


### PR DESCRIPTION
Optimize `push_quoted` with byte-scan fast path and add tests for escaped literal rendering

`push_quoted` now emits `\n`, `\t`, `\r` escape sequences instead of raw control characters. That change is what makes `to_str` output stable and round-trippable — previously a parser-created `Literal { val: "\n" }` would serialize as a raw newline byte, which is invisible in source and inconsistent with how `\n` appears after parsing. Now both serialize to the same `\n` representation.

This commit adds a byte-scan fast path inside `push_quoted`. Since every character that needs escaping is a single-byte ASCII character, we can check for them using `s.bytes()` before falling back to the char-by-char loop. When the input contains no escapable characters at all, we take a single `push_str` and skip the loop entirely. This is the common case for literal subexpressions that are delegated to regex-automata, so it avoids the overhead of iterating Unicode codepoints and building a new string one character at a time.

Two unit tests are added:
- `to_str_literal_special_chars` verifies the public `to_str` output for `\n`, `\t`, `\r`, `\\`, and `.` literals — catching any regression in the escape serialization.
- `push_quoted_special_chars` verifies the helper directly, including multibyte UTF-8 input (`fø*ø`) to confirm the byte scan doesn't mis-handle non-ASCII bytes.

N.B. I used an LLM for part of this work