### PR TITLE
Add leftmost longest match mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: cargo check --no-default-features
       - run: cargo check --no-default-features --features "unicode,perf,variable-lookbehinds"
       - run: cargo check --no-default-features --features "std"
+      - run: cargo check --no-default-features --features "unicode,perf,leftmost_longest"
       - run: cargo check --examples
       - run: cargo check --benches
 
@@ -69,6 +70,7 @@ jobs:
       - run: cargo test
       - run: cargo test --no-default-features
       - run: cargo test --no-default-features --features "unicode,perf,variable-lookbehinds"
+      - run: cargo test --no-default-features --features "unicode,perf,leftmost_longest"
 
   example:
     name: example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,9 @@ See the @CONTRIBUTING.md guide for details.
 - Full CI check:
   - `cargo check --no-default-features`
   - `cargo check --no-default-features --features "unicode,perf,variable-lookbehinds"`
+  - `cargo check --no-default-features --features "unicode,perf,variable-lookbehinds,leftmost_longest"`
   - `cargo test --examples`
+  - `cargo test --features leftmost_longest`
   - `cargo check --benches`
   - `cd playground && cargo test`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with the exception that 0.x versions can break between minor versions.
 
 ## [Unreleased]
 ### Added
+- Add a `leftmost_longest` feature (off by default) that adds a method to the `RegexBuilder`/`RegexOptionsBuilder` for building a VM which would operate in leftmost-longest match mode instead of the regular leftmost-first mode. Useful for POSIX compliance. (#281)
 ### Changed
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ When adding support for new syntax (i.e. for better compatibility with
 oniguruma syntax), remember to update the "Syntax" section of the
 documentation - `docs/syntax.md`.
 
+When adding new feature flags, remember to update `docs/features.md` so
+that users can discover and understand the feature more easily.
+
 ## Manual testing
 
 Sometimes it's useful to manually check how regexes are matched, e.g.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ unicode = ["regex-automata/unicode", "regex-syntax/unicode"]
 std = ["regex-automata/std", "regex-syntax/std", "bit-set/std"]
 # Enable variable-length lookbehinds using reverse DFA search
 variable-lookbehinds = ["regex-automata/dfa-search"]
+# Enable builder support for leftmost-longest match semantics (as opposed to default leftmost-first).
+leftmost_longest = []
 # Let regex-automata eagerly build a fully compiled dense DFA for small
 # patterns (and delegated fragments). Trades noticeably slower compiles and
 # more memory for the fastest search engine; without it searches use the lazy

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,6 +5,7 @@ This crate supports several optional features that can be enabled or disabled:
 - **`std`** (enabled by default): Enables standard library support. Disable for `no_std` environments.
 - **`unicode`** (enabled by default): Enables Unicode support for character classes and word boundaries.
 - **`perf`** (enabled by default): Enables performance optimizations in the underlying regex engine.
+- **`perf-dfa-full`** (disabled by default): Let regex-automata eagerly build a fully compiled dense DFA for small patterns (and delegated fragments). Trades noticeably slower compiles and more memory for the fastest search engine; without it searches use the lazy DFA, which performs about the same on typical workloads. Mirrors the `regex` crate's `perf-dfa-full` opt-in.
 - **`variable-lookbehinds`** (enabled by default): Enables support for variable-length lookbehind
   assertions (e.g., `(?<=a+)`). Without this feature, only constant-length lookbehinds are supported.
   This feature uses reverse DFA matching from the `regex-automata` crate to efficiently handle

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,3 +9,4 @@ This crate supports several optional features that can be enabled or disabled:
   assertions (e.g., `(?<=a+)`). Without this feature, only constant-length lookbehinds are supported.
   This feature uses reverse DFA matching from the `regex-automata` crate to efficiently handle
   variable-length patterns that don't use backreferences or other fancy features.
+- **`leftmost_longest`** (disabled by default): Enables support for switching on leftmost-longest match semantics in the `RegexBuilder`/`RegexOptionsBuilder`, as opposed to the usual leftmost-first.

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 wasm-opt = true
 
 [dependencies]
-fancy-regex = { path = ".." }
+fancy-regex = { path = "..", features = ["leftmost_longest"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -51,6 +51,7 @@ pub struct RegexFlags {
     pub find_not_empty: bool,
     pub ignore_numbered_groups_when_named_groups_exist: bool,
     pub ignore_trailing_newline: bool,
+    pub leftmost_longest: bool,
 }
 
 impl Default for RegexFlags {
@@ -65,6 +66,7 @@ impl Default for RegexFlags {
             find_not_empty: false,
             ignore_numbered_groups_when_named_groups_exist: false,
             ignore_trailing_newline: false,
+            leftmost_longest: false,
         }
     }
 }
@@ -93,6 +95,7 @@ fn build_regex(pattern: &str, flags: &RegexFlags) -> Result<Regex, String> {
         flags.ignore_numbered_groups_when_named_groups_exist,
     );
     builder.disallow_empty_match_at_eof_after_newline(flags.ignore_trailing_newline);
+    builder.leftmost_longest(flags.leftmost_longest);
 
     builder
         .build()
@@ -210,6 +213,7 @@ pub fn analyze_regex(pattern: &str, flags: JsValue) -> Result<String, String> {
                     find_not_empty: flags.find_not_empty,
                     disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
                     allow_input_assertion_overrides: false,
+                    leftmost_longest: flags.leftmost_longest,
                 },
             ) {
                 Ok(info) => Ok(format!("{:#?}", info)),
@@ -516,6 +520,7 @@ pub fn analyze_regex_tree(pattern: &str, flags: JsValue) -> Result<JsValue, Stri
                     find_not_empty: flags.find_not_empty,
                     disallow_empty_match_at_eof_after_newline: flags.ignore_trailing_newline,
                     allow_input_assertion_overrides: false,
+                    leftmost_longest: flags.leftmost_longest,
                 },
             ) {
                 Ok(info) => {
@@ -1103,6 +1108,31 @@ mod tests {
         assert!(
             re.is_match("world\nhello\nfoo").unwrap(),
             "^ should match start of line with multi_line"
+        );
+    }
+
+    /// Leftmost-longest flag is wired through correctly.
+    #[test]
+    fn smoke_leftmost_longest_flag() {
+        let default_flags = RegexFlags::default();
+        let re = build_regex(r"a|ab", &default_flags).unwrap();
+        let caps = re.captures("ab").unwrap().unwrap();
+        assert_eq!(
+            caps.get(0).unwrap().as_str(),
+            "a",
+            "default leftmost-first should prefer first alternative"
+        );
+
+        let leftmost_longest_flags = RegexFlags {
+            leftmost_longest: true,
+            ..Default::default()
+        };
+        let re = build_regex(r"a|ab", &leftmost_longest_flags).unwrap();
+        let caps = re.captures("ab").unwrap().unwrap();
+        assert_eq!(
+            caps.get(0).unwrap().as_str(),
+            "ab",
+            "leftmost-longest should prefer longer match at same position"
         );
     }
 }

--- a/playground/web/app.js
+++ b/playground/web/app.js
@@ -41,6 +41,7 @@ class FancyRegexPlayground {
                 ignoreWhitespace: document.getElementById('flag-ignore-whitespace'),
                 onigurumaMode: document.getElementById('flag-oniguruma-mode'),
                 findNotEmpty: document.getElementById('flag-find-not-empty'),
+                leftmostLongest: document.getElementById('flag-leftmost-longest'),
                 ignoreNumberedGroups: document.getElementById('flag-ignore-numbered-groups'),
                 unicode: document.getElementById('flag-unicode'),
                 ignoreTrailingNewline: document.getElementById('flag-no-match-at-trailing-newline'),
@@ -87,6 +88,7 @@ class FancyRegexPlayground {
             unicode: this.elements.flags.unicode.checked,
             oniguruma_mode: this.elements.flags.onigurumaMode.checked,
             find_not_empty: this.elements.flags.findNotEmpty.checked,
+            leftmost_longest: this.elements.flags.leftmostLongest.checked,
             ignore_numbered_groups_when_named_groups_exist: this.elements.flags.ignoreNumberedGroups.checked,
             ignore_trailing_newline: this.elements.flags.ignoreTrailingNewline.checked,
         };
@@ -101,6 +103,7 @@ class FancyRegexPlayground {
             { param: 'u', key: 'unicode', element: this.elements.flags.unicode },
             { param: 'O', key: 'oniguruma_mode', element: this.elements.flags.onigurumaMode },
             { param: 'N', key: 'find_not_empty', element: this.elements.flags.findNotEmpty },
+            { param: 'L', key: 'leftmost_longest', element: this.elements.flags.leftmostLongest },
             { param: 'G', key: 'ignore_numbered_groups_when_named_groups_exist', element: this.elements.flags.ignoreNumberedGroups },
             { param: 'T', key: 'ignore_trailing_newline', element: this.elements.flags.ignoreTrailingNewline },
         ];

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -50,6 +50,10 @@
                             <input type="checkbox" id="flag-find-not-empty" />
                             <label for="flag-find-not-empty">Find not empty</label>
                         </div>
+                        <div class="flag-group">
+                            <input type="checkbox" id="flag-leftmost-longest" />
+                            <label for="flag-leftmost-longest">Leftmost longest</label>
+                        </div>
                         <div class="flag-group flag-group--wide">
                             <input type="checkbox" id="flag-ignore-numbered-groups" />
                             <label for="flag-ignore-numbered-groups">Ignore numbered groups when named groups exist</label>

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -153,6 +153,8 @@ struct Analyzer<'a> {
     /// When true, assertions with runtime input suppression overrides are promoted to hard
     /// so they run on the VM.
     allow_input_assertion_overrides: bool,
+    /// When true, leftmost-longest match semantics are enabled.
+    leftmost_longest: bool,
     /// Oniguruma's `^` rejects the empty match at the absolute end of the haystack after a trailing
     /// newline when it anchors the match itself. When used as a sub-assertion inside a lookaround,
     /// it behaves as a plain line start. So we need to track when we are analyzing inside a lookaround.
@@ -288,8 +290,20 @@ impl<'a> Analyzer<'a> {
                 children.push(child_info);
             }
             Expr::Repeat {
-                ref child, lo, hi, ..
+                ref child,
+                lo,
+                hi,
+                greedy,
+                ..
             } => {
+                if !greedy && self.leftmost_longest {
+                    return Err(Error::CompileError(Box::new(
+                        CompileError::FeatureNotYetSupported(
+                            "non-greedy quantifiers are not supported in leftmost-longest mode"
+                                .to_string(),
+                        ),
+                    )));
+                }
                 // If lo and hi are both 0, we're in a zero-repetition (unreachable)
                 let child_inside_zero_rep = if lo == 0 && hi == 0 {
                     true
@@ -571,6 +585,8 @@ impl<'a> Analyzer<'a> {
         // must be handled by the VM so it can backtrack past it to find a non-empty match.
         if self.find_not_empty && min_size == 0 && !const_size {
             hard = true;
+        } else if self.leftmost_longest && !const_size {
+            hard = true;
         }
 
         Ok(Info {
@@ -839,6 +855,8 @@ pub struct AnalyzeContext {
     /// When true, treat assertions that support runtime input suppression overrides (`\A`, `\z`)
     /// as hard so that they execute on the VM.
     pub allow_input_assertion_overrides: bool,
+    /// When true, leftmost-longest match semantics are enabled.
+    pub leftmost_longest: bool,
 }
 
 /// Analyze the parsed expression to determine whether it requires fancy features.
@@ -847,6 +865,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
     let find_not_empty = ctx.find_not_empty;
     let disallow_empty_match_at_eof_after_newline = ctx.disallow_empty_match_at_eof_after_newline;
     let allow_input_assertion_overrides = ctx.allow_input_assertion_overrides;
+    let leftmost_longest = ctx.leftmost_longest;
 
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
     if tree.numbered_groups_ignored
@@ -881,6 +900,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
         find_not_empty,
         disallow_empty_match_at_eof_after_newline,
         allow_input_assertion_overrides,
+        leftmost_longest,
         in_lookaround: false,
     };
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -157,6 +157,7 @@ struct Analyzer<'a> {
     /// so they run on the VM.
     allow_input_assertion_overrides: bool,
     /// When true, leftmost-longest match semantics are enabled.
+    #[cfg(feature = "leftmost_longest")]
     leftmost_longest: bool,
     /// Oniguruma's `^` rejects the empty match at the absolute end of the haystack after a trailing
     /// newline when it anchors the match itself. When used as a sub-assertion inside a lookaround,
@@ -313,9 +314,11 @@ impl<'a> Analyzer<'a> {
                 ref child,
                 lo,
                 hi,
+                #[cfg(feature = "leftmost_longest")]
                 greedy,
                 ..
             } => {
+                #[cfg(feature = "leftmost_longest")]
                 if !greedy && self.leftmost_longest {
                     return Err(Error::CompileError(Box::new(
                         CompileError::FeatureNotYetSupported(
@@ -627,7 +630,9 @@ impl<'a> Analyzer<'a> {
         // must be handled by the VM so it can backtrack past it to find a non-empty match.
         if self.find_not_empty && min_size == 0 && !const_size {
             hard = true;
-        } else if self.leftmost_longest && !const_size {
+        }
+        #[cfg(feature = "leftmost_longest")]
+        if self.leftmost_longest && !const_size {
             hard = true;
         }
 
@@ -899,6 +904,7 @@ pub struct AnalyzeContext {
     /// as hard so that they execute on the VM.
     pub allow_input_assertion_overrides: bool,
     /// When true, leftmost-longest match semantics are enabled.
+    #[cfg(feature = "leftmost_longest")]
     pub leftmost_longest: bool,
 }
 
@@ -908,6 +914,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
     let find_not_empty = ctx.find_not_empty;
     let disallow_empty_match_at_eof_after_newline = ctx.disallow_empty_match_at_eof_after_newline;
     let allow_input_assertion_overrides = ctx.allow_input_assertion_overrides;
+    #[cfg(feature = "leftmost_longest")]
     let leftmost_longest = ctx.leftmost_longest;
 
     // Check that numeric capture group references (backrefs and subroutine calls) and named groups are not mixed
@@ -943,6 +950,7 @@ pub fn analyze<'a>(tree: &'a ExprTree, ctx: AnalyzeContext) -> Result<Info<'a>> 
         find_not_empty,
         disallow_empty_match_at_eof_after_newline,
         allow_input_assertion_overrides,
+        #[cfg(feature = "leftmost_longest")]
         leftmost_longest,
         in_lookaround: false,
     };
@@ -2185,6 +2193,7 @@ mod tests {
 
     // Tests for leftmost_longest flag
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_rejects_non_greedy_star() {
         let tree = Expr::parse_tree(r"a*?").unwrap();
@@ -2201,6 +2210,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_rejects_non_greedy_plus() {
         let tree = Expr::parse_tree(r"a+?").unwrap();
@@ -2217,6 +2227,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_rejects_non_greedy_optional() {
         let tree = Expr::parse_tree(r"a??").unwrap();
@@ -2233,6 +2244,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_rejects_non_greedy_bounded() {
         let tree = Expr::parse_tree(r"a{1,3}?").unwrap();
@@ -2249,6 +2261,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_accepts_greedy_quantifiers() {
         assert_analyze_ok(
@@ -2281,6 +2294,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_promotes_non_const_to_hard() {
         // Without leftmost_longest, a* is not hard (can be delegated to regex-automata)
@@ -2302,6 +2316,7 @@ mod tests {
         assert!(!info.const_size);
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_keeps_const_size_easy() {
         let tree = Expr::parse_tree(r"abc").unwrap();

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -24,7 +24,7 @@ use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::cmp::min;
+use core::cmp::{max, min};
 
 use bit_set::BitSet;
 
@@ -48,6 +48,8 @@ pub struct Info<'a> {
     pub(crate) capture_groups: CaptureGroupRange,
     /// The minimum number of characters this expression will match
     pub min_size: usize,
+    /// The maximum number of characters this expression can match
+    pub max_size: usize,
     /// Whether this expression always matches the same number of characters
     pub const_size: bool,
     /// Tracks the minimum number of characters that would be consumed in the innermost capture group
@@ -114,6 +116,7 @@ impl<'a> Info<'a> {
 struct SizeInfo {
     min_size: usize,
     const_size: bool,
+    max_size: usize,
 }
 
 /// Represents a subroutine call and its minimum position within a group
@@ -177,8 +180,9 @@ impl<'a> Analyzer<'a> {
             Expr::Concat(ref v) | Expr::Alt(ref v) => Vec::with_capacity(v.len()),
             _ => Vec::new(),
         };
-        let mut min_size = 0;
+        let mut min_size: usize = 0;
         let mut const_size = false;
+        let mut max_size: usize = 0;
         let mut hard = false;
         match *expr {
             Expr::Assertion(assertion) if assertion.is_always_hard() => {
@@ -201,12 +205,17 @@ impl<'a> Analyzer<'a> {
                 const_size = true;
                 hard = true; // NOTE: \Z is already considered hard and covered in the branch above
             }
+            Expr::Assertion(Assertion::EndText) if self.find_not_empty && !self.in_lookaround => {
+                const_size = true;
+                hard = true;
+            }
             Expr::Empty | Expr::Assertion(_) => {
                 const_size = true;
             }
             Expr::Any { .. } => {
                 min_size = 1;
                 const_size = true;
+                max_size = 1;
             }
             Expr::GeneralNewline { .. } => {
                 // \R matches either \r\n (2 chars) or single newline chars (1 char)
@@ -214,11 +223,13 @@ impl<'a> Analyzer<'a> {
                 min_size = 1;
                 const_size = false;
                 hard = true; // requires backtracking to handle \r\n without backtracking to \r
+                max_size = 2;
             }
             Expr::Literal { ref val, casei } => {
                 // right now each character in a literal gets its own node, that might change
                 min_size = 1;
                 const_size = literal_const_size(val, casei);
+                max_size = 1;
             }
             Expr::Concat(ref v) => {
                 const_size = true;
@@ -226,10 +237,15 @@ impl<'a> Analyzer<'a> {
                 for child in v {
                     let child_info =
                         self.visit(child, pos_in_group, inside_zero_rep, enclosing_group)?;
-                    min_size += child_info.min_size;
+                    min_size = min_size.saturating_add(child_info.min_size);
+                    max_size = if max_size == usize::MAX || child_info.max_size == usize::MAX {
+                        usize::MAX
+                    } else {
+                        max_size.saturating_add(child_info.max_size)
+                    };
                     const_size &= child_info.const_size;
                     hard |= child_info.hard;
-                    pos_in_group += child_info.min_size;
+                    pos_in_group = pos_in_group.saturating_add(child_info.min_size);
                     children.push(child_info);
                 }
             }
@@ -237,6 +253,7 @@ impl<'a> Analyzer<'a> {
                 let child_info =
                     self.visit(&v[0], min_pos_in_group, inside_zero_rep, enclosing_group)?;
                 min_size = child_info.min_size;
+                max_size = child_info.max_size;
                 const_size = child_info.const_size;
                 hard = child_info.hard;
                 children.push(child_info);
@@ -245,6 +262,7 @@ impl<'a> Analyzer<'a> {
                         self.visit(child, min_pos_in_group, inside_zero_rep, enclosing_group)?;
                     const_size &= child_info.const_size && min_size == child_info.min_size;
                     min_size = min(min_size, child_info.min_size);
+                    max_size = max(max_size, child_info.max_size);
                     hard |= child_info.hard;
                     children.push(child_info);
                 }
@@ -262,6 +280,7 @@ impl<'a> Analyzer<'a> {
                 let child_info = self.visit(child, 0, inside_zero_rep, group)?;
                 self.analyzing_groups.remove(group);
                 min_size = child_info.min_size;
+                max_size = child_info.max_size;
                 const_size = child_info.const_size;
                 // Store the group info for use by backrefs
                 self.group_info.insert(
@@ -269,6 +288,7 @@ impl<'a> Analyzer<'a> {
                     SizeInfo {
                         min_size,
                         const_size,
+                        max_size,
                     },
                 );
                 // If there's a backref to this group, we potentially have to backtrack within the
@@ -317,6 +337,11 @@ impl<'a> Analyzer<'a> {
                     enclosing_group,
                 )?;
                 min_size = child_info.min_size * lo;
+                max_size = if hi == usize::MAX || child_info.max_size == usize::MAX {
+                    usize::MAX
+                } else {
+                    child_info.max_size.saturating_mul(hi)
+                };
                 const_size = child_info.const_size && lo == hi;
                 hard = child_info.hard;
                 children.push(child_info);
@@ -326,6 +351,7 @@ impl<'a> Analyzer<'a> {
                 // This constraint ensures consistency in the AST representation.
                 min_size = 1;
                 const_size = true;
+                max_size = 1;
             }
             Expr::Backref { group, .. } => {
                 if group == 0 {
@@ -354,10 +380,13 @@ impl<'a> Analyzer<'a> {
                 // Look up the referenced group's size information
                 if let Some(&SizeInfo {
                     min_size: group_min_size,
+                    max_size: group_max_size,
                     const_size: group_const_size,
+                    ..
                 }) = self.group_info.get(&group)
                 {
                     min_size = group_min_size;
+                    max_size = group_max_size;
                     const_size = group_const_size;
                 }
                 hard = true;
@@ -366,6 +395,7 @@ impl<'a> Analyzer<'a> {
                 let child_info =
                     self.visit(child, min_pos_in_group, inside_zero_rep, enclosing_group)?;
                 min_size = child_info.min_size;
+                max_size = child_info.max_size;
                 const_size = child_info.const_size;
                 hard = true; // TODO: possibly could weaken
                 children.push(child_info);
@@ -414,6 +444,7 @@ impl<'a> Analyzer<'a> {
 
                 min_size = child_info_condition.min_size
                     + min(child_info_truth.min_size, child_info_false.min_size);
+                max_size = max(child_info_truth.max_size, child_info_false.max_size);
                 const_size = child_info_condition.const_size
                     && child_info_truth.const_size
                     && child_info_false.const_size
@@ -444,14 +475,17 @@ impl<'a> Analyzer<'a> {
                 if let Some(&SizeInfo {
                     min_size: group_min_size,
                     const_size: group_const_size,
+                    max_size: group_max_size,
                 }) = self.group_info.get(&target_group)
                 {
                     min_size = group_min_size;
+                    max_size = group_max_size;
                     const_size = group_const_size;
                 } else if self.analyzing_groups.contains(target_group) {
                     // Currently analyzing this group - circular reference
                     // Use conservative defaults to avoid infinite recursion
                     min_size = 0;
+                    max_size = usize::MAX;
                     const_size = false;
                 } else if let Some(&group_expr) = self.group_exprs.get(&target_group) {
                     // If the group hasn't been seen yet (forward reference),
@@ -467,6 +501,7 @@ impl<'a> Analyzer<'a> {
                     self.analyzing_groups.remove(target_group);
 
                     min_size = group_info.min_size;
+                    max_size = group_info.max_size;
                     const_size = group_info.const_size;
                     // Store the analysis result for future lookups
                     self.group_info.insert(
@@ -474,11 +509,13 @@ impl<'a> Analyzer<'a> {
                         SizeInfo {
                             min_size,
                             const_size,
+                            max_size,
                         },
                     );
                 } else {
                     // Group doesn't exist - this shouldn't happen as the parser would have caught it
                     min_size = 0;
+                    max_size = usize::MAX;
                     const_size = false;
                 }
                 hard = true;
@@ -534,6 +571,7 @@ impl<'a> Analyzer<'a> {
                         let child_info =
                             self.visit(child, min_pos_in_group, inside_zero_rep, enclosing_group)?;
                         min_size = 0;
+                        max_size = usize::MAX;
                         const_size = false;
                         hard = true;
                         children.push(child_info);
@@ -547,6 +585,7 @@ impl<'a> Analyzer<'a> {
                         let exp_info =
                             self.visit(exp, min_pos_in_group, inside_zero_rep, enclosing_group)?;
                         min_size = exp_info.min_size;
+                        max_size = exp_info.max_size;
                         const_size = false;
                         hard = true;
                         children.push(absent_info);
@@ -557,6 +596,7 @@ impl<'a> Analyzer<'a> {
                             self.visit(child, min_pos_in_group, inside_zero_rep, enclosing_group)?;
                         // Absent stopper doesn't consume any characters itself
                         min_size = 0;
+                        max_size = 0;
                         const_size = true;
                         hard = true;
                         children.push(child_info);
@@ -564,6 +604,7 @@ impl<'a> Analyzer<'a> {
                     Clear => {
                         // Range clear doesn't consume any characters
                         min_size = 0;
+                        max_size = 0;
                         const_size = true;
                         hard = true;
                     }
@@ -576,6 +617,7 @@ impl<'a> Analyzer<'a> {
                 // delegated (as an empty string) to the underlying engine.
                 let def_info = self.visit(definitions, 0, inside_zero_rep, enclosing_group)?;
                 min_size = 0;
+                max_size = 0;
                 const_size = true;
                 children.push(def_info);
             }
@@ -594,6 +636,7 @@ impl<'a> Analyzer<'a> {
             children,
             capture_groups: CaptureGroupRange(start_group, self.next_group_number),
             min_size,
+            max_size,
             const_size,
             hard,
             min_pos_in_group,

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -2085,5 +2085,278 @@ mod tests {
         assert_eq!(info.children[0].start_group(), 1);
         assert_eq!(info.children[1].children[0].start_group(), 2);
         assert_eq!(info.children[2].start_group(), 5);
+        assert_eq!(info.children[2].end_group(), 6);
+    }
+
+    // Tests for max_size
+
+    #[test]
+    fn max_size_for_literal() {
+        let tree = Expr::parse_tree("a").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 1);
+    }
+
+    #[test]
+    fn max_size_for_concat_of_literals() {
+        let tree = Expr::parse_tree("abc").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 3);
+    }
+
+    #[test]
+    fn max_size_for_general_newline() {
+        let tree = Expr::parse_tree(r"\R").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 2);
+    }
+
+    #[test]
+    fn max_size_for_greedy_star() {
+        let tree = Expr::parse_tree("a*").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, usize::MAX);
+    }
+
+    #[test]
+    fn max_size_for_greedy_plus() {
+        let tree = Expr::parse_tree("a+").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, usize::MAX);
+    }
+
+    #[test]
+    fn max_size_for_optional() {
+        let tree = Expr::parse_tree("a?").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 1);
+    }
+
+    #[test]
+    fn max_size_for_bounded_repeat() {
+        let tree = Expr::parse_tree("a{1,3}").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 3);
+    }
+
+    #[test]
+    fn max_size_for_exact_repeat() {
+        let tree = Expr::parse_tree("a{3}").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 3);
+    }
+
+    #[test]
+    fn max_size_for_alternation() {
+        let tree = Expr::parse_tree("a|bc").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 2);
+    }
+
+    #[test]
+    fn max_size_for_group() {
+        let tree = Expr::parse_tree(r"(abc)").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 3);
+    }
+
+    #[test]
+    fn max_size_for_backref_inherits_group() {
+        let tree = Expr::parse_tree(r"(ab)\1").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 4);
+    }
+
+    #[test]
+    fn max_size_for_concat_accumulates() {
+        // ab*cd = concat(literal a, repeat b*, literal c, literal d)
+        // max_size = 1 + MAX + 1 + 1 = MAX
+        let tree = Expr::parse_tree("ab*cd").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, usize::MAX);
+    }
+
+    #[test]
+    fn max_size_for_empty_assertion_is_zero() {
+        let tree = Expr::parse_tree(r"\b").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert_eq!(info.max_size, 0);
+    }
+
+    // Tests for leftmost_longest flag
+
+    #[test]
+    fn leftmost_longest_rejects_non_greedy_star() {
+        let tree = Expr::parse_tree(r"a*?").unwrap();
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_compile_error(
+            result,
+            |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("non-greedy")),
+        );
+    }
+
+    #[test]
+    fn leftmost_longest_rejects_non_greedy_plus() {
+        let tree = Expr::parse_tree(r"a+?").unwrap();
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_compile_error(
+            result,
+            |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("non-greedy")),
+        );
+    }
+
+    #[test]
+    fn leftmost_longest_rejects_non_greedy_optional() {
+        let tree = Expr::parse_tree(r"a??").unwrap();
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_compile_error(
+            result,
+            |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("non-greedy")),
+        );
+    }
+
+    #[test]
+    fn leftmost_longest_rejects_non_greedy_bounded() {
+        let tree = Expr::parse_tree(r"a{1,3}?").unwrap();
+        let result = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_compile_error(
+            result,
+            |e| matches!(e, CompileError::FeatureNotYetSupported(s) if s.contains("non-greedy")),
+        );
+    }
+
+    #[test]
+    fn leftmost_longest_accepts_greedy_quantifiers() {
+        assert_analyze_ok(
+            &Expr::parse_tree(r"a*").unwrap(),
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_analyze_ok(
+            &Expr::parse_tree(r"a+").unwrap(),
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_analyze_ok(
+            &Expr::parse_tree(r"a?").unwrap(),
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+        assert_analyze_ok(
+            &Expr::parse_tree(r"a{1,3}").unwrap(),
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn leftmost_longest_promotes_non_const_to_hard() {
+        // Without leftmost_longest, a* is not hard (can be delegated to regex-automata)
+        let tree = Expr::parse_tree(r"a*").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert!(!info.hard);
+        assert!(!info.const_size);
+
+        // With leftmost_longest, a* becomes hard because it's not const_size
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(info.hard);
+        assert!(!info.const_size);
+    }
+
+    #[test]
+    fn leftmost_longest_keeps_const_size_easy() {
+        let tree = Expr::parse_tree(r"abc").unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                leftmost_longest: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(!info.hard);
+        assert!(info.const_size);
+    }
+
+    // Tests for EndText assertion with find_not_empty
+
+    #[test]
+    fn end_text_hard_with_find_not_empty() {
+        let tree = Expr::parse_tree(r"$").unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                find_not_empty: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(info.hard);
+        assert!(info.const_size);
+    }
+
+    #[test]
+    fn end_text_not_hard_without_find_not_empty() {
+        let tree = Expr::parse_tree(r"$").unwrap();
+        let info = analyze(&tree, AnalyzeContext::default()).unwrap();
+        assert!(!info.hard);
+        assert!(info.const_size);
+    }
+
+    #[test]
+    fn end_text_not_hard_in_lookaround_with_find_not_empty() {
+        // Inside a lookaround, $ does not get the find_not_empty hard treatment
+        let tree = Expr::parse_tree(r"(?=$)").unwrap();
+        let info = analyze(
+            &tree,
+            AnalyzeContext {
+                find_not_empty: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // The lookahead's child is directly the EndText assertion
+        let end_text_info = &info.children[0];
+        assert!(!end_text_info.hard);
+        assert!(end_text_info.const_size);
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -69,8 +69,8 @@ impl VMBuilder {
         }
     }
 
-    fn build(self, bytes_mode: BytesMode, seek_pattern: String) -> Prog {
-        Prog::new(self.prog, self.n_saves, bytes_mode, seek_pattern)
+    fn build(self, bytes_mode: BytesMode, seek_pattern: String, max_size: usize) -> Prog {
+        Prog::new(self.prog, self.n_saves, bytes_mode, seek_pattern, max_size)
     }
 
     fn newsave(&mut self) -> usize {
@@ -1316,7 +1316,7 @@ pub fn compile(info: &Info<'_>, options: CompileOptions) -> Result<Prog> {
         c.b.add(Insn::RejectEmptyMatchAtEOFFollowingNewline);
     }
     c.b.add(Insn::End);
-    Ok(c.b.build(bytes_mode, seek_pattern))
+    Ok(c.b.build(bytes_mode, seek_pattern, info.max_size))
 }
 
 struct DelegateBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@ use crate::compile::{compile, CompileOptions};
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::parse_flags::*;
-use crate::vm::{
-    Prog, OPTION_FIND_NOT_EMPTY, OPTION_LEFTMOST_LONGEST, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH,
-};
+#[cfg(feature = "leftmost_longest")]
+use crate::vm::OPTION_LEFTMOST_LONGEST;
+use crate::vm::{Prog, OPTION_FIND_NOT_EMPTY, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH};
 
 pub use crate::bytes::MatchBytes;
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
@@ -522,6 +522,7 @@ struct RegexOptions {
     /// the set only ever searches them anchored at candidate positions, where
     /// a prefilter is never consulted, so building one wastes time and memory.
     delegate_prefilter: bool,
+    #[cfg(feature = "leftmost_longest")]
     leftmost_longest: bool,
 }
 
@@ -534,7 +535,8 @@ impl fmt::Debug for RegexOptions {
             }
             Some(_) => "Some(<custom>)",
         };
-        f.debug_struct("RegexOptions")
+        let mut debug = f.debug_struct("RegexOptions");
+        debug
             .field("syntaxc", &self.syntaxc)
             .field("delegate_size_limit", &self.delegate_size_limit)
             .field("delegate_dfa_size_limit", &self.delegate_dfa_size_limit)
@@ -548,9 +550,10 @@ impl fmt::Debug for RegexOptions {
                 &self.hard_regex_runtime_options,
             )
             .field("seek_filter", &seek_filter_desc)
-            .field("delegate_prefilter", &self.delegate_prefilter)
-            .field("leftmost_longest", &self.leftmost_longest)
-            .finish()
+            .field("delegate_prefilter", &self.delegate_prefilter);
+        #[cfg(feature = "leftmost_longest")]
+        debug.field("leftmost_longest", &self.leftmost_longest);
+        debug.finish()
     }
 }
 
@@ -566,6 +569,7 @@ impl Default for RegexOptions {
             bytes_mode: BytesMode::default(),
             seek_filter: None, // when we are ready to enable seek by default, use: `Some(seek_pattern_is_useful)`
             delegate_prefilter: true,
+            #[cfg(feature = "leftmost_longest")]
             leftmost_longest: false,
         }
     }
@@ -577,6 +581,7 @@ struct HardRegexRuntimeOptions {
     find_not_empty: bool,
     disallow_empty_match_at_eof_after_newline: bool,
     allow_input_assertion_overrides: bool,
+    #[cfg(feature = "leftmost_longest")]
     leftmost_longest: bool,
 }
 
@@ -624,6 +629,7 @@ impl Default for HardRegexRuntimeOptions {
             find_not_empty: false,
             disallow_empty_match_at_eof_after_newline: false,
             allow_input_assertion_overrides: false,
+            #[cfg(feature = "leftmost_longest")]
             leftmost_longest: false,
         }
     }
@@ -802,6 +808,9 @@ impl RegexOptionsBuilder {
     /// (PCRE-style) semantics.
     ///
     /// Default is `false`.
+    ///
+    /// **Note:** This requires the `leftmost_longest` feature to be enabled.
+    #[cfg(feature = "leftmost_longest")]
     pub fn leftmost_longest(&mut self, yes: bool) -> &mut Self {
         self.options.leftmost_longest = yes;
         self.options.hard_regex_runtime_options.leftmost_longest = yes;
@@ -1092,6 +1101,7 @@ impl RegexBuilder {
     }
 
     /// See [`RegexOptionsBuilder::leftmost_longest`]
+    #[cfg(feature = "leftmost_longest")]
     pub fn leftmost_longest(&mut self, yes: bool) -> &mut Self {
         self.options.leftmost_longest(yes);
         self
@@ -1170,6 +1180,7 @@ impl Regex {
         let allow_input_assertion_overrides = options
             .hard_regex_runtime_options
             .allow_input_assertion_overrides;
+        #[cfg(feature = "leftmost_longest")]
         let leftmost_longest = options.leftmost_longest;
 
         let requires_capture_group_fixup = if find_not_empty {
@@ -1190,6 +1201,7 @@ impl Regex {
                 find_not_empty,
                 disallow_empty_match_at_eof_after_newline,
                 allow_input_assertion_overrides,
+                #[cfg(feature = "leftmost_longest")]
                 leftmost_longest,
             },
         )?;
@@ -1461,17 +1473,21 @@ impl Regex {
                 Ok(result)
             }
             RegexImpl::Fancy { prog, options, .. } => {
-                let option_flags = option_flags
+                #[allow(unused_mut)]
+                let mut option_flags = option_flags
                     | if options.find_not_empty {
                         OPTION_FIND_NOT_EMPTY
                     } else {
                         0
-                    }
-                    | if options.leftmost_longest {
+                    };
+                #[cfg(feature = "leftmost_longest")]
+                {
+                    option_flags |= if options.leftmost_longest {
                         OPTION_LEFTMOST_LONGEST
                     } else {
                         0
                     };
+                }
                 // Span-only VM entry: nothing is moved out of the pooled
                 // scratch, so this path is allocation-free per call.
                 vm::run_spans(prog, input, option_flags, options)
@@ -1663,17 +1679,21 @@ impl Regex {
                 options,
                 ..
             } => {
-                let option_flags = option_flags
+                #[allow(unused_mut)]
+                let mut option_flags = option_flags
                     | if options.find_not_empty {
                         OPTION_FIND_NOT_EMPTY
                     } else {
                         0
-                    }
-                    | if options.leftmost_longest {
+                    };
+                #[cfg(feature = "leftmost_longest")]
+                {
+                    option_flags |= if options.leftmost_longest {
                         OPTION_LEFTMOST_LONGEST
                     } else {
                         0
                     };
+                }
                 let result = vm::run(prog, input, option_flags, options)?;
                 Ok(result.map(|mut saves| {
                     saves.truncate(n_groups * 2);
@@ -3124,6 +3144,7 @@ mod tests {
         assert_eq!(s, format!("{:?}", regex));
     }
 
+    #[cfg(feature = "leftmost_longest")]
     #[test]
     fn leftmost_longest_alt_compiles_to_fancy() {
         let regex = RegexBuilder::new(r"a|ab")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,9 @@ use crate::compile::{compile, CompileOptions};
 use crate::optimize::optimize;
 use crate::parse::{ExprTree, NamedGroups, Parser};
 use crate::parse_flags::*;
-use crate::vm::{Prog, OPTION_FIND_NOT_EMPTY, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH};
+use crate::vm::{
+    Prog, OPTION_FIND_NOT_EMPTY, OPTION_LEFTMOST_LONGEST, OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH,
+};
 
 pub use crate::bytes::MatchBytes;
 pub use crate::error::{CompileError, Error, ParseError, Result, RuntimeError};
@@ -520,6 +522,7 @@ struct RegexOptions {
     /// the set only ever searches them anchored at candidate positions, where
     /// a prefilter is never consulted, so building one wastes time and memory.
     delegate_prefilter: bool,
+    leftmost_longest: bool,
 }
 
 impl fmt::Debug for RegexOptions {
@@ -546,6 +549,7 @@ impl fmt::Debug for RegexOptions {
             )
             .field("seek_filter", &seek_filter_desc)
             .field("delegate_prefilter", &self.delegate_prefilter)
+            .field("leftmost_longest", &self.leftmost_longest)
             .finish()
     }
 }
@@ -562,6 +566,7 @@ impl Default for RegexOptions {
             bytes_mode: BytesMode::default(),
             seek_filter: None, // when we are ready to enable seek by default, use: `Some(seek_pattern_is_useful)`
             delegate_prefilter: true,
+            leftmost_longest: false,
         }
     }
 }
@@ -572,6 +577,7 @@ struct HardRegexRuntimeOptions {
     find_not_empty: bool,
     disallow_empty_match_at_eof_after_newline: bool,
     allow_input_assertion_overrides: bool,
+    leftmost_longest: bool,
 }
 
 impl RegexOptions {
@@ -618,6 +624,7 @@ impl Default for HardRegexRuntimeOptions {
             find_not_empty: false,
             disallow_empty_match_at_eof_after_newline: false,
             allow_input_assertion_overrides: false,
+            leftmost_longest: false,
         }
     }
 }
@@ -785,6 +792,19 @@ impl RegexOptionsBuilder {
     /// combination to execute pointlessly at runtime.
     pub fn find_not_empty(&mut self, yes: bool) -> &mut Self {
         self.options.hard_regex_runtime_options.find_not_empty = yes;
+        self
+    }
+
+    /// Enable leftmost-longest match semantics.
+    ///
+    /// When enabled, among all matches starting at the leftmost possible position,
+    /// the longest match is returned. This contrasts with the default leftmost-first
+    /// (PCRE-style) semantics.
+    ///
+    /// Default is `false`.
+    pub fn leftmost_longest(&mut self, yes: bool) -> &mut Self {
+        self.options.leftmost_longest = yes;
+        self.options.hard_regex_runtime_options.leftmost_longest = yes;
         self
     }
 
@@ -1071,6 +1091,12 @@ impl RegexBuilder {
         self
     }
 
+    /// See [`RegexOptionsBuilder::leftmost_longest`]
+    pub fn leftmost_longest(&mut self, yes: bool) -> &mut Self {
+        self.options.leftmost_longest(yes);
+        self
+    }
+
     /// See [`RegexOptionsBuilder::ignore_numbered_groups_when_named_groups_exist`]
     pub fn ignore_numbered_groups_when_named_groups_exist(&mut self, yes: bool) -> &mut Self {
         self.options
@@ -1144,6 +1170,7 @@ impl Regex {
         let allow_input_assertion_overrides = options
             .hard_regex_runtime_options
             .allow_input_assertion_overrides;
+        let leftmost_longest = options.leftmost_longest;
 
         let requires_capture_group_fixup = if find_not_empty {
             // if the find_not_empty flag is set, we skip optimizations
@@ -1163,6 +1190,7 @@ impl Regex {
                 find_not_empty,
                 disallow_empty_match_at_eof_after_newline,
                 allow_input_assertion_overrides,
+                leftmost_longest,
             },
         )?;
 
@@ -1438,6 +1466,11 @@ impl Regex {
                         OPTION_FIND_NOT_EMPTY
                     } else {
                         0
+                    }
+                    | if options.leftmost_longest {
+                        OPTION_LEFTMOST_LONGEST
+                    } else {
+                        0
                     };
                 // Span-only VM entry: nothing is moved out of the pooled
                 // scratch, so this path is allocation-free per call.
@@ -1633,6 +1666,11 @@ impl Regex {
                 let option_flags = option_flags
                     | if options.find_not_empty {
                         OPTION_FIND_NOT_EMPTY
+                    } else {
+                        0
+                    }
+                    | if options.leftmost_longest {
+                        OPTION_LEFTMOST_LONGEST
                     } else {
                         0
                     };
@@ -3084,6 +3122,18 @@ mod tests {
         );
         assert_eq!(s, regex.as_str());
         assert_eq!(s, format!("{:?}", regex));
+    }
+
+    #[test]
+    fn leftmost_longest_alt_compiles_to_fancy() {
+        let regex = RegexBuilder::new(r"a|ab")
+            .leftmost_longest(true)
+            .build()
+            .unwrap();
+        assert!(
+            matches!(regex.inner, RegexImpl::Fancy { .. }),
+            "alternation with non-const size should compile to VM when leftmost_longest is enabled"
+        );
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -114,8 +114,8 @@ pub(crate) const OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH: u32 = 1 << 1;
 /// \K is ignored as part of this check - so empty matches can still be reported if the engine
 /// consumed characters and then \K was used afterwards.
 pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
-/// When set, the VM uses leftmost-longest match semantics instead of leftmost-first.
 #[cfg(feature = "leftmost_longest")]
+/// When set, the VM uses leftmost-longest match semantics instead of leftmost-first.
 pub(crate) const OPTION_LEFTMOST_LONGEST: u32 = 1 << 3;
 
 // TODO: make configurable
@@ -1206,6 +1206,13 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                     continue;
                 }
                 Insn::SplitUnanchored(x, y) => {
+                    #[cfg(feature = "leftmost_longest")]
+                    if leftmost_longest {
+                        if let Some(saves) = best_saves {
+                            state.saves.copy_from_slice(&saves);
+                            return Ok(Some(extract(state)));
+                        }
+                    }
                     if ix > match_range.end {
                         return Ok(None);
                     }
@@ -1502,6 +1509,13 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                     }
                 }
                 Insn::Seek(Seek { ref inner, .. }) => {
+                    #[cfg(feature = "leftmost_longest")]
+                    if leftmost_longest {
+                        if let Some(saves) = best_saves {
+                            state.saves.copy_from_slice(&saves);
+                            return Ok(Some(extract(state)));
+                        }
+                    }
                     // A sentinel value greater than haystack.len() is pushed onto the backtrack stack
                     // when the seek found a zero-width match at end-of-string.  On re-entry with
                     // that sentinel, there are no more positions to try.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -115,6 +115,7 @@ pub(crate) const OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH: u32 = 1 << 1;
 /// consumed characters and then \K was used afterwards.
 pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
 /// When set, the VM uses leftmost-longest match semantics instead of leftmost-first.
+#[cfg(feature = "leftmost_longest")]
 pub(crate) const OPTION_LEFTMOST_LONGEST: u32 = 1 << 3;
 
 // TODO: make configurable
@@ -1031,8 +1032,11 @@ fn run_with<S: HaystackInput + ?Sized, T>(
     let mut ix = pos;
     let mut slash_z_matched = false;
     let mut match_attempt_start = pos;
+    #[cfg(feature = "leftmost_longest")]
     let leftmost_longest = option_flags & OPTION_LEFTMOST_LONGEST != 0;
+    #[cfg(feature = "leftmost_longest")]
     let mut best_saves: Option<Vec<usize>> = None;
+    #[cfg(feature = "leftmost_longest")]
     let mut best_match_len = 0;
     loop {
         // break from this loop to fail, causes stack to pop
@@ -1068,6 +1072,7 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                     if state.get(0) < match_range.start || state.get(1) > match_range.end {
                         break 'fail;
                     }
+                    #[cfg(feature = "leftmost_longest")]
                     if leftmost_longest {
                         let match_len = state.get(1) - state.get(0);
                         if best_saves.is_none() || match_len > best_match_len {
@@ -1562,6 +1567,7 @@ fn run_with<S: HaystackInput + ?Sized, T>(
         }
         // "break 'fail" goes here
         if state.stack.is_empty() {
+            #[cfg(feature = "leftmost_longest")]
             if leftmost_longest {
                 if let Some(saves) = best_saves {
                     state.saves.copy_from_slice(&saves);
@@ -1571,6 +1577,7 @@ fn run_with<S: HaystackInput + ?Sized, T>(
             return Ok(None);
         }
 
+        #[cfg(feature = "leftmost_longest")]
         if leftmost_longest && best_match_len == prog.max_size {
             if let Some(saves) = best_saves {
                 state.saves.copy_from_slice(&saves);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -566,6 +566,9 @@ pub struct Prog {
     /// A pattern compatible with a DFA which can be used to seek to candidate positions where the real/full pattern might match
     pub(crate) seek_pattern: String,
     scratch_pool: Pool<Scratch, fn() -> Scratch>,
+    /// Maximum number of bytes this pattern can match. When `leftmost_longest` is enabled and a match
+    /// of this length is found, no longer match is possible, so backtracking can stop early.
+    pub max_size: usize,
 }
 
 impl Prog {
@@ -574,6 +577,7 @@ impl Prog {
         n_saves: usize,
         bytes_mode: BytesMode,
         seek_pattern: String,
+        max_size: usize,
     ) -> Prog {
         Prog {
             body,
@@ -581,6 +585,7 @@ impl Prog {
             bytes_mode,
             seek_pattern,
             scratch_pool: Pool::new(new_scratch),
+            max_size,
         }
     }
 
@@ -1068,6 +1073,9 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                         if best_saves.is_none() || match_len > best_match_len {
                             best_saves = Some(state.saves.clone());
                             best_match_len = match_len;
+                        }
+                        if best_match_len == prog.max_size {
+                            return Ok(Some(extract(state)));
                         }
                         break 'fail;
                     }
@@ -1561,6 +1569,13 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                 }
             }
             return Ok(None);
+        }
+
+        if leftmost_longest && best_match_len == prog.max_size {
+            if let Some(saves) = best_saves {
+                state.saves.copy_from_slice(&saves);
+                return Ok(Some(extract(state)));
+            }
         }
 
         backtrack_count += 1;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -953,6 +953,17 @@ fn store_capture_groups(
     }
 }
 
+#[cfg(feature = "leftmost_longest")]
+#[inline]
+fn apply_best_saves(state: &mut State, best_saves: &Option<Vec<usize>>) -> bool {
+    if let Some(saves) = best_saves {
+        state.saves.copy_from_slice(saves);
+        true
+    } else {
+        false
+    }
+}
+
 /// Run the program with trace printing for debugging.
 pub fn run_trace(prog: &Prog, s: &str, pos: usize) -> Result<Option<Vec<usize>>> {
     run(
@@ -1207,11 +1218,8 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                 }
                 Insn::SplitUnanchored(x, y) => {
                     #[cfg(feature = "leftmost_longest")]
-                    if leftmost_longest {
-                        if let Some(saves) = best_saves {
-                            state.saves.copy_from_slice(&saves);
-                            return Ok(Some(extract(state)));
-                        }
+                    if leftmost_longest && apply_best_saves(state, &best_saves) {
+                        return Ok(Some(extract(state)));
                     }
                     if ix > match_range.end {
                         return Ok(None);
@@ -1510,11 +1518,8 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                 }
                 Insn::Seek(Seek { ref inner, .. }) => {
                     #[cfg(feature = "leftmost_longest")]
-                    if leftmost_longest {
-                        if let Some(saves) = best_saves {
-                            state.saves.copy_from_slice(&saves);
-                            return Ok(Some(extract(state)));
-                        }
+                    if leftmost_longest && apply_best_saves(state, &best_saves) {
+                        return Ok(Some(extract(state)));
                     }
                     // A sentinel value greater than haystack.len() is pushed onto the backtrack stack
                     // when the seek found a zero-width match at end-of-string.  On re-entry with
@@ -1582,21 +1587,18 @@ fn run_with<S: HaystackInput + ?Sized, T>(
         // "break 'fail" goes here
         if state.stack.is_empty() {
             #[cfg(feature = "leftmost_longest")]
-            if leftmost_longest {
-                if let Some(saves) = best_saves {
-                    state.saves.copy_from_slice(&saves);
-                    return Ok(Some(extract(state)));
-                }
+            if leftmost_longest && apply_best_saves(state, &best_saves) {
+                return Ok(Some(extract(state)));
             }
             return Ok(None);
         }
 
         #[cfg(feature = "leftmost_longest")]
-        if leftmost_longest && best_match_len == prog.max_size {
-            if let Some(saves) = best_saves {
-                state.saves.copy_from_slice(&saves);
-                return Ok(Some(extract(state)));
-            }
+        if leftmost_longest
+            && best_match_len == prog.max_size
+            && apply_best_saves(state, &best_saves)
+        {
+            return Ok(Some(extract(state)));
         }
 
         backtrack_count += 1;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -114,6 +114,8 @@ pub(crate) const OPTION_NOT_CONTINUED_FROM_PREVIOUS_MATCH: u32 = 1 << 1;
 /// \K is ignored as part of this check - so empty matches can still be reported if the engine
 /// consumed characters and then \K was used afterwards.
 pub(crate) const OPTION_FIND_NOT_EMPTY: u32 = 1 << 2;
+/// When set, the VM uses leftmost-longest match semantics instead of leftmost-first.
+pub(crate) const OPTION_LEFTMOST_LONGEST: u32 = 1 << 3;
 
 // TODO: make configurable
 const MAX_STACK: usize = 1_000_000;
@@ -1024,6 +1026,9 @@ fn run_with<S: HaystackInput + ?Sized, T>(
     let mut ix = pos;
     let mut slash_z_matched = false;
     let mut match_attempt_start = pos;
+    let leftmost_longest = option_flags & OPTION_LEFTMOST_LONGEST != 0;
+    let mut best_saves: Option<Vec<usize>> = None;
+    let mut best_match_len = 0;
     loop {
         // break from this loop to fail, causes stack to pop
         'fail: loop {
@@ -1056,6 +1061,14 @@ fn run_with<S: HaystackInput + ?Sized, T>(
                         }
                     }
                     if state.get(0) < match_range.start || state.get(1) > match_range.end {
+                        break 'fail;
+                    }
+                    if leftmost_longest {
+                        let match_len = state.get(1) - state.get(0);
+                        if best_saves.is_none() || match_len > best_match_len {
+                            best_saves = Some(state.saves.clone());
+                            best_match_len = match_len;
+                        }
                         break 'fail;
                     }
                     return Ok(Some(extract(state)));
@@ -1541,6 +1554,12 @@ fn run_with<S: HaystackInput + ?Sized, T>(
         }
         // "break 'fail" goes here
         if state.stack.is_empty() {
+            if leftmost_longest {
+                if let Some(saves) = best_saves {
+                    state.saves.copy_from_slice(&saves);
+                    return Ok(Some(extract(state)));
+                }
+            }
             return Ok(None);
         }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -92,6 +92,7 @@ pub fn assert_find(re: &str, text: &str) -> Option<(usize, usize)> {
     str_result
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[cfg_attr(feature = "track_caller", track_caller)]
 #[allow(dead_code)]
 pub fn assert_match_lr(re: &str, text: &str, expected: &str) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -92,31 +92,6 @@ pub fn assert_find(re: &str, text: &str) -> Option<(usize, usize)> {
     str_result
 }
 
-#[cfg(feature = "leftmost_longest")]
-#[cfg_attr(feature = "track_caller", track_caller)]
-#[allow(dead_code)]
-pub fn assert_match_lr(re: &str, text: &str, expected: &str) {
-    let str_re = RegexBuilder::new(re)
-        .leftmost_longest(true)
-        .build()
-        .expect("regex should compile");
-    let str_result = str_re.find(text).unwrap();
-    assert!(
-        str_result.is_some(),
-        "Expected regex '{}' to match '{}' in leftmost-longest mode",
-        re,
-        text
-    );
-    assert_eq!(
-        str_result.unwrap().as_str(),
-        expected,
-        "Expected leftmost-longest match of '{}' on '{}' to be '{}'",
-        re,
-        text,
-        expected
-    );
-}
-
 /// Run `find_input` against `text` in both str mode and ASCII bytes mode, assert
 /// that both agree, and return the common result.
 #[cfg_attr(feature = "track_caller", track_caller)]
@@ -326,7 +301,7 @@ pub fn assert_captures<'t>(re: &str, text: &'t str) -> Option<Captures<'t, str>>
             assert_eq!(
                 str_span,
                 bytes_span,
-                "Expected capture group {} to agree between str and bytes mode for regex '{}' on '{}'",
+                "Expected capture group {} to agree between str and bytes modes for regex '{}' on '{}'",
                 i,
                 re,
                 text
@@ -334,4 +309,23 @@ pub fn assert_captures<'t>(re: &str, text: &'t str) -> Option<Captures<'t, str>>
         }
     }
     str_result
+}
+
+#[cfg_attr(feature = "track_caller", track_caller)]
+#[allow(dead_code)]
+/// Assert that `seek(true)` produces the same first match as without seeking.
+pub fn assert_seek_same(re: &str, text: &str) -> Option<(usize, usize)> {
+    let str_result = regex(re).find(text).unwrap();
+    let seek_result = RegexBuilder::new(re)
+        .seek(true)
+        .build()
+        .expect("regex should compile with seek enabled")
+        .find(text)
+        .unwrap();
+    assert_eq!(
+        str_result.map(|m| (m.start(), m.end())),
+        seek_result.map(|m| (m.start(), m.end())),
+        "seek=true gave different result for /{re}/ on '{text}'"
+    );
+    str_result.map(|m| (m.start(), m.end()))
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -92,6 +92,30 @@ pub fn assert_find(re: &str, text: &str) -> Option<(usize, usize)> {
     str_result
 }
 
+#[cfg_attr(feature = "track_caller", track_caller)]
+#[allow(dead_code)]
+pub fn assert_match_lr(re: &str, text: &str, expected: &str) {
+    let str_re = RegexBuilder::new(re)
+        .leftmost_longest(true)
+        .build()
+        .expect("regex should compile");
+    let str_result = str_re.find(text).unwrap();
+    assert!(
+        str_result.is_some(),
+        "Expected regex '{}' to match '{}' in leftmost-longest mode",
+        re,
+        text
+    );
+    assert_eq!(
+        str_result.unwrap().as_str(),
+        expected,
+        "Expected leftmost-longest match of '{}' on '{}' to be '{}'",
+        re,
+        text,
+        expected
+    );
+}
+
 /// Run `find_input` against `text` in both str mode and ASCII bytes mode, assert
 /// that both agree, and return the common result.
 #[cfg_attr(feature = "track_caller", track_caller)]

--- a/tests/finding.rs
+++ b/tests/finding.rs
@@ -1320,44 +1320,31 @@ fn seek_regex(re: &str) -> fancy_regex::Regex {
     result.unwrap()
 }
 
-/// Assert that `seek(true)` produces the same first match as the default.
-fn assert_seek_same(re: &str, text: &str) -> Option<(usize, usize)> {
-    let default_result = common::regex(re).find(text).unwrap();
-    let seek_result = seek_regex(re).find(text).unwrap();
-    assert_eq!(
-        default_result.map(|m| (m.start(), m.end())),
-        seek_result.map(|m| (m.start(), m.end())),
-        "seek=true gave different result for /{re}/ on {:?}",
-        text
-    );
-    seek_result.map(|m| (m.start(), m.end()))
-}
-
 #[test]
 fn seek_backref_finds_match() {
     // The seek pattern inlines the group body ("abc") and jumps past irrelevant text.
-    assert_seek_same(r"(abc)\1", "xxxabcabcyyy");
-    assert_seek_same(r"(abc)\1", "xabcabcx");
+    common::assert_seek_same(r"(abc)\1", "xxxabcabcyyy");
+    common::assert_seek_same(r"(abc)\1", "xabcabcx");
 }
 
 #[test]
 fn seek_overlapping_alternatives_finds_leftmost_match() {
     // https://github.com/rust-lang/regex/issues/1354
-    let result = assert_seek_same(r".abb|b", "zabb");
+    let result = common::assert_seek_same(r".abb|b", "zabb");
     assert_eq!(result, Some((0, 4)));
 }
 
 #[test]
 fn seek_negated_char_class_optional_finds_leftmost_match() {
     // https://github.com/rust-lang/regex/issues/1345
-    let result = assert_seek_same(r"[^()]*(?:\([^()]*\))?[^()]*:", "$(:):");
+    let result = common::assert_seek_same(r"[^()]*(?:\([^()]*\))?[^()]*:", "$(:):");
     assert_eq!(result, Some((0, 5)));
 }
 
 #[test]
 fn seek_backref_no_match() {
-    assert_seek_same(r"(abc)\1", "xxxyyy");
-    assert_seek_same(r"(abc)\1", "abcxabc");
+    common::assert_seek_same(r"(abc)\1", "xxxyyy");
+    common::assert_seek_same(r"(abc)\1", "abcxabc");
 }
 
 #[test]
@@ -1385,7 +1372,7 @@ fn seek_matches_identical_to_default() {
         (r"(?<=)\tbaz", "foobar\n\tbaz\n\ttest"),
     ];
     for (re, text) in cases {
-        assert_seek_same(re, text);
+        common::assert_seek_same(re, text);
     }
 }
 

--- a/tests/leftmost_longest.rs
+++ b/tests/leftmost_longest.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "leftmost_longest")]
+
+use fancy_regex::{BytesMode, Regex, RegexBuilder};
+
+#[cfg_attr(feature = "track_caller", track_caller)]
+pub fn assert_match_longest(re: &str, text: &str, expected: &str) {
+    let str_re = RegexBuilder::new(re)
+        .leftmost_longest(true)
+        .build()
+        .expect("regex should compile");
+    let str_result = str_re.find(text).unwrap();
+    assert!(
+        str_result.is_some(),
+        "Expected regex '{}' to match '{}' in leftmost-longest mode",
+        re,
+        text
+    );
+    assert_eq!(
+        str_result.unwrap().as_str(),
+        expected,
+        "Expected leftmost-longest match of '{}' on '{}' to be '{}'",
+        re,
+        text,
+        expected
+    );
+}
+
+#[test]
+fn leftmost_longest_basic() {
+    assert_match_longest(r"(a|ab)c", "xabc", "abc");
+    assert_match_longest(r"(ab|a)c", "xabc", "abc");
+}
+
+#[test]
+fn leftmost_longest_greedy_star() {
+    assert_match_longest(r"a.*b", "xaabxb", "aabxb");
+}
+
+#[test]
+fn leftmost_longest_tie() {
+    assert_match_longest(r"a|a", "xa", "a");
+}
+
+#[test]
+fn leftmost_longest_no_match() {
+    let re = RegexBuilder::new(r"(a|ab)c")
+        .leftmost_longest(true)
+        .build()
+        .unwrap();
+    assert!(re.find("xbc").unwrap().is_none());
+}
+
+#[test]
+fn leftmost_longest_non_greedy_error() {
+    let result = RegexBuilder::new(r"a.*?(b)").leftmost_longest(true).build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn leftmost_longest_alt_basic() {
+    assert_match_longest(r"a|ab", "ab", "ab");
+}
+
+fn leftmost_longest_re(re: &str) -> Regex {
+    RegexBuilder::new(re)
+        .leftmost_longest(true)
+        .build()
+        .expect("regex should compile in leftmost-longest mode")
+}
+
+#[test]
+fn leftmost_longest_iter_does_not_skip_matches() {
+    let spans: Vec<(usize, usize)> = leftmost_longest_re(r"a|ab")
+        .find_iter("abaa ab")
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(spans, vec![(0, 2), (2, 3), (3, 4), (5, 7)]);
+}
+
+#[test]
+fn leftmost_longest_iter_longest_at_leftmost_position() {
+    let spans: Vec<(usize, usize)> = leftmost_longest_re(r"a|ab|abc")
+        .find_iter("xabcabc")
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(spans, vec![(1, 4), (4, 7)]);
+}
+
+#[test]
+fn leftmost_longest_iter_order_independent() {
+    let text = "abaa ab";
+    for re in [r"a|ab", r"ab|a", r"a|ab|a"] {
+        let spans: Vec<(usize, usize)> = RegexBuilder::new(re)
+            .leftmost_longest(true)
+            .build()
+            .unwrap()
+            .find_iter(text)
+            .map(|m| {
+                let m = m.unwrap();
+                (m.start(), m.end())
+            })
+            .collect();
+        assert_eq!(
+            spans,
+            vec![(0, 2), (2, 3), (3, 4), (5, 7)],
+            "pattern {re:?} produced different leftmost-longest results"
+        );
+    }
+}
+
+#[test]
+fn leftmost_longest_find_from_pos_does_not_skip() {
+    let re = leftmost_longest_re(r"a|ab");
+    let text = "abaa ab";
+    assert_eq!(re.find_from_pos(text, 0).unwrap().unwrap().as_str(), "ab");
+    assert_eq!(re.find_from_pos(text, 2).unwrap().unwrap().as_str(), "a");
+    assert_eq!(re.find_from_pos(text, 3).unwrap().unwrap().as_str(), "a");
+    assert_eq!(re.find_from_pos(text, 5).unwrap().unwrap().as_str(), "ab");
+}
+
+#[test]
+fn leftmost_longest_captures_iter_does_not_skip() {
+    let re = leftmost_longest_re(r"(a|ab)");
+    let captures: Vec<(usize, usize)> = re
+        .captures_iter("abaa ab")
+        .map(|c| {
+            let c = c.unwrap();
+            (c.get(0).unwrap().start(), c.get(0).unwrap().end())
+        })
+        .collect();
+    assert_eq!(captures, vec![(0, 2), (2, 3), (3, 4), (5, 7)]);
+}
+
+#[test]
+fn leftmost_longest_iter_does_not_skip_bytes_mode() {
+    let spans: Vec<(usize, usize)> = RegexBuilder::new(r"a|ab")
+        .leftmost_longest(true)
+        .bytes_mode(BytesMode::Ascii)
+        .build()
+        .unwrap()
+        .find_iter(&b"abaa ab"[..])
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(spans, vec![(0, 2), (2, 3), (3, 4), (5, 7)]);
+}
+
+#[test]
+fn leftmost_longest_iter_does_not_skip_with_seek() {
+    // Seek mode and leftmost-longest mode should produce identical results
+    // since the seek pre-filter does not affect leftmost-longest semantics.
+    let text = "abaa ab";
+    let seek_spans: Vec<(usize, usize)> = RegexBuilder::new(r"a|ab")
+        .leftmost_longest(true)
+        .seek(true)
+        .build()
+        .unwrap()
+        .find_iter(text)
+        .map(|m| {
+            let m = m.unwrap();
+            (m.start(), m.end())
+        })
+        .collect();
+    assert_eq!(seek_spans, vec![(0, 2), (2, 3), (3, 4), (5, 7)]);
+}

--- a/tests/leftmost_longest.rs
+++ b/tests/leftmost_longest.rs
@@ -34,6 +34,7 @@ fn leftmost_longest_basic() {
 #[test]
 fn leftmost_longest_greedy_star() {
     assert_match_longest(r"a.*b", "xaabxb", "aabxb");
+    assert_match_longest(r"aaaaa|a*", "aaaaaa", "aaaaaa");
 }
 
 #[test]

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1100,22 +1100,26 @@ fn casei_keyword_alternation_in_hard_pattern() {
     assert_eq!(&haystack[m.start()..m.end()], "ABSENT");
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_basic() {
     common::assert_match_lr(r"(a|ab)c", "xabc", "abc");
     common::assert_match_lr(r"(ab|a)c", "xabc", "abc");
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_greedy_star() {
     common::assert_match_lr(r"a.*b", "xaabxb", "aabxb");
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_tie() {
     common::assert_match_lr(r"a|a", "xa", "a");
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_no_match() {
     let re = RegexBuilder::new(r"(a|ab)c")
@@ -1125,6 +1129,7 @@ fn leftmost_longest_no_match() {
     assert!(re.find("xbc").unwrap().is_none());
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_non_greedy_error() {
     let result = RegexBuilder::new(r"a.*?(b)").leftmost_longest(true).build();
@@ -1137,6 +1142,7 @@ fn leftmost_longest_default_behavior_unchanged() {
     assert_eq!(re.find("xabc").unwrap().unwrap().as_str(), "abc");
 }
 
+#[cfg(feature = "leftmost_longest")]
 #[test]
 fn leftmost_longest_alt_basic() {
     let re = RegexBuilder::new(r"a|ab")

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1099,3 +1099,49 @@ fn casei_keyword_alternation_in_hard_pattern() {
         .unwrap();
     assert_eq!(&haystack[m.start()..m.end()], "ABSENT");
 }
+
+#[test]
+fn leftmost_longest_basic() {
+    common::assert_match_lr(r"(a|ab)c", "xabc", "abc");
+    common::assert_match_lr(r"(ab|a)c", "xabc", "abc");
+}
+
+#[test]
+fn leftmost_longest_greedy_star() {
+    common::assert_match_lr(r"a.*b", "xaabxb", "aabxb");
+}
+
+#[test]
+fn leftmost_longest_tie() {
+    common::assert_match_lr(r"a|a", "xa", "a");
+}
+
+#[test]
+fn leftmost_longest_no_match() {
+    let re = RegexBuilder::new(r"(a|ab)c")
+        .leftmost_longest(true)
+        .build()
+        .unwrap();
+    assert!(re.find("xbc").unwrap().is_none());
+}
+
+#[test]
+fn leftmost_longest_non_greedy_error() {
+    let result = RegexBuilder::new(r"a.*?(b)").leftmost_longest(true).build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn leftmost_longest_default_behavior_unchanged() {
+    let re = RegexBuilder::new(r"(a|ab)c").build().unwrap();
+    assert_eq!(re.find("xabc").unwrap().unwrap().as_str(), "abc");
+}
+
+#[test]
+fn leftmost_longest_alt_basic() {
+    let re = RegexBuilder::new(r"a|ab")
+        .leftmost_longest(true)
+        .build()
+        .unwrap();
+    assert_eq!(re.find("ab").unwrap().unwrap().as_str(), "ab");
+}

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1100,54 +1100,8 @@ fn casei_keyword_alternation_in_hard_pattern() {
     assert_eq!(&haystack[m.start()..m.end()], "ABSENT");
 }
 
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_basic() {
-    common::assert_match_lr(r"(a|ab)c", "xabc", "abc");
-    common::assert_match_lr(r"(ab|a)c", "xabc", "abc");
-}
-
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_greedy_star() {
-    common::assert_match_lr(r"a.*b", "xaabxb", "aabxb");
-}
-
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_tie() {
-    common::assert_match_lr(r"a|a", "xa", "a");
-}
-
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_no_match() {
-    let re = RegexBuilder::new(r"(a|ab)c")
-        .leftmost_longest(true)
-        .build()
-        .unwrap();
-    assert!(re.find("xbc").unwrap().is_none());
-}
-
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_non_greedy_error() {
-    let result = RegexBuilder::new(r"a.*?(b)").leftmost_longest(true).build();
-    assert!(result.is_err());
-}
-
 #[test]
 fn leftmost_longest_default_behavior_unchanged() {
     let re = RegexBuilder::new(r"(a|ab)c").build().unwrap();
     assert_eq!(re.find("xabc").unwrap().unwrap().as_str(), "abc");
-}
-
-#[cfg(feature = "leftmost_longest")]
-#[test]
-fn leftmost_longest_alt_basic() {
-    let re = RegexBuilder::new(r"a|ab")
-        .leftmost_longest(true)
-        .build()
-        .unwrap();
-    assert_eq!(re.find("ab").unwrap().unwrap().as_str(), "ab");
 }


### PR DESCRIPTION
Add an opt-in `leftmost_longest` mode that returns the longest match among all matches starting at the leftmost match position, matching POSIX leftmost-longest behavior. Closes #280 