### PR TITLE
Fix capture_names() panic on zero-repeated named group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with the exception that 0.x versions can break between minor versions.
 ### Added
 ### Changed
 ### Fixed
+- Fix a panic in `capture_names()` for a pattern with a zero-repeated named group such as `(?<n>a){0}` (#275)
 
 ## [0.19.1] - 2026-09-06
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1675,7 +1675,9 @@ impl Regex {
         let mut names = Vec::new();
         names.resize(self.captures_len(), None);
         for (name, &i) in self.named_groups.iter() {
-            names[i] = Some(name.as_str());
+            if let Some(slot) = names.get_mut(i) {
+                *slot = Some(name.as_str());
+            }
         }
         CaptureNames(names.into_iter())
     }

--- a/tests/captures.rs
+++ b/tests/captures.rs
@@ -16,6 +16,17 @@ fn capture_names() {
 }
 
 #[test]
+fn capture_names_with_zero_repeated_named_group() {
+    let regex = common::regex("(?<n>a){0}");
+    let names: Vec<_> = regex.capture_names().collect();
+    assert_eq!(names, vec![None]);
+
+    let regex = common::regex("(?<n>a){0,0}");
+    let names: Vec<_> = regex.capture_names().collect();
+    assert_eq!(names, vec![None]);
+}
+
+#[test]
 fn captures_fancy() {
     let captures = common::assert_captures(r"\s*(\w+)(?=\.)", "foo bar.").unwrap();
     assert_eq!(captures.len(), 2);


### PR DESCRIPTION
## What
Closes #275.

`capture_names()` panicked (`index out of bounds`) for any pattern with a named group inside a zero quantifier, e.g. `(?<n>a){0}`, `(?<n>a){0,0}`, or `(?<n>a){0}(?<m>b)`.

## Fix
A group inside `{0}` is dropped at compile time, so `captures_len()` shrinks but `named_groups` still holds the original (now out-of-range) index for that name. `capture_names()` indexed the `names` vector directly with that index and panicked. Guard the write with `get_mut`, so a stale index is skipped — matching how `Captures::name()` already tolerates it (it uses `.get()` and returns `None`).

## Tests
Added `capture_names_with_zero_repeated_named_group` in `tests/captures.rs` covering `(?<n>a){0}` and `(?<n>a){0,0}`.

## Validation
```
cargo test           # 291 + 46 + 51 + 80 + 57 + 39 + ... all green
cargo test --test captures capture_names   # 3 passed
cargo fmt --check    # clean
```
Verified genuine RED→GREEN: with the fix reverted the new test panics with `index out of bounds: the len is 1 but the index is 1`; with the fix it passes and the full suite stays green.

Happy to adjust.
